### PR TITLE
Fix links on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Trillian examples
 
 This repository contains example applications built on top of
-[Trillian](github.com/google/trillian), showing that it's possible to apply
+[Trillian](https://github.com/google/trillian), showing that it's possible to apply
 Transparency concepts to problems other than
-[Certificates](github.com/google/certificate-transparency-go).
+[Certificates](https://github.com/google/certificate-transparency-go).
 
 Currently the examples here are:
  * [etherslurp](etherslurp): An app which syncs a popular blockchain into a
@@ -12,4 +12,4 @@ Currently the examples here are:
 
 These examples are not supported per-se, but the Trillian team will likely try
 to help where possible.  You can contact them via the channels listed under
-*Support* on the [Trillian](github.com/google/trillian) repo.
+*Support* on the [Trillian](https://github.com/google/trillian) repo.


### PR DESCRIPTION
Without `https://`, markdown created relative links