### PR TITLE
Enable golang mod proxy on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ cache:
 env:
   global:
     - GO111MODULE=on
+      GOPROXY=https://proxy.golang.org
   matrix:
     - WITH_COVERAGE=true
     - GOFLAGS='-race'


### PR DESCRIPTION
Trial using the Google module proxy in travis builds:
 - in preparation for [Golang module transparency](https://blog.golang.org/modules2019)
 - Make dep fetching faster and more reliable.
