### PR TITLE
Remove use of FixedBackendResolver, which has been deleted.

### DIFF
--- a/gossip/hub/hub_server/main.go
+++ b/gossip/hub/hub_server/main.go
@@ -90,7 +90,7 @@ func main() {
 	dialOpts := []grpc.DialOption{grpc.WithInsecure()}
 	if strings.Contains(*rpcBackend, ",") {
 		// This should probably not be used in production. Either use etcd or a gRPC
-		// load balancer. 
+		// load balancer.
 		glog.Warning("Multiple RPC backends from flags not recommended for production. Should probably be using etcd or a gRPC load balancer / proxy.")
 		res, cleanup := manual.GenerateAndRegisterManualResolver()
 		defer cleanup()


### PR DESCRIPTION
The replacement should be functionality identical.

Also removed the deprecated way of setting up roundrobin balancing. This might need more work to be fully up to date with gRPC API changes but this change should avoid problems in using a newer version of gRPC.