### PR TITLE
Add go_package option to gossip config proto.

### DIFF
--- a/gossip/hub/configpb/config.proto
+++ b/gossip/hub/configpb/config.proto
@@ -14,6 +14,7 @@
 
 syntax = "proto3";
 
+option go_package = "github.com/google/trillian-examples/gossip/hub/configpb";
 package configpb;
 
 import "crypto/keyspb/keyspb.proto";


### PR DESCRIPTION
This will become mandatory at some point so we might as well fix it now.