### PR TITLE
Log info from manifest in monitor

### DIFF
--- a/binary_transparency/firmware/api/firmware_metadata.go
+++ b/binary_transparency/firmware/api/firmware_metadata.go
@@ -14,6 +14,8 @@
 
 package api
 
+import "fmt"
+
 // FirmwareMetadata represents a firmware image and related info.
 type FirmwareMetadata struct {
 	////// What's this firmware for? //////
@@ -42,6 +44,11 @@ type FirmwareMetadata struct {
 	// BuildTimestamp is the time at which this build was published in RFC3339 format.
 	// e.g. "1985-04-12T23:20:50.52Z"
 	BuildTimestamp string
+}
+
+// String returns a human-readable representation of the firmware metadata info.
+func (m FirmwareMetadata) String() string {
+	return fmt.Sprintf("%s/v%d built at %s with image hash 0x%x", m.DeviceID, m.FirmwareRevision, m.BuildTimestamp, m.FirmwareImageSHA512)
 }
 
 // FirmwareStatement is the embodiment of the Statement in the claimant model for this demo.

--- a/binary_transparency/firmware/cmd/ft_monitor/main.go
+++ b/binary_transparency/firmware/cmd/ft_monitor/main.go
@@ -119,6 +119,9 @@ func main() {
 				glog.Warningf("Unable to decode FW Metadata from Statement %q", err)
 				continue
 			}
+
+			glog.Infof("Found firmware (@%d): %s", idx, meta)
+
 			// Fetch the Image from FT Personality
 			image, err := c.GetFirmwareImage(meta.FirmwareImageSHA512)
 			if err != nil {


### PR DESCRIPTION
Adds entries like these to the "normal" (non-verbose) level logging, to easily see details of discovered firmware:

```
I1124 14:39:56.905375 1280867 main.go:123] Found firmware (@0): TalkieToaster/v3 built at 2020-11-24T14:39:47Z with image hash 0xbf2f21936b66a0665883716ea4b1ceda609304ad76dd48f6423128bc36d4cb0fb5effaa9c1f2e328a5cfc25d2cb89a337d4285a8bc3e22dbb99bddbed19e7095
```