### PR TITLE
Use DCP for measurement hashing

### DIFF
--- a/binary_transparency/firmware/devices/usb_armory/bootloader/boot.go
+++ b/binary_transparency/firmware/devices/usb_armory/bootloader/boot.go
@@ -27,7 +27,6 @@ func exec(kernel uint32, params uint32)
 func svc()
 
 func bootKernel(kernel []byte, dtb []byte, cmdline string) {
-	dma.Init(dmaStart, dmaSize)
 	mem, _ := dma.Reserve(dmaSize, 0)
 
 	dma.Write(mem, kernel, kernelOffset)

--- a/binary_transparency/firmware/devices/usb_armory/bootloader/main.go
+++ b/binary_transparency/firmware/devices/usb_armory/bootloader/main.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 
 	"github.com/f-secure-foundry/tamago/board/f-secure/usbarmory/mark-two"
+	"github.com/f-secure-foundry/tamago/dma"
 	"github.com/f-secure-foundry/tamago/soc/imx6"
 	"github.com/f-secure-foundry/tamago/soc/imx6/usdhc"
 )
@@ -37,6 +38,7 @@ func init() {
 }
 
 func main() {
+	dma.Init(dmaStart, dmaSize)
 	usbarmory.LED("blue", false)
 	usbarmory.LED("white", false)
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/dsoprea/go-ext4 v0.0.0-20190528173430-c13b09fc0ff8
 	github.com/dsoprea/go-logging v0.0.0-20200710184922-b02d349568dd // indirect
 	github.com/ethereum/go-ethereum v1.9.24
-	github.com/f-secure-foundry/tamago v0.0.0-20201126222218-ecc3aa53ae88
+	github.com/f-secure-foundry/tamago v0.0.0-20201127101424-e0d521d1ec51
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,8 @@ github.com/f-secure-foundry/tamago v0.0.0-20201119100619-1bcafd8de66a h1:3kgNV8R
 github.com/f-secure-foundry/tamago v0.0.0-20201119100619-1bcafd8de66a/go.mod h1:+xmhdYxGfaNhWUZ/F1mbwFu38H73slg/k/oPjOL7tc8=
 github.com/f-secure-foundry/tamago v0.0.0-20201126222218-ecc3aa53ae88 h1:YbymNPHcE11B4twyG+8lAtLgfFaj8rhiRIBVzaN2m1A=
 github.com/f-secure-foundry/tamago v0.0.0-20201126222218-ecc3aa53ae88/go.mod h1:+xmhdYxGfaNhWUZ/F1mbwFu38H73slg/k/oPjOL7tc8=
+github.com/f-secure-foundry/tamago v0.0.0-20201127101424-e0d521d1ec51 h1:pewB+4yHr4ivS1KAfQx3jQtld96ceV2ORqpi7xZ3s/Y=
+github.com/f-secure-foundry/tamago v0.0.0-20201127101424-e0d521d1ec51/go.mod h1:+xmhdYxGfaNhWUZ/F1mbwFu38H73slg/k/oPjOL7tc8=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=


### PR DESCRIPTION
This gives a ~300% speed up (15.8s down to 5.5s hashing the 64MB partition) 