### PR TITLE
Minor improvements to SumDB auditor

### DIFF
--- a/sumdbaudit/audit/service.go
+++ b/sumdbaudit/audit/service.go
@@ -125,7 +125,7 @@ func (s *Service) CloneLeafTiles(ctx context.Context, checkpoint *tlog.Tree) err
 			// Status updates if verbosity is high enough.
 			if glog.V(2) {
 				select {
-				case _ = <-ticker.C:
+				case <-ticker.C:
 					glog.V(2).Infof("cloning tile %d of %d", i, remainingChunks)
 				default:
 				}


### PR DESCRIPTION
Added documentation and better console logging when running. None of this is critical, but it's all stuff that is clear after being away from this code for a while. Also made the error handling stricter in case the DB schema is corrupt when reading the latest tree head.

The reason for revisiting this code is that it will be changed to persist the Golden Checkpoint between runs. This improves the security for the stragglers, and it will give the map demo that builds on this access to a Log Checkpoint to write in its Map Checkpoint to allow traceability.