### PR TITLE
Store and check Golden Checkpoints

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -337,6 +337,7 @@ github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3 h1:x95R7cp+rSeeqAMI2knLtQ0DKlaBhv2NrtrOvafPHRo=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/sumdbaudit/audit/database.go
+++ b/sumdbaudit/audit/database.go
@@ -79,7 +79,7 @@ func (d *Database) GoldenCheckpoint(parse func([]byte) (*Checkpoint, error)) (*C
 	var datetime sql.NullTime
 	var data []byte
 	if err := d.db.QueryRow("SELECT datetime, checkpoint FROM checkpoints ORDER BY datetime DESC LIMIT 1").Scan(&datetime, &data); err != nil {
-		return nil, fmt.Errorf("failed to get max revision: %v", err)
+		return nil, fmt.Errorf("failed to get latest checkpoint: %w", err)
 	}
 	if !datetime.Valid {
 		return nil, NoDataFound(errors.New("no data found"))

--- a/sumdbaudit/audit/service.go
+++ b/sumdbaudit/audit/service.go
@@ -302,9 +302,6 @@ func (s *Service) checkCheckpoint(cp *Checkpoint, getStragglers func(stragglerCo
 		if err != nil {
 			return fmt.Errorf("failed to get stragglers: %w", err)
 		}
-		if err != nil {
-			return fmt.Errorf("failed to get tile: %w", err)
-		}
 		for i := 0; i < stragglersCount; i++ {
 			logRange.Append(stragglers[i], nil)
 		}

--- a/sumdbaudit/audit/service.go
+++ b/sumdbaudit/audit/service.go
@@ -62,6 +62,15 @@ func NewService(localDB *Database, sumDB *SumDBClient, height int) *Service {
 	}
 }
 
+// GoldenCheckpoint gets the previously checked Checkpoint, or nil if not found.
+func (s *Service) GoldenCheckpoint(ctx context.Context) *Checkpoint {
+	golden, err := s.localDB.GoldenCheckpoint(s.sumDB.ParseCheckpointNote)
+	if err != nil {
+		return nil
+	}
+	return golden
+}
+
 // CloneLeafTiles copies the leaf data from the SumDB into the local database.
 // It only copies whole tiles, which means that some stragglers may not be
 // copied locally.

--- a/sumdbaudit/audit/sumdb_test.go
+++ b/sumdbaudit/audit/sumdb_test.go
@@ -15,6 +15,7 @@
 package audit
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"testing"
@@ -80,18 +81,21 @@ func TestLatestCheckpoint(t *testing.T) {
 			values: map[string]string{"/latest": checkpointData},
 		},
 	}
-	tree, err := sumdb.LatestCheckpoint()
+	checkpoint, err := sumdb.LatestCheckpoint()
 	if err != nil {
 		t.Fatalf("failed to get checkpoint: %v", err)
+	}
+	if !bytes.Equal(checkpoint.Raw, []byte(checkpointData)) {
+		t.Errorf("expected raw checkpoint %q but got %q", checkpointData, checkpoint.Raw)
 	}
 	expectedHash, err := tlog.ParseHash("kn9DgqDhXzoZMM8828SQsbuovr/WRn7QfFd5Qe1rpwA=")
 	if err != nil {
 		t.Fatalf("static hash failed to parse")
 	}
-	if got, want := tree.Hash, expectedHash; got != want {
+	if got, want := checkpoint.Hash, expectedHash; got != want {
 		t.Errorf("unexpected hash. got, want = %s, %s", got, want)
 	}
-	if got, want := tree.N, int64(1514086); got != want {
+	if got, want := checkpoint.N, int64(1514086); got != want {
 		t.Errorf("unexpected tree size. got, want = %d, %d", got, want)
 	}
 }

--- a/sumdbaudit/cli/clone/clone.go
+++ b/sumdbaudit/cli/clone/clone.go
@@ -57,6 +57,12 @@ func main() {
 
 	glog.Infof("Got SumDB checkpoint for %d entries. Downloading...", checkpoint.N)
 	s := audit.NewService(db, sumDB, *height)
+	golden := s.GoldenCheckpoint(ctx)
+	if golden != nil && golden.N >= checkpoint.N {
+		glog.Infof("nothing to do: latest SumDB size is %d and local size is %d", checkpoint.N, golden.N)
+		return
+	}
+
 	if err := s.CloneLeafTiles(ctx, checkpoint); err != nil {
 		glog.Exitf("failed to update leaves: %v", err)
 	}

--- a/sumdbaudit/cli/clone/clone.go
+++ b/sumdbaudit/cli/clone/clone.go
@@ -65,7 +65,11 @@ func main() {
 	if err := s.HashTiles(ctx, checkpoint); err != nil {
 		glog.Exitf("HashTiles: %v", err)
 	}
-	glog.Infof("Hashes updated successfully. Checking root hash...")
+	glog.Infof("Hashes updated successfully. Checking consistency with previous checkpoint...")
+	if err := s.CheckConsistency(ctx); err != nil {
+		glog.Exitf("CheckConsistency: %v", err)
+	}
+	glog.Infof("Log consistent. Checking root hash with remote...")
 	if err := s.CheckRootHash(ctx, checkpoint); err != nil {
 		glog.Exitf("CheckRootHash: %v", err)
 	}


### PR DESCRIPTION
* Checkpoints for successfully validated trees are stored in a new table in the database
* Clone tool now checks that the local tree is consistent with the previous Golden Checkpoint
* Short-circuit the clone tool if the remote SumDB is reporting the same size as the Golden Checkpoint