### PR TITLE
Created a mirror service which continually runs

### DIFF
--- a/sumdbaudit/audit/service.go
+++ b/sumdbaudit/audit/service.go
@@ -97,9 +97,8 @@ func (s *Service) Sync(ctx context.Context, checkpoint *Checkpoint) error {
 	if err := s.checkRootHash(ctx, checkpoint); err != nil {
 		return fmt.Errorf("checkRootHash: %w", err)
 	}
-	s.localDB.SetGoldenCheckpoint(checkpoint)
 	glog.V(1).Infof("Log sync and verification complete")
-	return nil
+	return s.localDB.SetGoldenCheckpoint(checkpoint)
 }
 
 // ProcessMetadata parses the leaf data and writes the semantic data into the DB.

--- a/sumdbaudit/audit/service.go
+++ b/sumdbaudit/audit/service.go
@@ -84,19 +84,20 @@ func (s *Service) Sync(ctx context.Context, checkpoint *Checkpoint) error {
 	if err := s.cloneLeafTiles(ctx, checkpoint); err != nil {
 		return fmt.Errorf("cloneLeafTiles: %w", err)
 	}
-	glog.Infof("Updated leaves to latest checkpoint (tree size %d). Calculating hashes...", checkpoint.N)
+	glog.V(1).Infof("Updated leaves to latest checkpoint (tree size %d). Calculating hashes...", checkpoint.N)
 
 	if err := s.hashTiles(ctx, checkpoint); err != nil {
 		return fmt.Errorf("hashTiles: %w", err)
 	}
-	glog.Infof("Hashes updated successfully. Checking consistency with previous checkpoint...")
+	glog.V(1).Infof("Hashes updated successfully. Checking consistency with previous checkpoint...")
 	if err := s.checkConsistency(ctx); err != nil {
 		return fmt.Errorf("checkConsistency: %w", err)
 	}
-	glog.Infof("Log consistent. Checking root hash with remote...")
+	glog.V(1).Infof("Log consistent. Checking root hash with remote...")
 	if err := s.checkRootHash(ctx, checkpoint); err != nil {
 		return fmt.Errorf("checkRootHash: %w", err)
 	}
+	glog.V(1).Infof("Log sync and verification complete")
 	return nil
 }
 

--- a/sumdbaudit/audit/service.go
+++ b/sumdbaudit/audit/service.go
@@ -97,6 +97,7 @@ func (s *Service) Sync(ctx context.Context, checkpoint *Checkpoint) error {
 	if err := s.checkRootHash(ctx, checkpoint); err != nil {
 		return fmt.Errorf("checkRootHash: %w", err)
 	}
+	s.localDB.SetGoldenCheckpoint(checkpoint)
 	glog.V(1).Infof("Log sync and verification complete")
 	return nil
 }
@@ -352,7 +353,7 @@ func (s *Service) checkRootHash(ctx context.Context, checkpoint *Checkpoint) err
 	if err != nil {
 		return fmt.Errorf("local log does not match the SumDB checkpoint: %w", err)
 	}
-	return s.localDB.SetGoldenCheckpoint(checkpoint)
+	return nil
 }
 
 // checkCheckpoint ensures that the local log matches the commitment in the given checkpoint.

--- a/sumdbaudit/cli/mirror/mirror.go
+++ b/sumdbaudit/cli/mirror/mirror.go
@@ -16,12 +16,10 @@ package main
 
 import (
 	"context"
+	"flag"
 	"time"
 
-	"flag"
-
 	"github.com/golang/glog"
-
 	"github.com/google/trillian-examples/sumdbaudit/audit"
 	_ "github.com/mattn/go-sqlite3"
 )

--- a/sumdbaudit/cli/mirror/mirror.go
+++ b/sumdbaudit/cli/mirror/mirror.go
@@ -64,7 +64,7 @@ func main() {
 			glog.Infof("syncing to latest SumDB size %d", head.N)
 			s.Sync(ctx, head)
 			if *unpack {
-				glog.V(1).Infof("processing metadata", head.N)
+				glog.V(1).Infof("processing metadata")
 				if err := s.ProcessMetadata(ctx, head); err != nil {
 					glog.Exitf("ProcessMetadata: %v", err)
 				}

--- a/sumdbaudit/cli/mirror/mirror.go
+++ b/sumdbaudit/cli/mirror/mirror.go
@@ -1,0 +1,79 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"time"
+
+	"flag"
+
+	"github.com/golang/glog"
+
+	"github.com/google/trillian-examples/sumdbaudit/audit"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+var (
+	height   = flag.Int("h", 8, "tile height")
+	vkey     = flag.String("k", "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8", "key")
+	db       = flag.String("db", "", "database file location (will be created if it doesn't exist)")
+	unpack   = flag.Bool("unpack", false, "if provided then the leafMetadata table will be populated by parsing the raw leaf data")
+	interval = flag.Duration("interval", 5*time.Minute, "how long to wait between runs")
+)
+
+// Runs a service which continually keeps a local database up to date with a verified
+// clone of the Go SumDB.
+func main() {
+	ctx := context.Background()
+	flag.Parse()
+
+	if len(*db) == 0 {
+		glog.Exit("db must be provided")
+	}
+	db, err := audit.NewDatabase(*db)
+	if err != nil {
+		glog.Exitf("failed to open DB: %v", err)
+	}
+	err = db.Init()
+	if err != nil {
+		glog.Exitf("failed to init DB: %v", err)
+	}
+	sumDB := audit.NewSumDB(*height, *vkey)
+	s := audit.NewService(db, sumDB, *height)
+
+	for {
+		head, err := sumDB.LatestCheckpoint()
+		if err != nil {
+			glog.Exitf("failed to get latest checkpoint: %s", err)
+		}
+		golden := s.GoldenCheckpoint(ctx)
+		if golden != nil && golden.N >= head.N {
+			glog.Infof("nothing to do: latest SumDB size is %d and local size is %d", head.N, golden.N)
+		} else {
+			glog.Infof("syncing to latest SumDB size %d", head.N)
+			s.Sync(ctx, head)
+			if *unpack {
+				glog.V(1).Infof("processing metadata", head.N)
+				if err := s.ProcessMetadata(ctx, head); err != nil {
+					glog.Exitf("ProcessMetadata: %v", err)
+				}
+			}
+		}
+
+		glog.V(1).Infof("sleeping for %v", *interval)
+		time.Sleep(*interval)
+	}
+}


### PR DESCRIPTION
The clone.go tool is intended to be a one-shot tool, and a gentle introduction/demo. This tool is intended to be run as a service which can continually keep a database up to date.

Future work might be to support different databases (e.g. MySQL starts to look reasonable for something like this), or to have some documentation on how to set this up as a Linux service.