### PR TITLE
Add CloudBuild CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ language: go
 go: "1.15.x"
 go_import_path: github.com/google/trillian-examples
 
-services:
-  - mysql
-
 cache:
   directories:
     - "$HOME/gopath/pkg/mod"
@@ -57,9 +54,20 @@ install:
 
 before_script:
   - |
-    RESETDB="$(go list -f '{{.Dir}}' github.com/google/trillian)/scripts/resetdb.sh"
-    chmod +x $RESETDB
-    $RESETDB --force
+    # Use latest versions of Trillian docker images built by the Trillian CI cloudbuilders.
+    export PROJECT_ID=trillian-opensource-ci
+    docker pull gcr.io/$PROJECT_ID/log_server:latest
+    docker tag gcr.io/$PROJECT_ID/log_server:latest deployment_trillian-log-server
+    docker pull gcr.io/$PROJECT_ID/log_signer:latest
+    docker tag gcr.io/$PROJECT_ID/log_signer:latest deployment_trillian-log-signer
+
+    # Bring up an ephemeral trillian instance using the docker-compose config in the Trillian repo:
+    export TRILLIAN_PATH="$(go list -f '{{.Dir}}' github.com/google/trillian)"
+
+    docker-compose -f ${TRILLIAN_PATH}/examples/deployment/docker-compose.yml pull mysql trillian-log-server trillian-log-signer
+    docker-compose -f ${TRILLIAN_PATH}/examples/deployment/docker-compose.yml up -d mysql trillian-log-server trillian-log-signer
+
+    export TRILLIAN_LOG_RPC="localhost:8090"
 
 script:
   - set -e

--- a/binary_transparency/firmware/integration/ft_test.sh
+++ b/binary_transparency/firmware/integration/ft_test.sh
@@ -6,6 +6,9 @@ INTEGRATION_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 COMMON_FLAGS="-v 2 --alsologtostderr"
 
+# Trillian must already be running
+[ -z ${TRILLIAN_LOG_RPC+x} ] && TRILLIAN_LOG_RPC="localhost:8090"
+
 ft_prep_test
 
 function cleanup {
@@ -23,8 +26,6 @@ MALWARE_UPDATE_FILE=$(mktemp /tmp/malware-update-XXXXX.json)
 
 # Cleanup for the Trillian components
 TO_DELETE="${TO_DELETE} ${ETCD_DB_DIR}"
-TO_KILL+=(${LOG_SIGNER_PIDS[@]})
-TO_KILL+=(${RPC_SERVER_PIDS[@]})
 TO_KILL+=(${ETCD_PID})
 
 # Cleanup for the personality

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,89 @@
+timeout: 1800s
+options:
+  machineType: N1_HIGHCPU_8
+  volumes:
+  - name: go-modules
+    path: /go
+  env:
+  - GO111MODULE=on
+  - GOPROXY=https://proxy.golang.org
+  - PROJECT_ROOT=github.com/google/trillian-examples
+  - GOPATH=/go
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/testbase', '-f', './integration/Dockerfile', '.']
+
+- name: gcr.io/$PROJECT_ID/testbase
+  entrypoint: 'bash'
+  id: 'install'
+  args:
+  - '-exc'
+  - |
+    # googleapis is not Go code, but it's required for .pb.go regeneration because of API dependencies.
+    git clone --depth=1 https://github.com/googleapis/googleapis.git "$$GOPATH/src/github.com/googleapis/googleapis"
+
+    export TRILLIAN_PATH="$(go list -f '{{.Dir}}' github.com/google/trillian)"
+    for i in log_server log_signer; do
+      docker pull gcr.io/$PROJECT_ID/$$i:latest
+    done
+    docker-compose -f $${TRILLIAN_PATH}/examples/deployment/docker-compose.yml up -d mysql trillian-log-server trillian-log-signer
+
+- name: gcr.io/$PROJECT_ID/testbase
+  id: 'go-get-proto'
+  args: ['go', 'get', 'github.com/golang/protobuf/proto']
+  waitFor: ['install']
+
+- name: gcr.io/$PROJECT_ID/testbase
+  id: 'go-get-proto-gen'
+  args: ['go', 'get', 'github.com/golang/protobuf/protoc-gen-go']
+  waitFor: ['install']
+
+- name: gcr.io/$PROJECT_ID/testbase
+  entrypoint: 'bash'
+  id: 'presubmit'
+  args:
+    - '-exc'
+    - |
+      ./scripts/presubmit.sh
+      # Check re-generation didn't change anything.
+      echo "Checking that generated files are the same as checked-in versions."
+      git diff --  --exit-code
+  waitFor: ['go-get-proto', 'go-get-proto-gen']
+
+- name: gcr.io/$PROJECT_ID/testbase
+  entrypoint: 'bash'
+  id: 'presubmit-with-coverage'
+  args:
+    - '-exc'
+    - |
+      ./scripts/presubmit.sh --coverage
+  waitFor: ['go-get-proto', 'go-get-proto-gen']
+
+- name: gcr.io/$PROJECT_ID/testbase
+  entrypoint: 'bash'
+  id: 'gossip-integration-test'
+  args:
+    - '-exc'
+    - |
+      export PATH=/bin:/usr/bin:/workspace/bin:/go/protoc/bin:/usr/local/go/bin
+      ./gossip/integration/gossip_test.sh
+  waitFor: ['go-get-proto', 'go-get-proto-gen']
+
+- name: gcr.io/$PROJECT_ID/testbase
+  entrypoint: 'bash'
+  id: 'firmware-integration-test'
+  args:
+    - '-exc'
+    - |
+      export PATH=/bin:/usr/bin:/workspace/bin:/go/protoc/bin:/usr/local/go/bin
+      ./binary_transparency/firmware/integration/ft_test.sh
+  # Don't run integration tests in parallel until we've removed the resetDB step
+  waitFor: ['gossip-integration-test']
+
+images:
+ - 'gcr.io/$PROJECT_ID/db_server'
+ - 'gcr.io/$PROJECT_ID/log_server'
+ - 'gcr.io/$PROJECT_ID/log_signer'
+ - 'gcr.io/$PROJECT_ID/testbase'
+

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 1800s
+timeout: 600s
 options:
   machineType: N1_HIGHCPU_8
   volumes:
@@ -11,34 +11,46 @@ options:
   - GOPATH=/go
 
 steps:
+# First build a "testbase" docker image which contains most of the tools we need for the later steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/testbase', '-f', './integration/Dockerfile', '.']
 
+# prepare spins up an ephemeral trillian instance for testing use.
 - name: gcr.io/$PROJECT_ID/testbase
   entrypoint: 'bash'
-  id: 'install'
+  id: 'prepare'
   args:
   - '-exc'
   - |
     # googleapis is not Go code, but it's required for .pb.go regeneration because of API dependencies.
     git clone --depth=1 https://github.com/googleapis/googleapis.git "$$GOPATH/src/github.com/googleapis/googleapis"
 
+    # Use latest versions of Trillian docker images built by the Trillian CI cloudbuilders.
+    docker pull gcr.io/$PROJECT_ID/log_server:latest
+    docker tag gcr.io/$PROJECT_ID/log_server:latest deployment_trillian-log-server
+    docker pull gcr.io/$PROJECT_ID/log_signer:latest
+    docker tag gcr.io/$PROJECT_ID/log_signer:latest deployment_trillian-log-signer
+
+    # Bring up an ephemeral trillian instance using the docker-compose config in the Trillian repo:
     export TRILLIAN_PATH="$(go list -f '{{.Dir}}' github.com/google/trillian)"
-    for i in log_server log_signer; do
-      docker pull gcr.io/$PROJECT_ID/$$i:latest
-    done
+
+    # We need to fix up Trillian's docker-compose to connect to the CloudBuild network to that tests can use it:
+    echo -e "networks:\n      default:\n        external:\n          name: cloudbuild" >> $${TRILLIAN_PATH}/examples/deployment/docker-compose.yml
+
+    docker-compose -f $${TRILLIAN_PATH}/examples/deployment/docker-compose.yml pull mysql trillian-log-server trillian-log-signer
     docker-compose -f $${TRILLIAN_PATH}/examples/deployment/docker-compose.yml up -d mysql trillian-log-server trillian-log-signer
 
+# Install proto related bits
 - name: gcr.io/$PROJECT_ID/testbase
   id: 'go-get-proto'
   args: ['go', 'get', 'github.com/golang/protobuf/proto']
-  waitFor: ['install']
-
+  waitFor: ['prepare']
 - name: gcr.io/$PROJECT_ID/testbase
   id: 'go-get-proto-gen'
   args: ['go', 'get', 'github.com/golang/protobuf/protoc-gen-go']
-  waitFor: ['install']
+  waitFor: ['prepare']
 
+# Run the presubmit tests
 - name: gcr.io/$PROJECT_ID/testbase
   entrypoint: 'bash'
   id: 'presubmit'
@@ -51,6 +63,7 @@ steps:
       git diff --  --exit-code
   waitFor: ['go-get-proto', 'go-get-proto-gen']
 
+# Run the presubmit tests with coverage enabled in parallel
 - name: gcr.io/$PROJECT_ID/testbase
   entrypoint: 'bash'
   id: 'presubmit-with-coverage'
@@ -59,7 +72,18 @@ steps:
     - |
       ./scripts/presubmit.sh --coverage
   waitFor: ['go-get-proto', 'go-get-proto-gen']
+- name: 'gcr.io/cloud-builders/curl'
+  entrypoint: bash
+  args: ['-c', 'bash <(curl -s https://codecov.io/bash)']
+  env:
+  - 'VCS_COMMIT_ID=$COMMIT_SHA'
+  - 'VCS_BRANCH_NAME=$BRANCH_NAME'
+  - 'VCS_PULL_REQUEST=$_PR_NUMBER'
+  - 'CI_BUILD_ID=$BUILD_ID'
+  - 'CODECOV_TOKEN=$_CODECOV_TOKEN' # _CODECOV_TOKEN is specified in the cloud build trigger
+  waitFor: ['presubmit-with-coverage']
 
+# Run the gossip integration test
 - name: gcr.io/$PROJECT_ID/testbase
   entrypoint: 'bash'
   id: 'gossip-integration-test'
@@ -67,9 +91,11 @@ steps:
     - '-exc'
     - |
       export PATH=/bin:/usr/bin:/workspace/bin:/go/protoc/bin:/usr/local/go/bin
+      export TRILLIAN_LOG_RPC="deployment_trillian-log-server_1:8090"
       ./gossip/integration/gossip_test.sh
   waitFor: ['go-get-proto', 'go-get-proto-gen']
 
+# Run the FT integration test
 - name: gcr.io/$PROJECT_ID/testbase
   entrypoint: 'bash'
   id: 'firmware-integration-test'
@@ -77,13 +103,6 @@ steps:
     - '-exc'
     - |
       export PATH=/bin:/usr/bin:/workspace/bin:/go/protoc/bin:/usr/local/go/bin
+      export TRILLIAN_LOG_RPC="deployment_trillian-log-server_1:8090"
       ./binary_transparency/firmware/integration/ft_test.sh
-  # Don't run integration tests in parallel until we've removed the resetDB step
-  waitFor: ['gossip-integration-test']
-
-images:
- - 'gcr.io/$PROJECT_ID/db_server'
- - 'gcr.io/$PROJECT_ID/log_server'
- - 'gcr.io/$PROJECT_ID/log_signer'
- - 'gcr.io/$PROJECT_ID/testbase'
-
+  waitFor: ['go-get-proto', 'go-get-proto-gen']

--- a/gossip/integration/gossip_killall.sh
+++ b/gossip/integration/gossip_killall.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
-# Kill all gossip/trillian related processes.
+# Kill all gossip related processes.
 killall $@ hub_server
-killall $@ trillian_log_server
-killall $@ trillian_log_signer
 killall $@ gosmin
 killall $@ goshawk
 if [[ -x "${ETCD_DIR}/etcd" ]]; then

--- a/gossip/integration/gossip_test.sh
+++ b/gossip/integration/gossip_test.sh
@@ -4,29 +4,25 @@ set -e
 INTEGRATION_DIR="$( cd "$( dirname "$0" )" && pwd )"
 . "${INTEGRATION_DIR}"/gossip_functions.sh
 
-# Default to one of everything.
-LOG_SERVER_COUNT=${1:-1}
-LOG_SIGNER_COUNT=${2:-1}
-HUB_SERVER_COUNT=${3:-1}
+# Trillian must already be running
+[ -z ${TRILLIAN_LOG_RPC+x} ] && TRILLIAN_LOG_RPC="localhost:8090"
 
-gossip_prep_test "${LOG_SERVER_COUNT}" "${LOG_SIGNER_COUNT}" "${HUB_SERVER_COUNT}"
+gossip_prep_test 1
 
 # Cleanup for the Trillian components
 TO_DELETE="${TO_DELETE} ${ETCD_DB_DIR} ${PROMETHEUS_CFGDIR}"
-TO_KILL+=(${LOG_SIGNER_PIDS[@]})
-TO_KILL+=(${RPC_SERVER_PIDS[@]})
 TO_KILL+=(${ETCD_PID})
 TO_KILL+=(${PROMETHEUS_PID})
 TO_KILL+=(${ETCDISCOVER_PID})
 
 # Cleanup for the personality
 TO_DELETE="${TO_DELETE} ${HUB_CFG} ${SRC_PRIV_KEYS}"
-TO_KILL+=(${HUB_SERVER_PIDS[@]})
+TO_KILL+=(${HUB_SERVER_PID})
 
 echo "Running test(s)"
 pushd "${INTEGRATION_DIR}"
 set +e
-go test -v -run ".*LiveGossip.*" --timeout=5m ./ --hub_servers=${HUB_SERVERS} --hub_config=${HUB_CFG} --src_priv_keys=${SRC_PRIV_KEY_LIST}
+go test -v -run ".*LiveGossip.*" --timeout=5m ./ --hub_servers=${HUB_SERVER} --hub_config=${HUB_CFG} --src_priv_keys=${SRC_PRIV_KEY_LIST}
 RESULT=$?
 set -e
 popd

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.15 as testbase
+
+WORKDIR /testbase
+
+ARG GOFLAGS=""
+ENV GOFLAGS=$GOFLAGS
+ENV GO111MODULE=on
+
+RUN apt-get update && apt-get -y install curl unzip wget default-mysql-client docker-compose
+RUN cd /usr/bin && curl -L -O https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux && mv jq-linux jq && chmod +x jq
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.18.0
+RUN mkdir protoc && \
+    (cd protoc && \
+    wget "https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip" && \
+    unzip "protoc-3.5.1-linux-x86_64.zip" \
+    )
+RUN pwd
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/testbase/protoc:$PATH

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,3 +1,6 @@
+# This Dockerfile builds a base image for the CloudBuild integration testing.
+# It just extends a golang/linux base image with a few extra tools which the
+# tests need.
 FROM golang:1.15 as testbase
 
 WORKDIR /testbase
@@ -6,8 +9,8 @@ ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
 ENV GO111MODULE=on
 
-RUN apt-get update && apt-get -y install curl unzip wget default-mysql-client docker-compose
-RUN cd /usr/bin && curl -L -O https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux && mv jq-linux jq && chmod +x jq
+RUN apt-get update && apt-get -y install curl unzip wget default-mysql-client docker-compose lsof xxd
+RUN cd /usr/bin && curl -L -O https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && mv jq-linux64 /usr/bin/jq && chmod +x /usr/bin/jq
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.18.0
 RUN mkdir protoc && \
     (cd protoc && \
@@ -17,4 +20,4 @@ RUN mkdir protoc && \
 RUN pwd
 
 ENV GOPATH /go
-ENV PATH $GOPATH/bin:/testbase/protoc:$PATH
+ENV PATH $GOPATH/bin:/testbase/protoc/bin:$PATH

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -115,7 +115,7 @@ main() {
       'have you installed github.com/golangci/golangci-lint?' || exit 1
 
     echo 'running golangci-lint'
-    golangci-lint run
+    golangci-lint run --deadline=10m
     echo 'checking license headers'
     ./scripts/check_license.sh ${go_srcs}
   fi


### PR DESCRIPTION
Given the future of Travis support for opensource projects is unclear, and we have more control over our destiny using GCP Cloudbuild, add support for migrating our CI over there.