### PR TITLE
Added a simple witness to the SumDB examples

### DIFF
--- a/sumdbaudit/README.md
+++ b/sumdbaudit/README.md
@@ -5,6 +5,9 @@ This directory contains tools for verifiably creating a local copy of the
 database.
  * `cli/clone` is a one-shot tool to clone the Log at its current size
  * `cli/mirror` is a service which continually clones the Log
+ * `cli/witness` is an HTTP service that uses a local clone of the Log to provide
+   checkpoint validation for other clients. This is a very lightweight way of
+   providing some Gossip solution to detect split views.
 
 ## Background
 This is a quick summary of https://blog.golang.org/module-mirror-launch but is not
@@ -118,6 +121,38 @@ In the `ExecStart` line above, add `-unpack` and then restart the `sumdbmirror` 
 (`sudo systemctl daemon-reload && sudo systemctl restart sumdbmirror`).
 When it next updates tiles this table will be populated.
 This will use more CPU and around 60% more disk.
+
+## Setting up a `witness` service
+This requires a local clone of the SumDB Log to be available. For this to be of any
+real value, it should be running against a database which is regularly being updated
+by the `mirror` service described above.
+
+A client which successfully checks its checkpoints with a witness can ensure that if
+there is a "split view" of the SumDB Log, then it is on the same side of the split as
+the witness. If this witness is also verifying the claims of the log, then the client
+is safe in relying on the data within (providing it trusts the verifer!).
+
+The service can be started with the command (assuming `~/sum.db` is the database):
+```bash
+go run ./sumdbaudit/cli/witness -listen :8080 -db ~/sum.db -v=1 -alsologtostderr
+```
+
+This can be set up as a Linux service in much the same way as the `mirror` above.
+
+Once running, the server will be available for GET requests at the listen address
+given as a commandline parameter.
+
+Some example requests that can be made:
+```bash
+# Simply get the latest golden checkpoint
+curl -i http://localhost:8080/golden
+
+# Validate that the witness is consistent with the Checkpoint your go build tools are using
+curl -i http://localhost:8080/checkConsistency/`base64 -i ~/go/pkg/sumdb/sum.golang.org/latest`
+
+# Validate that the witness is consistent with the latest Checkpoint from the real Log
+curl -i http://localhost:8080/checkConsistency/`curl https://sum.golang.org/latest | base64`
+```
 
 ## Querying the database
 The number of leaves downloaded can be queried:

--- a/sumdbaudit/README.md
+++ b/sumdbaudit/README.md
@@ -127,10 +127,10 @@ This requires a local clone of the SumDB Log to be available. For this to be of 
 real value, it should be running against a database which is regularly being updated
 by the `mirror` service described above.
 
-Note that the witness is missing features (outlined below) in order to be used in an
-untrusted environment. This witness implementation is useful only in a trusted domain
-where the correct operation of the witness is implicit. This precludes being run as
-a general service on the Web, but is still useful within a household or organization.
+> :warning: The witness is missing features (outlined below) in order to be used in an
+> untrusted environment. This witness implementation is useful only in a trusted domain
+> where the correct operation of the witness is implicit. This precludes being run as
+> a general service on the Web, but is still useful within a household or organization.
 
 A client which successfully checks its checkpoints with a witness can ensure that if
 there is a "split view" of the SumDB Log, then it is on the same side of the split as

--- a/sumdbaudit/README.md
+++ b/sumdbaudit/README.md
@@ -127,6 +127,11 @@ This requires a local clone of the SumDB Log to be available. For this to be of 
 real value, it should be running against a database which is regularly being updated
 by the `mirror` service described above.
 
+Note that the witness is missing features (outlined below) in order to be used in an
+untrusted environment. This witness implementation is useful only in a trusted domain
+where the correct operation of the witness is implicit. This precludes being run as
+a general service on the Web, but is still useful within a household or organization.
+
 A client which successfully checks its checkpoints with a witness can ensure that if
 there is a "split view" of the SumDB Log, then it is on the same side of the split as
 the witness. If this witness is also verifying the claims of the log, then the client
@@ -177,3 +182,6 @@ sqlite3 ~/sum.db 'SELECT module, COUNT(*) cnt FROM leafMetadata GROUP BY module 
 * Only parse and process new leaves.
 * Support other SQL databases, e.g. MySQL
   * This should be trivial to support in code, but sqlite was picked for simplicity of admin for a demo
+* Witness should return detailed responses
+  * In the event of an inconsistency, both Checkpoints notes should be serialized and returned
+  * Consistency should return a proof that the tree is consistent with the witnesses Golden Checkpoint

--- a/sumdbaudit/audit/service.go
+++ b/sumdbaudit/audit/service.go
@@ -164,7 +164,7 @@ func (s *Service) ProcessMetadata(ctx context.Context, checkpoint *Checkpoint) e
 func (s *Service) CheckConsistency(ctx context.Context, checkpoint *Checkpoint) error {
 	golden, err := s.localDB.GoldenCheckpoint(s.ParseCheckpointNote)
 	if err != nil {
-		return fmt.Errorf("failed to query for golden checkpoint: %v", err)
+		return fmt.Errorf("failed to query for golden checkpoint: %w", err)
 	}
 	if bytes.Equal(checkpoint.Raw, golden.Raw) {
 		// This is easy and possibly common, so handle it as a special case.
@@ -172,7 +172,7 @@ func (s *Service) CheckConsistency(ctx context.Context, checkpoint *Checkpoint) 
 	}
 	head, err := s.localDB.Head()
 	if err != nil {
-		return fmt.Errorf("cannot find head of local log: %v", err)
+		return fmt.Errorf("cannot find head of local log: %w", err)
 	}
 	if checkpoint.N > head {
 		// If we wanted to, we _could_ check consistency for checkpoints that
@@ -216,11 +216,11 @@ func (s *Service) VerifyTiles(ctx context.Context, checkpoint *Checkpoint) error
 					finishedLevel = true
 					continue
 				}
-				return fmt.Errorf("failed to get tile hashes: %v", err)
+				return fmt.Errorf("failed to get tile hashes: %w", err)
 			}
 			sumDBHashes, err := s.sumDB.TileHashes(level, offset)
 			if err != nil {
-				return fmt.Errorf("failed to get tile hashes: %v", err)
+				return fmt.Errorf("failed to get tile hashes: %w", err)
 			}
 
 			for i := 0; i < 1<<s.height; i++ {
@@ -247,7 +247,7 @@ func (s *Service) cloneLeafTiles(ctx context.Context, checkpoint *Checkpoint) er
 			glog.Infof("failed to find head of database, assuming empty and starting from scratch: %v", err)
 			head = -1
 		default:
-			return fmt.Errorf("failed to query for head of local log: %v", err)
+			return fmt.Errorf("failed to query for head of local log: %w", err)
 		}
 	}
 	if checkpoint.N < head {
@@ -353,7 +353,7 @@ func (s *Service) hashTiles(ctx context.Context, checkpoint *Checkpoint) error {
 		roots = outRoots
 	}
 	if err := g.Wait(); err != nil {
-		return fmt.Errorf("failed to hash: %v", err)
+		return fmt.Errorf("failed to hash: %w", err)
 	}
 	return nil
 }
@@ -373,12 +373,12 @@ func (s *Service) checkConsistency(ctx context.Context) error {
 			glog.Warning("Failed to find golden checkpoint!")
 			return nil
 		default:
-			return fmt.Errorf("failed to query for golden checkpoint: %v", err)
+			return fmt.Errorf("failed to query for golden checkpoint: %w", err)
 		}
 	}
 	head, err := s.localDB.Head()
 	if err != nil {
-		return fmt.Errorf("cannot find head of local log: %v", err)
+		return fmt.Errorf("cannot find head of local log: %w", err)
 	}
 	if golden.N > head {
 		// This can happen if SumDB hasn't committed to any new complete tiles since the
@@ -477,7 +477,7 @@ func (s *Service) checkCheckpoint(cp *Checkpoint, getStragglers func(stragglerCo
 	}
 	root, err := logRange.GetRootHash(nil)
 	if err != nil {
-		return fmt.Errorf("failed to get root hash: %v", err)
+		return fmt.Errorf("failed to get root hash: %w", err)
 	}
 	var rootHash tlog.Hash
 	copy(rootHash[:], root)
@@ -513,7 +513,7 @@ func (s *Service) hashLeafTile(offset int) ([][]byte, error) {
 
 	leaves, err := s.localDB.Leaves(int64(tileWidth)*int64(offset), tileWidth)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get leaves from DB: %v", err)
+		return nil, fmt.Errorf("failed to get leaves from DB: %w", err)
 	}
 	res := make([][]byte, tileWidth)
 	leafHashes := make([]byte, tileWidth*HashLenBytes)

--- a/sumdbaudit/cli/mirror/mirror.go
+++ b/sumdbaudit/cli/mirror/mirror.go
@@ -43,11 +43,11 @@ func main() {
 	}
 	db, err := audit.NewDatabase(*db)
 	if err != nil {
-		glog.Exitf("failed to open DB: %v", err)
+		glog.Exitf("Failed to open DB: %v", err)
 	}
 	err = db.Init()
 	if err != nil {
-		glog.Exitf("failed to init DB: %v", err)
+		glog.Exitf("Failed to init DB: %v", err)
 	}
 	sumDB := audit.NewSumDB(*height, *vkey)
 	s := audit.NewService(db, sumDB, *height)
@@ -55,23 +55,23 @@ func main() {
 	for {
 		head, err := sumDB.LatestCheckpoint()
 		if err != nil {
-			glog.Exitf("failed to get latest checkpoint: %s", err)
+			glog.Exitf("Failed to get latest checkpoint: %s", err)
 		}
 		golden := s.GoldenCheckpoint(ctx)
 		if golden != nil && golden.N >= head.N {
-			glog.Infof("nothing to do: latest SumDB size is %d and local size is %d", head.N, golden.N)
+			glog.Infof("Nothing to do: latest SumDB size is %d and local size is %d", head.N, golden.N)
 		} else {
-			glog.Infof("syncing to latest SumDB size %d", head.N)
+			glog.Infof("Syncing to latest SumDB size %d", head.N)
 			s.Sync(ctx, head)
 			if *unpack {
-				glog.V(1).Infof("processing metadata")
+				glog.V(1).Infof("Processing metadata")
 				if err := s.ProcessMetadata(ctx, head); err != nil {
 					glog.Exitf("ProcessMetadata: %v", err)
 				}
 			}
 		}
 
-		glog.V(1).Infof("sleeping for %v", *interval)
+		glog.V(1).Infof("Sleeping for %v", *interval)
 		time.Sleep(*interval)
 	}
 }

--- a/sumdbaudit/cli/witness/witness.go
+++ b/sumdbaudit/cli/witness/witness.go
@@ -1,0 +1,118 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// witness starts a HTTP server that can return its latest Golden Checkpoint, and
+// perform consistency checks for client-provided Checkpoints.
+package main
+
+import (
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/sumdbaudit/audit"
+	"github.com/gorilla/mux"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+var (
+	height = flag.Int("h", 8, "tile height")
+	vkey   = flag.String("k", "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8", "key")
+	db     = flag.String("db", "", "database file location (will be created if it doesn't exist)")
+
+	listenAddr = flag.String("listen", ":8000", "address:port to listen for requests on")
+)
+
+type server struct {
+	a *audit.Service
+}
+
+// getGolden returns the latest validated Checkpoint.
+func (s *server) getGolden(w http.ResponseWriter, r *http.Request) {
+	golden := s.a.GoldenCheckpoint(r.Context())
+	if golden == nil {
+		http.Error(w, "failed to find golden checkpoint!", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
+	w.Header().Set("Content-Length", strconv.Itoa(len(golden.Raw)))
+	w.Write(golden.Raw)
+}
+
+// checkConsistency validates whether the provided checkpoint is consistent
+// with the local state.
+func (s *server) checkConsistency(w http.ResponseWriter, r *http.Request) {
+	rawCheckpoint, err := parseBase64Param(r, "cp")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	glog.V(2).Infof("got checkpoint %q", rawCheckpoint)
+	checkpoint, err := s.a.ParseCheckpointNote(rawCheckpoint)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := s.a.CheckConsistency(r.Context(), checkpoint); err != nil {
+		switch err.(type) {
+		case audit.CheckpointTooFresh:
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		case audit.InconsistentCheckpoints:
+			// TODO(mhutchinson): Return both checkpoints in a parseable response
+			http.Error(w, err.Error(), http.StatusTeapot)
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+}
+
+func main() {
+	flag.Parse()
+
+	if len(*db) == 0 {
+		glog.Exit("db must be provided")
+	}
+
+	db, err := audit.NewDatabase(*db)
+	if err != nil {
+		glog.Exitf("failed to open DB: %v", err)
+	}
+
+	sumDB := audit.NewSumDB(*height, *vkey)
+	auditor := audit.NewService(db, sumDB, *height)
+	server := &server{a: auditor}
+
+	glog.Infof("Starting witness listening on %s...", *listenAddr)
+
+	r := mux.NewRouter()
+	r.HandleFunc(fmt.Sprintf("/golden"), server.getGolden).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/checkConsistency/{cp}"), server.checkConsistency).Methods("GET")
+	glog.Fatal(http.ListenAndServe(*listenAddr, r))
+}
+
+func parseBase64Param(r *http.Request, name string) ([]byte, error) {
+	v := mux.Vars(r)
+	b, err := base64.URLEncoding.DecodeString(v[name])
+	if err != nil {
+		return nil, fmt.Errorf("%s should be URL-safe base64 (%q)", name, err)
+	}
+	return b, nil
+}

--- a/sumdbaudit/cli/witness/witness.go
+++ b/sumdbaudit/cli/witness/witness.go
@@ -81,6 +81,7 @@ func (s *server) checkConsistency(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// TODO(mhutchinson): Synthesize and return a proof of consistency with Golden CP.
 	w.Header().Set("Content-Type", "application/json")
 }
 


### PR DESCRIPTION
This allows the mirror to be easily upgraded to provide a service which is easy to integrate with from any other tooling.