### PR TITLE
Update integration test to cover signature checking on device

### DIFF
--- a/binary_transparency/firmware/cmd/hacker/modify_bundle/modify_bundle.go
+++ b/binary_transparency/firmware/cmd/hacker/modify_bundle/modify_bundle.go
@@ -1,0 +1,127 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// modify_bundle is a hacker tool for modifying proof bundles.
+//
+// It can update the expected measurement and firmware image hashes of the specified
+// proof bundle file, optionally sign the firmware statement, and finally write the bundle
+// to the specified output file.
+//
+// Usage:
+//   go run ./cmd/hacker/modify_bundle/ --logtostderr --device=[dummy,usbarmory] --binary=/path/to/new/firmware/image --input=/path/to/bundle.json --output=/path/to/bundle.json
+//
+// The first time you use this tool there will be no prior firmware metadata
+// stored on the device and the tool will fail.  In this case, use the --force
+// flag to apply the update anyway thereby creating the metadata.
+// Subsequent invocations should then work without needing the --force flag.package main
+package main
+
+import (
+	"crypto/sha512"
+	"encoding/json"
+	"flag"
+	"io/ioutil"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/binary_transparency/firmware/api"
+	dummy_common "github.com/google/trillian-examples/binary_transparency/firmware/devices/dummy/common"
+	"github.com/google/trillian-examples/binary_transparency/firmware/devices/usbarmory"
+	"github.com/google/trillian-examples/binary_transparency/firmware/internal/crypto"
+)
+
+var (
+	input      = flag.String("input", "", "File path read input ProofBundle from.")
+	output     = flag.String("output", "", "File path to write output ProofBundle to.")
+	sign       = flag.Bool("sign", true, "Whether to use stolen key to sign manifest.")
+	binaryPath = flag.String("binary", "", "Replacement binary image.")
+	deviceID   = flag.String("device", "", "One of [dummy,usbarmory].")
+)
+
+func main() {
+	flag.Parse()
+
+	bundleRaw, err := ioutil.ReadFile(*input)
+	if err != nil {
+		glog.Exitf("Failed to read transparency bundle %q: %q", *input, err)
+	}
+	var pb api.ProofBundle
+	if err := json.Unmarshal(bundleRaw, &pb); err != nil {
+		glog.Exitf("Failed to parse proof bundle file: %q", err)
+	}
+	var fs api.FirmwareStatement
+	if err := json.Unmarshal(pb.ManifestStatement, &fs); err != nil {
+		glog.Exitf("Failed to parse FirmwareStatement: %q", err)
+	}
+	var fm api.FirmwareMetadata
+	if err := json.Unmarshal(fs.Metadata, &fm); err != nil {
+		glog.Exitf("Failed to parse FirmwareMetadata: %q", err)
+	}
+
+	if len(*binaryPath) > 0 {
+		var measure func([]byte) ([]byte, error)
+		switch *deviceID {
+		case "armory":
+			measure = usbarmory.ExpectedMeasurement
+		case "dummy":
+			measure = dummy_common.ExpectedMeasurement
+		default:
+			glog.Exit("--device must be one of: 'dummy', 'armory'")
+		}
+
+		fw, err := ioutil.ReadFile(*binaryPath)
+		if err != nil {
+			glog.Exitf("Failed to read %q: %q", *binaryPath, err)
+		}
+
+		h := sha512.Sum512(fw)
+
+		m, err := measure(fw)
+		if err != nil {
+			glog.Exitf("Failed to calculate expected measurement for firmware: %q", err)
+		}
+
+		fm.ExpectedFirmwareMeasurement = m
+		fm.FirmwareImageSHA512 = h[:]
+	}
+	rawMeta, err := json.Marshal(fm)
+	if err != nil {
+		glog.Exitf("Failed to marshal FirmwareMetadata: %q", err)
+	}
+	fs.Metadata = rawMeta
+
+	if *sign {
+		// Use stolen key to re-sign the dodgy metadata
+		sig, err := crypto.SignMessage(rawMeta)
+		if err != nil {
+			glog.Exitf("Failed to sign FirmwareMetadata: %q", err)
+		}
+		fs.Signature = sig
+	}
+
+	rawFS, err := json.Marshal(fs)
+	if err != nil {
+		glog.Exitf("Failed to marshal FirmwareStatement: %q", err)
+	}
+
+	pb.ManifestStatement = rawFS
+
+	rawPB, err := json.Marshal(pb)
+	if err != nil {
+		glog.Exitf("Failed to marshal ProofBundle: %q", err)
+	}
+
+	if err := ioutil.WriteFile(*output, rawPB, 0x644); err != nil {
+		glog.Exitf("Failed to write modified bundle to %q: %q", *output, err)
+	}
+}

--- a/binary_transparency/firmware/integration/ft_functions.sh
+++ b/binary_transparency/firmware/integration/ft_functions.sh
@@ -109,9 +109,9 @@ EXPECT_FAIL() {
     echo "FAIL: Expected command to fail, but it returned success"
     exit 1
   fi
-  echo "${output}" | grep --color "${want}\|$"
+  echo "${output}" | grep --color "${want}"
   if [ $? -ne 0 ]; then
-    echo "FAIL: Didn't find expected error message '${want}' in output: ${output}"
+    echo "FAIL: Didn't find expected error message '${want}' in output:\n${output}"
     exit 2
   fi
 

--- a/binary_transparency/firmware/integration/ft_test.sh
+++ b/binary_transparency/firmware/integration/ft_test.sh
@@ -92,7 +92,7 @@ go run ../cmd/emulator/dummy/ \
     ${COMMON_FLAGS}
 
 ####################
-banner "Fiddle with installed firmware and try to boot device"
+banner "Replace installed firmware and try to boot device"
 cp -v ../testdata/firmware/dummy_device/hacked.wasm ${DEVICE_STATE}/firmware.bin
 EXPECT_FAIL "firmware measurement does not match" \
     go run ../cmd/emulator/dummy/ \
@@ -100,7 +100,7 @@ EXPECT_FAIL "firmware measurement does not match" \
         ${COMMON_FLAGS}
 
 ####################
-banner "Fiddle with installed firmware & manifest and try to boot device"
+banner "Replace installed firmware, update manifest hash, and try to boot device"
 HACKED_FIRMWARE=../testdata/firmware/dummy_device/hacked.wasm
 cp -v ${HACKED_FIRMWARE} ${DEVICE_STATE}/firmware.bin
 malware_hash=$(sha512sum ${DEVICE_STATE}/firmware.bin | awk '{print $1}' | xxd -r -p | base64 -w 0 )
@@ -113,21 +113,22 @@ EXPECT_FAIL "failed to verify signature" \
         --dummy_storage_dir="${DEVICE_STATE}" \
         ${COMMON_FLAGS}
 
-
 ####################
-banner "Fiddle with installed firmware & manifest and try to boot device"
+banner "Replace installed firmware, update manifest hash, sign, and try to boot device"
 HACKED_FIRMWARE=../testdata/firmware/dummy_device/hacked.wasm
 cp -v ${HACKED_FIRMWARE} ${DEVICE_STATE}/firmware.bin
-malware_hash=$(sha512sum ${DEVICE_STATE}/firmware.bin | awk '{print $1}' | xxd -r -p | base64 -w 0 )
-echo "new hash ${malware_hash}"
-mv ${DEVICE_STATE}/bundle.json ${DEVICE_STATE}/bundle.json.orig
-# This beastly jq command unpacks the nested json structures and replaces just the fimware measurement with the one from our hacked firmware:
-jq --arg hacked ${malware_hash} -c '.ManifestStatement=(.ManifestStatement|@base64d|fromjson|.Metadata=(.Metadata|@base64d|fromjson|.ExpectedFirmwareMeasurement=$hacked|tojson|@base64)|tojson|@base64)' ${DEVICE_STATE}/bundle.json.orig > ${DEVICE_STATE}/bundle.json
+# Now update the bundle file with correct measurements for the hacked firmware,
+# and sign the manifest with a "stolen" key.
+go run ../cmd/hacker/modify_bundle \
+    --device="dummy" \
+    --input ${DEVICE_STATE}/bundle.json \
+    --binary ${DEVICE_STATE}/firmware.bin \
+    --output ${DEVICE_STATE}/bundle.json  \
+    ${COMMON_FLAGS}
 EXPECT_FAIL "invalid inclusion proof in bundle" \
     go run ../cmd/emulator/dummy/ \
         --dummy_storage_dir="${DEVICE_STATE}" \
         ${COMMON_FLAGS}
-
 
 ####################
 banner "Log malware, device boots, but monitor sees all!"


### PR DESCRIPTION
- fixes the integration EXPECT_FAIL test which would have caught this on the signature PR.
- adds a "hacker tool" to easily modify proof bundles
- updates integration test with a new test for checking signatures