### PR TITLE
Tidy up device side

### DIFF
--- a/binary_transparency/firmware/api/update_package.go
+++ b/binary_transparency/firmware/api/update_package.go
@@ -19,6 +19,7 @@ type UpdatePackage struct {
 	// FirmwareImage is the actual firmware image itself.
 	FirmwareImage []byte
 	// ProofBundle holds the various artifacts required to validate the firmware image.
+	// It should be a serialised JSON form of the ProofBundle structure.
 	ProofBundle []byte
 }
 

--- a/binary_transparency/firmware/api/update_package.go
+++ b/binary_transparency/firmware/api/update_package.go
@@ -19,7 +19,7 @@ type UpdatePackage struct {
 	// FirmwareImage is the actual firmware image itself.
 	FirmwareImage []byte
 	// ProofBundle holds the various artifacts required to validate the firmware image.
-	ProofBundle ProofBundle
+	ProofBundle []byte
 }
 
 // ProofBundle contains the manifest and associated proofs for a given firmware image.

--- a/binary_transparency/firmware/cmd/flash_tool/flash_tool.go
+++ b/binary_transparency/firmware/cmd/flash_tool/flash_tool.go
@@ -26,7 +26,6 @@
 package main
 
 import (
-	"bytes"
 	"crypto/sha512"
 	"encoding/json"
 	"errors"
@@ -40,7 +39,6 @@ import (
 	"github.com/google/trillian-examples/binary_transparency/firmware/cmd/flash_tool/devices"
 	"github.com/google/trillian-examples/binary_transparency/firmware/devices/dummy"
 	"github.com/google/trillian-examples/binary_transparency/firmware/internal/client"
-	"github.com/google/trillian-examples/binary_transparency/firmware/internal/crypto"
 	"github.com/google/trillian-examples/binary_transparency/firmware/internal/verify"
 )
 
@@ -71,10 +69,6 @@ func main() {
 		glog.Exitf("Failed to read update package file: %q", err)
 	}
 	// TODO(al): check signature on checkpoints when they're added.
-	// Verify Signature on the manifest statement
-	if err := checkSignature(up); err != nil {
-		glog.Exitf("Manifest/signature verification failed: %q", err)
-	}
 
 	var dev devices.Device
 	dev, err = dummy.NewFromFlags()
@@ -117,19 +111,6 @@ func readUpdateFileFromFlags() (api.UpdatePackage, error) {
 		glog.Exitf("Failed to parse update package file: %q", err)
 	}
 	return up, nil
-}
-
-func checkSignature(up api.UpdatePackage) error {
-	stmt := api.FirmwareStatement{}
-	if err := json.NewDecoder(bytes.NewReader(up.ProofBundle.ManifestStatement)).Decode(&stmt); err != nil {
-		return fmt.Errorf("failed to decode firmware statement: %w", err)
-	}
-
-	//Verify the signature:
-	if err := crypto.VerifySignature(stmt.Metadata, stmt.Signature); err != nil {
-		return fmt.Errorf("firmware signature verification failed reason %w", err)
-	}
-	return nil
 }
 
 // verifyUpdate checks that an update package is self-consistent.

--- a/binary_transparency/firmware/cmd/publisher/publish.go
+++ b/binary_transparency/firmware/cmd/publisher/publish.go
@@ -99,14 +99,19 @@ func main() {
 
 	if len(*outputPath) > 0 {
 		glog.Infof("Creating update package file %q...", *outputPath)
-
-		bundle := api.UpdatePackage{
-			FirmwareImage: fw,
-			ProofBundle: api.ProofBundle{
+		pb, err := json.Marshal(
+			api.ProofBundle{
 				ManifestStatement: js,
 				Checkpoint:        cp,
 				InclusionProof:    ip,
-			},
+			})
+		if err != nil {
+			glog.Exitf("Failed to marshal ProofBundle: %q", err)
+		}
+
+		bundle := api.UpdatePackage{
+			FirmwareImage: fw,
+			ProofBundle:   pb,
 		}
 
 		f, err := os.OpenFile(*outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)

--- a/binary_transparency/firmware/devices/dummy/flash.go
+++ b/binary_transparency/firmware/devices/dummy/flash.go
@@ -82,11 +82,7 @@ func (d Device) ApplyUpdate(u api.UpdatePackage) error {
 	fwFile := filepath.Join(*dummyDirectory, firmwarePath)
 	bundleFile := filepath.Join(*dummyDirectory, bundlePath)
 
-	proof, err := json.Marshal(u.ProofBundle)
-	if err != nil {
-		return fmt.Errorf("failed to marshal proof bundle: %q", err)
-	}
-	if err := ioutil.WriteFile(bundleFile, proof, os.ModePerm); err != nil {
+	if err := ioutil.WriteFile(bundleFile, u.ProofBundle, os.ModePerm); err != nil {
 		return fmt.Errorf("failed to write proof bundle to %q: %q", bundleFile, err)
 	}
 

--- a/binary_transparency/firmware/internal/verify/bundle.go
+++ b/binary_transparency/firmware/internal/verify/bundle.go
@@ -29,8 +29,8 @@ import (
 // are all self-consistent, and that the provided firmware image hash matches
 // the one in the bundle. It also checks consistency proof between update log point
 // and device log point (for non zero device tree size).
-func BundleForUpdate(b api.ProofBundle, fwHash []byte, dc api.LogCheckpoint, cProof [][]byte) error {
-	fwMeta, err := verifyBundle(b)
+func BundleForUpdate(bundleRaw, fwHash []byte, dc api.LogCheckpoint, cProof [][]byte) error {
+	proofBundle, fwMeta, err := verifyBundle(bundleRaw)
 	if err != nil {
 		return err
 	}
@@ -41,7 +41,7 @@ func BundleForUpdate(b api.ProofBundle, fwHash []byte, dc api.LogCheckpoint, cPr
 	// Verify the consistency proof between device and bundle checkpoint
 	if dc.TreeSize > 0 {
 		lv := NewLogVerifier()
-		if err := lv.VerifyConsistencyProof(int64(dc.TreeSize), int64(b.Checkpoint.TreeSize), dc.RootHash, b.Checkpoint.RootHash, cProof); err != nil {
+		if err := lv.VerifyConsistencyProof(int64(dc.TreeSize), int64(proofBundle.Checkpoint.TreeSize), dc.RootHash, proofBundle.Checkpoint.RootHash, cProof); err != nil {
 			return fmt.Errorf("failed verification of consistency proof %w", err)
 		}
 	}
@@ -51,8 +51,8 @@ func BundleForUpdate(b api.ProofBundle, fwHash []byte, dc api.LogCheckpoint, cPr
 // BundleForBoot checks that the manifest, checkpoint, and proofs in a bundle
 // are all self-consistent, and that the provided firmware measurement matches
 // the one expected by the bundle.
-func BundleForBoot(b api.ProofBundle, measurement []byte) error {
-	fwMeta, err := verifyBundle(b)
+func BundleForBoot(bundleRaw, measurement []byte) error {
+	_, fwMeta, err := verifyBundle(bundleRaw)
 	if err != nil {
 		return err
 	}
@@ -63,27 +63,34 @@ func BundleForBoot(b api.ProofBundle, measurement []byte) error {
 	return nil
 }
 
-// verifyBundle verifies the self-consistency of a proof bundle.
-func verifyBundle(b api.ProofBundle) (api.FirmwareMetadata, error) {
+// verifyBundle parses a proof bundle and verifies its self-consistency.
+func verifyBundle(bundleRaw []byte) (api.ProofBundle, api.FirmwareMetadata, error) {
+	var pb api.ProofBundle
+	if err := json.Unmarshal(bundleRaw, &pb); err != nil {
+		return api.ProofBundle{}, api.FirmwareMetadata{}, fmt.Errorf("failed to parse proof bundle: %w", err)
+	}
+
+	// TODO(al): check Checkpoint signature
+
 	var fwStatement api.FirmwareStatement
-	if err := json.Unmarshal(b.ManifestStatement, &fwStatement); err != nil {
-		return api.FirmwareMetadata{}, fmt.Errorf("failed to unmarshal FirmwareStatement: %w", err)
+	if err := json.Unmarshal(pb.ManifestStatement, &fwStatement); err != nil {
+		return api.ProofBundle{}, api.FirmwareMetadata{}, fmt.Errorf("failed to unmarshal FirmwareStatement: %w", err)
 	}
 	// Verify the statement signature:
 	if err := crypto.VerifySignature(fwStatement.Metadata, fwStatement.Signature); err != nil {
-		return api.FirmwareMetadata{}, fmt.Errorf("failed to verify signature on FirmwareStatement: %w", err)
+		return api.ProofBundle{}, api.FirmwareMetadata{}, fmt.Errorf("failed to verify signature on FirmwareStatement: %w", err)
+	}
+
+	lh := HashLeaf(pb.ManifestStatement)
+	lv := NewLogVerifier()
+	if err := lv.VerifyInclusionProof(int64(pb.InclusionProof.LeafIndex), int64(pb.Checkpoint.TreeSize), pb.InclusionProof.Proof, pb.Checkpoint.RootHash, lh); err != nil {
+		return api.ProofBundle{}, api.FirmwareMetadata{}, fmt.Errorf("invalid inclusion proof in bundle: %w", err)
 	}
 
 	var fwMeta api.FirmwareMetadata
 	if err := json.Unmarshal(fwStatement.Metadata, &fwMeta); err != nil {
-		return api.FirmwareMetadata{}, fmt.Errorf("failed to unmarshal Metadata: %w", err)
+		return api.ProofBundle{}, api.FirmwareMetadata{}, fmt.Errorf("failed to unmarshal Metadata: %w", err)
 	}
 
-	lh := HashLeaf(b.ManifestStatement)
-	lv := NewLogVerifier()
-
-	if err := lv.VerifyInclusionProof(int64(b.InclusionProof.LeafIndex), int64(b.Checkpoint.TreeSize), b.InclusionProof.Proof, b.Checkpoint.RootHash, lh); err != nil {
-		return api.FirmwareMetadata{}, fmt.Errorf("invalid inclusion proof in bundle: %w", err)
-	}
-	return fwMeta, nil
+	return pb, fwMeta, nil
 }

--- a/binary_transparency/firmware/internal/verify/bundle_test.go
+++ b/binary_transparency/firmware/internal/verify/bundle_test.go
@@ -17,7 +17,6 @@ package verify_test
 import (
 	"crypto/sha512"
 	"encoding/base64"
-	"encoding/json"
 	"testing"
 
 	"github.com/google/trillian-examples/binary_transparency/firmware/api"
@@ -25,7 +24,7 @@ import (
 )
 
 const (
-	goldenUpdate        = `{"FirmwareImage":"RmlybXdhcmUgaW1hZ2U=","ProofBundle":{"ManifestStatement":"eyJNZXRhZGF0YSI6ImV5SkVaWFpwWTJWSlJDSTZJbVIxYlcxNUlpd2lSbWx5YlhkaGNtVlNaWFpwYzJsdmJpSTZNU3dpUm1seWJYZGhjbVZKYldGblpWTklRVFV4TWlJNkltZ3ZTblpLTURVeE1GZE5Ua05hZG1wWFQwTXdVMUZxTDFKUFJHVXpLMGh6Uld0dE5HMUhUbnBWVEhSd1lXVlVhblkyU2xrcmQzSTBlVk51Vm5aNVJqVXdZa055TVhSd2NYZERiMEZvWm5CeFFscHNNbUpSUFQwaUxDSkZlSEJsWTNSbFpFWnBjbTEzWVhKbFRXVmhjM1Z5WlcxbGJuUWlPaUkyZEZWWGVYbHJlbmRtYjI5dVIzVm5ibVl4WkV3clkyZGtObUpGVjFWb2IyeEJUbUZFVERoS1dVdFhkR1J0VUdORlpWbDJaMDgyYmsxeUwwbE1aMWRRWTFWWloyZDJRVUZ5Y25SaFUwSnRZVzQxU0RSTFp6MDlJaXdpUW5WcGJHUlVhVzFsYzNSaGJYQWlPaUl5TURJd0xURXdMVEV3VkRFMU9qTXdPakl3TGpFd1dpSjkiLCJTaWduYXR1cmUiOiJFaXBNMXRMdjF4cnJMSHZEdC80VDFHUG9KV3hBYlExMmhiMkZTOWQ1cDhsbjBKeWJJZFBieVBPWTVYMXozbVBUV0VnMnp1VTB1aWs0VmQwNW84dmM1cGRPZEFTSHlCeDA5RXBhT0NjTWVxSW9SRm90N3lvVUVDdUxkZHBCNEw4aWlEZ3Vibnk1Tk8zaTkzTjNFcnBUclN0b1ZqWjd1ZnZRd082SWg4aWpQZTVTY0o5TG1zQjBMRkZKeUIvQVNnYXcyeE9NWDVnMjlxSzR5UWNBak11WlE3b25ITG95Z09pK2pWUy92akJ0SEVxcXQ1RVU3dU9NdVJVSitqOFYva25yWUJya2hMNEVqWW9SZFNKTnZ6azVpMDRrdGNWLzJQb1NBR2RqSi9rejMrUG1idStXUjRRMVZMcng2bzBaVFNRMi94dXR2K1d2K0lmQXFOdDB0QldoWnc9PSJ9","Checkpoint":{"TreeSize":5,"RootHash":"4E7J8K809jeqeg1oiTIz+5zfMItqZqUBFR0jySa3H/M=","TimestampNanos":1607450738111506088},"InclusionProof":{"Value":null,"LeafIndex":4,"Proof":["KFh4IVeIwbsvbWyz2QHVCXXyjWTRDqusRa0ZEjS2fls="]}}}`
+	goldenProofBundle   = `{"ManifestStatement":"eyJNZXRhZGF0YSI6ImV5SkVaWFpwWTJWSlJDSTZJbVIxYlcxNUlpd2lSbWx5YlhkaGNtVlNaWFpwYzJsdmJpSTZNU3dpUm1seWJYZGhjbVZKYldGblpWTklRVFV4TWlJNkltZ3ZTblpLTURVeE1GZE5Ua05hZG1wWFQwTXdVMUZxTDFKUFJHVXpLMGh6Uld0dE5HMUhUbnBWVEhSd1lXVlVhblkyU2xrcmQzSTBlVk51Vm5aNVJqVXdZa055TVhSd2NYZERiMEZvWm5CeFFscHNNbUpSUFQwaUxDSkZlSEJsWTNSbFpFWnBjbTEzWVhKbFRXVmhjM1Z5WlcxbGJuUWlPaUkyZEZWWGVYbHJlbmRtYjI5dVIzVm5ibVl4WkV3clkyZGtObUpGVjFWb2IyeEJUbUZFVERoS1dVdFhkR1J0VUdORlpWbDJaMDgyYmsxeUwwbE1aMWRRWTFWWloyZDJRVUZ5Y25SaFUwSnRZVzQxU0RSTFp6MDlJaXdpUW5WcGJHUlVhVzFsYzNSaGJYQWlPaUl5TURJd0xURXdMVEV3VkRFMU9qTXdPakl3TGpFd1dpSjkiLCJTaWduYXR1cmUiOiJFaXBNMXRMdjF4cnJMSHZEdC80VDFHUG9KV3hBYlExMmhiMkZTOWQ1cDhsbjBKeWJJZFBieVBPWTVYMXozbVBUV0VnMnp1VTB1aWs0VmQwNW84dmM1cGRPZEFTSHlCeDA5RXBhT0NjTWVxSW9SRm90N3lvVUVDdUxkZHBCNEw4aWlEZ3Vibnk1Tk8zaTkzTjNFcnBUclN0b1ZqWjd1ZnZRd082SWg4aWpQZTVTY0o5TG1zQjBMRkZKeUIvQVNnYXcyeE9NWDVnMjlxSzR5UWNBak11WlE3b25ITG95Z09pK2pWUy92akJ0SEVxcXQ1RVU3dU9NdVJVSitqOFYva25yWUJya2hMNEVqWW9SZFNKTnZ6azVpMDRrdGNWLzJQb1NBR2RqSi9rejMrUG1idStXUjRRMVZMcng2bzBaVFNRMi94dXR2K1d2K0lmQXFOdDB0QldoWnc9PSJ9","Checkpoint":{"TreeSize":5,"RootHash":"4E7J8K809jeqeg1oiTIz+5zfMItqZqUBFR0jySa3H/M=","TimestampNanos":1607450738111506088},"InclusionProof":{"Value":null,"LeafIndex":4,"Proof":["KFh4IVeIwbsvbWyz2QHVCXXyjWTRDqusRa0ZEjS2fls="]}}`
 	goldenFirmwareImage = `Firmware image`
 	// goldenFirmwareHashB64 is a base64 encoded string for ExpectedMeasurement field inside ManifestStatement.
 	// For the dummy device, this is SHA512("dummy"||img), where img is the base64 decoded bytes from
@@ -34,12 +33,8 @@ const (
 )
 
 func TestBundleForUpdate(t *testing.T) {
-	var up api.UpdatePackage
 	var dc api.LogCheckpoint
 	var proof [][]byte
-	if err := json.Unmarshal([]byte(goldenUpdate), &up); err != nil {
-		t.Fatalf(err.Error())
-	}
 
 	for _, test := range []struct {
 		desc    string
@@ -57,7 +52,7 @@ func TestBundleForUpdate(t *testing.T) {
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			imgHash := sha512.Sum512(test.img)
-			err := verify.BundleForUpdate(up.ProofBundle, imgHash[:], dc, proof)
+			err := verify.BundleForUpdate([]byte(goldenProofBundle), imgHash[:], dc, proof)
 			if (err != nil) != test.wantErr {
 				t.Fatalf("want err %T, got %q", test.wantErr, err)
 			}
@@ -75,11 +70,6 @@ func b64Decode(t *testing.T, b64 string) []byte {
 }
 
 func TestBundleForBoot(t *testing.T) {
-	var up api.UpdatePackage
-	if err := json.Unmarshal([]byte(goldenUpdate), &up); err != nil {
-		t.Fatalf(err.Error())
-	}
-
 	for _, test := range []struct {
 		desc        string
 		measurement []byte
@@ -95,7 +85,7 @@ func TestBundleForBoot(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			err := verify.BundleForBoot(up.ProofBundle, test.measurement)
+			err := verify.BundleForBoot([]byte(goldenProofBundle), test.measurement)
 			if (err != nil) != test.wantErr {
 				t.Fatalf("want err %T, got %q", test.wantErr, err)
 			}

--- a/binary_transparency/firmware/internal/verify/bundle_test.go
+++ b/binary_transparency/firmware/internal/verify/bundle_test.go
@@ -34,7 +34,7 @@ const (
 
 func TestBundleForUpdate(t *testing.T) {
 	var dc api.LogCheckpoint
-	var proof [][]byte
+	proof := func(from, to uint64) ([][]byte, error) { return [][]byte{}, nil }
 
 	for _, test := range []struct {
 		desc    string


### PR DESCRIPTION
- Refactor to improve device-side verification reuse
- Remove redundant signature and proof checks
- Flatten ProofBundle inside UpdatePackage
- Don't force device to parse ProofBundle twice
