### PR TITLE
Split cmds out into implementation and skeleton main files

### DIFF
--- a/binary_transparency/firmware/README.md
+++ b/binary_transparency/firmware/README.md
@@ -198,7 +198,7 @@ in the last step).
    > In both of these cases, you can use the `--force` flag on the `flash_tool`.
 
    ```bash
-   go run ./cmd/flash_tool/ --logtostderr --update_file=/tmp/update.ota --dummy_storage_dir=/tmp/dummy_device  # --force if it's the first time
+   go run ./cmd/flash_tool/ --logtostderr --update_file=/tmp/update.ota --device_storage=/tmp/dummy_device  # --force if it's the first time
    ```
 
 2. Boot the device.

--- a/binary_transparency/firmware/cmd/emulator/dummy/dummy_emu.go
+++ b/binary_transparency/firmware/cmd/emulator/dummy/dummy_emu.go
@@ -30,18 +30,19 @@ import (
 	"flag"
 
 	"github.com/golang/glog"
-	"github.com/google/trillian-examples/binary_transparency/firmware/devices/dummy/rom"
+	"github.com/google/trillian-examples/binary_transparency/firmware/cmd/emulator/dummy/impl"
+)
+
+var (
+	dummyDirectory = flag.String("dummy_storage_dir", "/tmp/dummy_device", "Directory path of the dummy device's state storage")
 )
 
 func main() {
 	flag.Parse()
 
-	boot, err := rom.ResetFromFlags()
-	if err != nil {
-		glog.Exitf("ROM: %q", err)
-	}
-
-	if err := boot(); err != nil {
-		glog.Warningf("boot(): %q", err)
+	if err := impl.Main(impl.EmulatorOpts{
+		DeviceStorage: *dummyDirectory,
+	}); err != nil {
+		glog.Exit(err.Error())
 	}
 }

--- a/binary_transparency/firmware/cmd/emulator/dummy/impl/inner_main.go
+++ b/binary_transparency/firmware/cmd/emulator/dummy/impl/inner_main.go
@@ -1,0 +1,41 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package impl is the implementation of the emulator for the dummy device.
+package impl
+
+import (
+	"fmt"
+
+	"github.com/google/trillian-examples/binary_transparency/firmware/devices/dummy/rom"
+)
+
+// EmulatorOpts encapsulates the parameters for running the emulator.
+type EmulatorOpts struct {
+	DeviceStorage string
+}
+
+// Main is the entry point for the dummy emulator
+func Main(opts EmulatorOpts) error {
+	boot, err := rom.Reset(opts.DeviceStorage)
+	if err != nil {
+		return fmt.Errorf("ROM: %w", err)
+	}
+
+	if err := boot(); err != nil {
+		return fmt.Errorf("boot(): %w", err)
+	}
+
+	return nil
+}

--- a/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
+++ b/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
@@ -1,0 +1,146 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package impl is the implementation of a util to flash firmware update packages created by the publisher tool onto devices.
+//
+// Currently, the only device is a dummy device, which simply sorts the firmware+metadata on local disk.
+package impl
+
+import (
+	"crypto/sha512"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/binary_transparency/firmware/api"
+	"github.com/google/trillian-examples/binary_transparency/firmware/cmd/flash_tool/devices"
+	"github.com/google/trillian-examples/binary_transparency/firmware/devices/dummy"
+	armory_flash "github.com/google/trillian-examples/binary_transparency/firmware/devices/usbarmory/flash"
+	"github.com/google/trillian-examples/binary_transparency/firmware/internal/client"
+	"github.com/google/trillian-examples/binary_transparency/firmware/internal/verify"
+)
+
+// FlashOpts encapsulates flash tool parameters.
+type FlashOpts struct {
+	DeviceID      string
+	LogURL        string
+	UpdateFile    string
+	Force         bool
+	DeviceStorage string
+}
+
+func Main(opts FlashOpts) error {
+	logURL, err := url.Parse(opts.LogURL)
+	if err != nil {
+		return fmt.Errorf("log_url is invalid: %w", err)
+	}
+	c := &client.ReadonlyClient{LogURL: logURL}
+
+	up, err := readUpdateFile(opts.UpdateFile)
+	if err != nil {
+		return fmt.Errorf("Failed to read update package file: %w", err)
+	}
+	// TODO(al): check signature on checkpoints when they're added.
+
+	var dev devices.Device
+	switch opts.DeviceID {
+	case "armory":
+		dev, err = armory_flash.New(opts.DeviceStorage)
+	case "dummy":
+		dev, err = dummy.New(opts.DeviceStorage)
+	default:
+		return errors.New("device must be one of: 'dummy', 'armory'")
+	}
+	if err != nil {
+		switch t := err.(type) {
+		case devices.ErrNeedsInit:
+			err := fmt.Errorf("device needs to be force initialised: %w", err)
+			if !opts.Force {
+				return err
+			}
+			glog.Warning(err)
+		default:
+			err := fmt.Errorf("failed to open device: %w", t)
+			if !opts.Force {
+				return err
+			}
+			glog.Warning(err)
+		}
+	}
+
+	if err := verifyUpdate(c, up, dev); err != nil {
+		err := fmt.Errorf("failed to validate update: %w", err)
+		if !opts.Force {
+			return err
+		}
+		glog.Warning(err)
+	}
+
+	glog.Info("Update verified, about to apply to device...")
+
+	if err := dev.ApplyUpdate(up); err != nil {
+		return fmt.Errorf("failed to apply update to device: %w", err)
+	}
+
+	glog.Info("Update applied.")
+	return nil
+}
+
+func readUpdateFile(path string) (api.UpdatePackage, error) {
+	if len(path) == 0 {
+		return api.UpdatePackage{}, errors.New("must specify update_file")
+	}
+
+	f, err := os.OpenFile(path, os.O_RDONLY, os.ModePerm)
+	if err != nil {
+		glog.Exitf("Failed to open update package file %q: %q", path, err)
+	}
+	defer f.Close()
+
+	var up api.UpdatePackage
+	if err := json.NewDecoder(f).Decode(&up); err != nil {
+		glog.Exitf("Failed to parse update package file: %q", err)
+	}
+	return up, nil
+}
+
+// verifyUpdate checks that an update package is self-consistent.
+func verifyUpdate(c *client.ReadonlyClient, up api.UpdatePackage, dev devices.Device) error {
+	// Get the consistency proof for the bundle
+	dc, err := dev.DeviceCheckpoint()
+	if err != nil {
+		return fmt.Errorf("failed to fetch the device checkpoint: %w", err)
+	}
+
+	cpFunc := func(from, to uint64) ([][]byte, error) {
+		var cp [][]byte
+		if dc.TreeSize > 0 {
+			r, err := c.GetConsistencyProof(api.GetConsistencyRequest{From: from, To: to})
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch consistency proof: %w", err)
+			}
+			cp = r.Proof
+		}
+		return cp, nil
+	}
+
+	fwHash := sha512.Sum512(up.FirmwareImage)
+	if err := verify.BundleForUpdate(up.ProofBundle, fwHash[:], dc, cpFunc); err != nil {
+		return fmt.Errorf("failed to verify proof bundle: %w", err)
+	}
+	return nil
+}

--- a/binary_transparency/firmware/cmd/ft_monitor/ft_monitor.go
+++ b/binary_transparency/firmware/cmd/ft_monitor/ft_monitor.go
@@ -1,0 +1,51 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This package is the entrypoint for the Firmware Transparency monitor.
+// The monitor follows the growth of the Firmware Transparency log server,
+// inspects new firmware metadata as it appears, and prints out a short
+// summary.
+//
+// TODO(al): Extend monitor to verify claims.
+//
+// Start the monitor using:
+// go run ./cmd/ft_monitor/main.go --logtostderr -v=2 --ftlog=http://localhost:8000/
+package main
+
+import (
+	"context"
+	"flag"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/binary_transparency/firmware/cmd/ft_monitor/impl"
+)
+
+var (
+	ftLog        = flag.String("ftlog", "http://localhost:8000", "Base URL of FT Log server")
+	pollInterval = flag.Duration("poll_interval", 5*time.Second, "Duration to wait between polling for new entries")
+	keyWord      = flag.String("keyword", "trojan", "Example keyword for malware")
+)
+
+func main() {
+	flag.Parse()
+
+	if err := impl.Main(context.Background(), impl.MonitorOpts{
+		LogURL:       *ftLog,
+		PollInterval: *pollInterval,
+		Keyword:      *keyWord,
+	}); err != nil {
+		glog.Exitf(err.Error())
+	}
+}

--- a/binary_transparency/firmware/cmd/ft_personality/impl/ft_personality.go
+++ b/binary_transparency/firmware/cmd/ft_personality/impl/ft_personality.go
@@ -1,0 +1,104 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package impl is the implementation of the Firmware Transparency personality server.
+// This requires a Trillian instance to be reachable via gRPC and a tree to have
+// been provisioned.
+package impl
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/binary_transparency/firmware/cmd/ft_personality/internal/cas"
+	ih "github.com/google/trillian-examples/binary_transparency/firmware/cmd/ft_personality/internal/http"
+	"github.com/google/trillian-examples/binary_transparency/firmware/cmd/ft_personality/internal/trillian"
+	"github.com/gorilla/mux"
+
+	_ "github.com/google/trillian/merkle/rfc6962" // Load hashers
+	_ "github.com/mattn/go-sqlite3"               // Load drivers for sqlite3
+)
+
+// PersonalityOpts encapsulates options for running an FT personality.
+type PersonalityOpts struct {
+	ListenAddr     string
+	TreeID         int64
+	CASFile        string
+	TrillianAddr   string
+	ConnectTimeout time.Duration
+	STHRefresh     time.Duration
+}
+
+func Main(ctx context.Context, opts PersonalityOpts) error {
+	if opts.TreeID < 0 {
+		return errors.New("tree ID is required")
+	}
+	if len(opts.CASFile) == 0 {
+		return errors.New("CAS file is required")
+	}
+
+	glog.Infof("Connecting to local DB at %q", opts.CASFile)
+	db, err := sql.Open("sqlite3", opts.CASFile)
+	if err != nil {
+		return fmt.Errorf("failed to connect to DB: %w", err)
+	}
+	cas, err := cas.NewBinaryStorage(db)
+	if err != nil {
+		return fmt.Errorf("failed to connect CAS to DB: %w", err)
+	}
+
+	glog.Infof("Connecting to Trillian Log...")
+	tclient, err := trillian.NewClient(ctx, opts.ConnectTimeout, opts.TrillianAddr, opts.TreeID)
+	if err != nil {
+		return fmt.Errorf("failed to connect to Trillian: %w", err)
+	}
+	defer tclient.Close()
+
+	// Periodically sync the golden STH in the background.
+	go func() {
+		for ctx.Err() == nil {
+			if err := tclient.UpdateRoot(ctx); err != nil {
+				glog.Warningf("error updating STH: %v", err)
+			}
+
+			select {
+			case <-ctx.Done():
+			case <-time.After(opts.STHRefresh):
+			}
+		}
+	}()
+
+	glog.Infof("Starting FT personality server...")
+	srv := ih.NewServer(tclient, cas)
+	r := mux.NewRouter()
+	srv.RegisterHandlers(r)
+	hServer := &http.Server{
+		Addr:    opts.ListenAddr,
+		Handler: r,
+	}
+	e := make(chan error, 1)
+	go func() {
+		e <- hServer.ListenAndServe()
+		close(e)
+	}()
+	<-ctx.Done()
+	glog.Info("Server shutting down")
+	hServer.Shutdown(ctx)
+	return <-e
+}

--- a/binary_transparency/firmware/cmd/hacker/modify_bundle/impl/modify_bundle.go
+++ b/binary_transparency/firmware/cmd/hacker/modify_bundle/impl/modify_bundle.go
@@ -1,0 +1,124 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package impl is the implementation of a hacker tool for modifying proof bundles.
+//
+// It can update the expected measurement and firmware image hashes of the specified
+// proof bundle file, optionally sign the firmware statement, and finally write the bundle
+// to the specified output file.
+package impl
+
+import (
+	"crypto/sha512"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/google/trillian-examples/binary_transparency/firmware/api"
+	dummy_common "github.com/google/trillian-examples/binary_transparency/firmware/devices/dummy/common"
+	"github.com/google/trillian-examples/binary_transparency/firmware/devices/usbarmory"
+	"github.com/google/trillian-examples/binary_transparency/firmware/internal/crypto"
+)
+
+// ModifyBundleOpts encapsulates parameters for the modify bundle Main below.
+type ModifyBundleOpts struct {
+	BinaryPath string
+	DeviceID   string
+	Input      string
+	Output     string
+	Sign       bool
+}
+
+// Main is the modify bundle entrypoint.
+func Main(opts ModifyBundleOpts) error {
+	if len(opts.BinaryPath) == 0 {
+		return errors.New("must specify BinaryPath")
+	}
+
+	bundleRaw, err := ioutil.ReadFile(opts.Input)
+	if err != nil {
+		return fmt.Errorf("failed to read transparency bundle %q: %w", opts.Input, err)
+	}
+	var pb api.ProofBundle
+	if err := json.Unmarshal(bundleRaw, &pb); err != nil {
+		return fmt.Errorf("failed to parse proof bundle file: %w", err)
+	}
+	var fs api.FirmwareStatement
+	if err := json.Unmarshal(pb.ManifestStatement, &fs); err != nil {
+		return fmt.Errorf("failed to parse FirmwareStatement: %w", err)
+	}
+	var fm api.FirmwareMetadata
+	if err := json.Unmarshal(fs.Metadata, &fm); err != nil {
+		return fmt.Errorf("failed to parse FirmwareMetadata: %w", err)
+	}
+
+	var measure func([]byte) ([]byte, error)
+	switch opts.DeviceID {
+	case "armory":
+		measure = usbarmory.ExpectedMeasurement
+	case "dummy":
+		measure = dummy_common.ExpectedMeasurement
+	default:
+		return fmt.Errorf("DeviceID must be one of: 'dummy', 'armory'")
+	}
+
+	fw, err := ioutil.ReadFile(opts.BinaryPath)
+	if err != nil {
+		return fmt.Errorf("failed to read %q: %w", opts.BinaryPath, err)
+	}
+
+	h := sha512.Sum512(fw)
+
+	m, err := measure(fw)
+	if err != nil {
+		return fmt.Errorf("failed to calculate expected measurement for firmware: %w", err)
+	}
+
+	fm.ExpectedFirmwareMeasurement = m
+	fm.FirmwareImageSHA512 = h[:]
+
+	rawMeta, err := json.Marshal(fm)
+	if err != nil {
+		return fmt.Errorf("failed to marshal FirmwareMetadata: %w", err)
+	}
+	fs.Metadata = rawMeta
+
+	if opts.Sign {
+		// Use stolen key to re-sign the dodgy metadata
+		sig, err := crypto.SignMessage(rawMeta)
+		if err != nil {
+			return fmt.Errorf("failed to sign FirmwareMetadata: %w", err)
+		}
+		fs.Signature = sig
+	}
+
+	rawFS, err := json.Marshal(fs)
+	if err != nil {
+		return fmt.Errorf("failed to marshal FirmwareStatement: %w", err)
+	}
+
+	pb.ManifestStatement = rawFS
+
+	rawPB, err := json.Marshal(pb)
+	if err != nil {
+		return fmt.Errorf("failed to marshal ProofBundle: %w", err)
+	}
+
+	if err := ioutil.WriteFile(opts.Output, rawPB, 0x644); err != nil {
+		return fmt.Errorf("failed to write modified bundle to %q: %w", opts.Output, err)
+	}
+
+	return nil
+}

--- a/binary_transparency/firmware/cmd/hacker/modify_bundle/modify_bundle.go
+++ b/binary_transparency/firmware/cmd/hacker/modify_bundle/modify_bundle.go
@@ -28,103 +28,30 @@
 package main
 
 import (
-	"crypto/sha512"
-	"encoding/json"
 	"flag"
-	"io/ioutil"
 
 	"github.com/golang/glog"
-	"github.com/google/trillian-examples/binary_transparency/firmware/api"
-	dummy_common "github.com/google/trillian-examples/binary_transparency/firmware/devices/dummy/common"
-	"github.com/google/trillian-examples/binary_transparency/firmware/devices/usbarmory"
-	"github.com/google/trillian-examples/binary_transparency/firmware/internal/crypto"
+	"github.com/google/trillian-examples/binary_transparency/firmware/cmd/hacker/modify_bundle/impl"
 )
 
 var (
+	binaryPath = flag.String("binary", "", "Replacement binary image.")
+	deviceID   = flag.String("device", "", "One of [dummy,usbarmory].")
 	input      = flag.String("input", "", "File path read input ProofBundle from.")
 	output     = flag.String("output", "", "File path to write output ProofBundle to.")
 	sign       = flag.Bool("sign", true, "Whether to use stolen key to sign manifest.")
-	binaryPath = flag.String("binary", "", "Replacement binary image.")
-	deviceID   = flag.String("device", "", "One of [dummy,usbarmory].")
 )
 
 func main() {
 	flag.Parse()
 
-	if len(*binaryPath) == 0 {
-		glog.Exit("Must specify --binary flag.")
-	}
-
-	bundleRaw, err := ioutil.ReadFile(*input)
-	if err != nil {
-		glog.Exitf("Failed to read transparency bundle %q: %q", *input, err)
-	}
-	var pb api.ProofBundle
-	if err := json.Unmarshal(bundleRaw, &pb); err != nil {
-		glog.Exitf("Failed to parse proof bundle file: %q", err)
-	}
-	var fs api.FirmwareStatement
-	if err := json.Unmarshal(pb.ManifestStatement, &fs); err != nil {
-		glog.Exitf("Failed to parse FirmwareStatement: %q", err)
-	}
-	var fm api.FirmwareMetadata
-	if err := json.Unmarshal(fs.Metadata, &fm); err != nil {
-		glog.Exitf("Failed to parse FirmwareMetadata: %q", err)
-	}
-
-	var measure func([]byte) ([]byte, error)
-	switch *deviceID {
-	case "armory":
-		measure = usbarmory.ExpectedMeasurement
-	case "dummy":
-		measure = dummy_common.ExpectedMeasurement
-	default:
-		glog.Exit("--device must be one of: 'dummy', 'armory'")
-	}
-
-	fw, err := ioutil.ReadFile(*binaryPath)
-	if err != nil {
-		glog.Exitf("Failed to read %q: %q", *binaryPath, err)
-	}
-
-	h := sha512.Sum512(fw)
-
-	m, err := measure(fw)
-	if err != nil {
-		glog.Exitf("Failed to calculate expected measurement for firmware: %q", err)
-	}
-
-	fm.ExpectedFirmwareMeasurement = m
-	fm.FirmwareImageSHA512 = h[:]
-
-	rawMeta, err := json.Marshal(fm)
-	if err != nil {
-		glog.Exitf("Failed to marshal FirmwareMetadata: %q", err)
-	}
-	fs.Metadata = rawMeta
-
-	if *sign {
-		// Use stolen key to re-sign the dodgy metadata
-		sig, err := crypto.SignMessage(rawMeta)
-		if err != nil {
-			glog.Exitf("Failed to sign FirmwareMetadata: %q", err)
-		}
-		fs.Signature = sig
-	}
-
-	rawFS, err := json.Marshal(fs)
-	if err != nil {
-		glog.Exitf("Failed to marshal FirmwareStatement: %q", err)
-	}
-
-	pb.ManifestStatement = rawFS
-
-	rawPB, err := json.Marshal(pb)
-	if err != nil {
-		glog.Exitf("Failed to marshal ProofBundle: %q", err)
-	}
-
-	if err := ioutil.WriteFile(*output, rawPB, 0x644); err != nil {
-		glog.Exitf("Failed to write modified bundle to %q: %q", *output, err)
+	if err := impl.Main(impl.ModifyBundleOpts{
+		BinaryPath: *binaryPath,
+		DeviceID:   *deviceID,
+		Input:      *input,
+		Output:     *output,
+		Sign:       *sign,
+	}); err != nil {
+		glog.Exit(err.Error())
 	}
 }

--- a/binary_transparency/firmware/cmd/publisher/impl/publish.go
+++ b/binary_transparency/firmware/cmd/publisher/impl/publish.go
@@ -1,0 +1,179 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package impl is a the implementation of a tool to put firmware metadata into the log.
+package impl
+
+import (
+	"context"
+	"crypto/sha512"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/binary_transparency/firmware/api"
+	dummy_common "github.com/google/trillian-examples/binary_transparency/firmware/devices/dummy/common"
+	"github.com/google/trillian-examples/binary_transparency/firmware/devices/usbarmory"
+	"github.com/google/trillian-examples/binary_transparency/firmware/internal/client"
+	"github.com/google/trillian-examples/binary_transparency/firmware/internal/crypto"
+)
+
+// PublishOpts encapsulates parameters for the publish Main below.
+type PublishOpts struct {
+	LogURL     string
+	DeviceID   string
+	Revision   uint64
+	BinaryPath string
+	Timestamp  string
+	OutputPath string
+}
+
+// Main is the entrypoint for the implementation of the publisher.
+func Main(ctx context.Context, opts PublishOpts) error {
+	logURL, err := url.Parse(opts.LogURL)
+	if err != nil {
+		return fmt.Errorf("LogURL is invalid: %w", err)
+	}
+
+	metadata, fw, err := createManifest(opts)
+	if err != nil {
+		return fmt.Errorf("failed to create manifest: %w", err)
+	}
+
+	glog.Infof("Measurement: %x", metadata.ExpectedFirmwareMeasurement)
+
+	js, err := createStatementJSON(metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal statement: %w", err)
+	}
+
+	c := &client.SubmitClient{
+		ReadonlyClient: &client.ReadonlyClient{
+			LogURL: logURL,
+		},
+	}
+
+	initialCP, err := c.GetCheckpoint()
+	if err != nil {
+		return fmt.Errorf("failed to get a pre-submission checkpoint from log: %w", err)
+	}
+
+	glog.Info("Submitting entry...")
+	if err := c.PublishFirmware(js, fw); err != nil {
+		return fmt.Errorf("couldn't submit statement: %w", err)
+	}
+
+	glog.Info("Successfully submitted entry, waiting for inclusion...")
+	cp, consistency, ip, err := client.AwaitInclusion(ctx, c.ReadonlyClient, *initialCP, js)
+	if err != nil {
+		glog.Errorf("Failed while waiting for inclusion: %v", err)
+		glog.Warningf("Failed checkpoint: %s", cp)
+		glog.Warningf("Failed consistency proof: %x", consistency)
+		glog.Warningf("Failed inclusion proof: %x", ip)
+		return fmt.Errorf("bailing: %w", err)
+	}
+
+	glog.Infof("Successfully logged %s", js)
+
+	if len(opts.OutputPath) > 0 {
+		glog.Infof("Creating update package file %q...", opts.OutputPath)
+		pb, err := json.Marshal(
+			api.ProofBundle{
+				ManifestStatement: js,
+				Checkpoint:        cp,
+				InclusionProof:    ip,
+			})
+		if err != nil {
+			return fmt.Errorf("failed to marshal ProofBundle: %w", err)
+		}
+
+		bundle := api.UpdatePackage{
+			FirmwareImage: fw,
+			ProofBundle:   pb,
+		}
+
+		f, err := os.OpenFile(opts.OutputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("failed to create output package file %q: %w", opts.OutputPath, err)
+		}
+		defer f.Close()
+
+		if err := json.NewEncoder(f).Encode(bundle); err != nil {
+			return fmt.Errorf("failed to encode output package JSON: %w", err)
+		}
+		glog.Infof("Successfully created update package file %q", opts.OutputPath)
+	}
+	return nil
+}
+
+func createManifest(opts PublishOpts) (api.FirmwareMetadata, []byte, error) {
+	var measure func([]byte) ([]byte, error)
+	switch opts.DeviceID {
+	case "armory":
+		measure = usbarmory.ExpectedMeasurement
+	case "dummy":
+		measure = dummy_common.ExpectedMeasurement
+	default:
+		return api.FirmwareMetadata{}, nil, errors.New("DeviceID must be one of: 'dummy', 'armory'")
+	}
+
+	fw, err := ioutil.ReadFile(opts.BinaryPath)
+	if err != nil {
+		return api.FirmwareMetadata{}, nil, fmt.Errorf("failed to read %q: %w", opts.BinaryPath, err)
+	}
+
+	h := sha512.Sum512(fw)
+
+	m, err := measure(fw)
+	if err != nil {
+		return api.FirmwareMetadata{}, nil, fmt.Errorf("failed to calculate expected measurement for firmware: %w", err)
+	}
+
+	buildTime := opts.Timestamp
+	if buildTime == "" {
+		buildTime = time.Now().Format(time.RFC3339)
+	}
+	metadata := api.FirmwareMetadata{
+		DeviceID:                    opts.DeviceID,
+		FirmwareRevision:            opts.Revision,
+		FirmwareImageSHA512:         h[:],
+		ExpectedFirmwareMeasurement: m,
+		BuildTimestamp:              buildTime,
+	}
+
+	return metadata, fw, nil
+}
+
+func createStatementJSON(m api.FirmwareMetadata) ([]byte, error) {
+	js, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+	sig, err := crypto.SignMessage(js)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate signature: %w", err)
+	}
+
+	statement := api.FirmwareStatement{
+		Metadata:  js,
+		Signature: sig,
+	}
+
+	return json.Marshal(statement)
+}

--- a/binary_transparency/firmware/devices/dummy/flash.go
+++ b/binary_transparency/firmware/devices/dummy/flash.go
@@ -16,7 +16,6 @@ package dummy
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -24,10 +23,6 @@ import (
 
 	"github.com/google/trillian-examples/binary_transparency/firmware/api"
 	"github.com/google/trillian-examples/binary_transparency/firmware/cmd/flash_tool/devices"
-)
-
-var (
-	dummyDirectory = flag.String("dummy_storage_dir", "/tmp/dummy_device", "Directory path to store the dummy device's state")
 )
 
 const (
@@ -39,24 +34,28 @@ const (
 type Device struct {
 	// bundle holds all the update data except the firmware image.
 	bundle api.ProofBundle
+
+	storage string
 }
 
 var _ devices.Device = Device{}
 
 // NewFromFlags creates a new dummy device instance using data from flags.
 // TODO(al): figure out how/whether to remove the flag from in here.
-func NewFromFlags() (*Device, error) {
-	dStat, err := os.Stat(*dummyDirectory)
+func New(storage string) (*Device, error) {
+	dStat, err := os.Stat(storage)
 	if err != nil {
-		return nil, fmt.Errorf("unable to stat dummy_storage_dir %q: %w", *dummyDirectory, err)
+		return nil, fmt.Errorf("unable to stat device storage dir %q: %w", storage, err)
 	}
 	if !dStat.Mode().IsDir() {
-		return nil, fmt.Errorf("dummy_storage_dir %q is not a directory", *dummyDirectory)
+		return nil, fmt.Errorf("device storage %q is not a directory", storage)
 	}
 
-	d := &Device{}
+	d := &Device{
+		storage: storage,
+	}
 
-	fPath := filepath.Join(*dummyDirectory, bundlePath)
+	fPath := filepath.Join(storage, bundlePath)
 	f, err := os.OpenFile(fPath, os.O_RDONLY, os.ModePerm)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -79,8 +78,8 @@ func (d Device) DeviceCheckpoint() (api.LogCheckpoint, error) {
 // The firmware image is stored in the dummy state directory in the firmware.bin file,
 // and the rest of the update bundle is stored in the bundle.json file.
 func (d Device) ApplyUpdate(u api.UpdatePackage) error {
-	fwFile := filepath.Join(*dummyDirectory, firmwarePath)
-	bundleFile := filepath.Join(*dummyDirectory, bundlePath)
+	fwFile := filepath.Join(d.storage, firmwarePath)
+	bundleFile := filepath.Join(d.storage, bundlePath)
 
 	if err := ioutil.WriteFile(bundleFile, u.ProofBundle, os.ModePerm); err != nil {
 		return fmt.Errorf("failed to write proof bundle to %q: %q", bundleFile, err)

--- a/binary_transparency/firmware/devices/dummy/rom/rom.go
+++ b/binary_transparency/firmware/devices/dummy/rom/rom.go
@@ -15,7 +15,6 @@
 package rom
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -23,10 +22,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/binary_transparency/firmware/devices/dummy/common"
 	"github.com/google/trillian-examples/binary_transparency/firmware/internal/verify"
-)
-
-var (
-	dummyDirectory = flag.String("dummy_storage_dir", "/tmp/dummy_device", "Directory path of the dummy device's state storage")
 )
 
 const (
@@ -37,7 +32,7 @@ const (
 // Chain represents the next stage in the boot process.
 type Chain func() error
 
-// ResetFromFlags is intended to emulate the early stage boot process of a device.
+// Reset is intended to emulate the early stage boot process of a device.
 //
 // It's separate from the device emulator code to highlight that the process of
 // verifying the local firmware/proofs/etc. could be done on-device at
@@ -48,14 +43,14 @@ type Chain func() error
 // process by checking once and leveraging properties of the hardware.
 //
 // Returns the first link in the boot chain as a func.
-func ResetFromFlags() (Chain, error) {
+func Reset(storagePath string) (Chain, error) {
 	glog.Info("----RESET----")
 	glog.Info("Powering up bananas, configuring Romulans, feeding the watchdogs")
 
-	glog.Infof("Configuring flash and loading FT artifacts from %q...", *dummyDirectory)
+	glog.Infof("Configuring flash and loading FT artifacts from %q...", storagePath)
 
-	fwFile := filepath.Clean(filepath.Join(*dummyDirectory, firmwarePath))
-	bundleFile := filepath.Clean(filepath.Join(*dummyDirectory, bundlePath))
+	fwFile := filepath.Clean(filepath.Join(storagePath, firmwarePath))
+	bundleFile := filepath.Clean(filepath.Join(storagePath, bundlePath))
 
 	bundleRaw, err := ioutil.ReadFile(bundleFile)
 	if err != nil {

--- a/binary_transparency/firmware/integration/ft_test.sh
+++ b/binary_transparency/firmware/integration/ft_test.sh
@@ -57,7 +57,7 @@ go run ../cmd/flash_tool/ \
     --device=dummy \
     --log_url="http://${FT_SERVER}" \
     --update_file="${UPDATE_FILE}" \
-    --dummy_storage_dir="${DEVICE_STATE}" \
+    --device_storage="${DEVICE_STATE}" \
     --force \
     ${COMMON_FLAGS}
 
@@ -84,7 +84,7 @@ go run ../cmd/flash_tool/ \
     --device=dummy \
     --log_url="http://${FT_SERVER}" \
     --update_file="${UPDATE_FILE}" \
-    --dummy_storage_dir="${DEVICE_STATE}" \
+    --device_storage="${DEVICE_STATE}" \
     ${COMMON_FLAGS}
 
 ####################
@@ -153,7 +153,7 @@ go run ../cmd/flash_tool/ \
     --device=dummy \
     --log_url="http://${FT_SERVER}" \
     --update_file="${MALWARE_UPDATE_FILE}" \
-    --dummy_storage_dir="${DEVICE_STATE}" \
+    --device_storage="${DEVICE_STATE}" \
     ${COMMON_FLAGS}
 
 set +e # hacked firmware exits with status 0x1337


### PR DESCRIPTION
- Splits all the `cmd` main files into implementation and bare-minimum `main` files.
- Uses the `cmd` implementations to build a golang integration test.