### PR TITLE
Support for building logs of versions for a module

### DIFF
--- a/experimental/batchmap/sumdb/README.md
+++ b/experimental/batchmap/sumdb/README.md
@@ -44,6 +44,26 @@ See the implementation of `mapEntryFn` in `build/map.go` for the implementation 
 
 A client that verifies inclusion of a key in a Verifiable Map can thus be satisfied that every client with the same map root will see the same hashes for any key they look up.
 
+#### Experimental++: Adding Logs of module versions to the map
+
+Providing the `--build_version_list` flag to the map builder will add an extra set of entries to the map.
+In addition to two entries for each `module@version`, this mode will add one entry for each `module` to the map.
+The value for each of these keys is a log root hash, and this log is constructed from all of the `version`s found for the module.
+The list of versions are recorded in the `logs` table of the map DB.
+
+This addition allows module developers to use the map to cheaply and verifiably check the list of all versions used for their module.
+Without this data being in the map, the only verifiable way to do this is to download the whole of the SumDB log.
+
+#### Verifying the map
+
+A verifiable map can be verified by constructing an equivalent map.
+The map root is determinstic given:
+ * The number of entries from the input log to consume
+ * The map functions (i.e. which key/values are extracted from the input log)
+ * The same hashing/salt functions
+
+Given this information, another party would detect any false construction if the map root they calculate is different than the one provided by the map operator.
+
 ## Running
 
 ### Building

--- a/experimental/batchmap/sumdb/build/map.go
+++ b/experimental/batchmap/sumdb/build/map.go
@@ -112,7 +112,7 @@ func main() {
 	entries := pipeline.CreateEntries(s, *treeID, records)
 
 	if *buildVersionList {
-		logEntries, logs := pipeline.MakeVersionLogs(s, records)
+		logEntries, logs := pipeline.MakeVersionLogs(s, *treeID, records)
 		entries = beam.Flatten(s, entries, logEntries)
 
 		rows := beam.ParDo(s, &logToDBRowFn{rev}, logs)

--- a/experimental/batchmap/sumdb/build/map.go
+++ b/experimental/batchmap/sumdb/build/map.go
@@ -110,7 +110,9 @@ func main() {
 	entries := pipeline.CreateEntries(s, *treeID, records)
 
 	if *buildVersionList {
-		entries = beam.Flatten(s, entries, pipeline.MakeVersionList(s, records))
+		// TODO(mhutchinson): The logs returned as this second arg should be persisted.
+		logEntries, _ := pipeline.MakeVersionLogs(s, records)
+		entries = beam.Flatten(s, entries, logEntries)
 	}
 
 	var allTiles beam.PCollection

--- a/experimental/batchmap/sumdb/build/pipeline/entries.go
+++ b/experimental/batchmap/sumdb/build/pipeline/entries.go
@@ -42,13 +42,6 @@ type Metadata struct {
 	ModHash  string
 }
 
-// MapTile is the schema format of the Map database to allow for databaseio writing.
-type MapTile struct {
-	Revision int
-	Path     []byte
-	Tile     []byte
-}
-
 // CreateEntries converts the PCollection<Metadata> into a PCollection<Entry> that will be
 // committed to by the map.
 func CreateEntries(s beam.Scope, treeID int64, records beam.PCollection) beam.PCollection {

--- a/experimental/batchmap/sumdb/build/pipeline/entries.go
+++ b/experimental/batchmap/sumdb/build/pipeline/entries.go
@@ -1,0 +1,80 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pipeline contains Beam pipeline library functions for the SumDB
+// verifiable map.
+package pipeline
+
+import (
+	"crypto"
+	"fmt"
+	"reflect"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/google/trillian/experimental/batchmap"
+	"github.com/google/trillian/merkle/coniks"
+)
+
+func init() {
+	beam.RegisterType(reflect.TypeOf((*mapEntryFn)(nil)).Elem())
+}
+
+const hash = crypto.SHA512_256
+
+// Metadata is the audit.Metadata object with the addition of an ID field.
+// It must map to the scheme of the leafMetadata table.
+type Metadata struct {
+	ID       int64
+	Module   string
+	Version  string
+	RepoHash string
+	ModHash  string
+}
+
+// MapTile is the schema format of the Map database to allow for databaseio writing.
+type MapTile struct {
+	Revision int
+	Path     []byte
+	Tile     []byte
+}
+
+// CreateEntries converts the PCollection<Metadata> into a PCollection<Entry> that will be
+// committed to by the map.
+func CreateEntries(s beam.Scope, treeID int64, records beam.PCollection) beam.PCollection {
+	return beam.ParDo(s.Scope("mapentries"), &mapEntryFn{treeID}, records)
+}
+
+type mapEntryFn struct {
+	TreeID int64
+}
+
+func (fn *mapEntryFn) ProcessElement(m Metadata, emit func(*batchmap.Entry)) {
+	h := hash.New()
+	h.Write([]byte(fmt.Sprintf("%s %s/go.mod", m.Module, m.Version)))
+	modKey := h.Sum(nil)
+
+	emit(&batchmap.Entry{
+		HashKey:   modKey,
+		HashValue: coniks.Default.HashLeaf(fn.TreeID, modKey, []byte(m.ModHash)),
+	})
+
+	h = hash.New()
+	h.Write([]byte(fmt.Sprintf("%s %s", m.Module, m.Version)))
+	repoKey := h.Sum(nil)
+
+	emit(&batchmap.Entry{
+		HashKey:   repoKey,
+		HashValue: coniks.Default.HashLeaf(fn.TreeID, repoKey, []byte(m.RepoHash)),
+	})
+}

--- a/experimental/batchmap/sumdb/build/pipeline/entries_test.go
+++ b/experimental/batchmap/sumdb/build/pipeline/entries_test.go
@@ -1,0 +1,67 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/testing/passert"
+	"github.com/apache/beam/sdks/go/pkg/beam/testing/ptest"
+)
+
+func TestMain(m *testing.M) {
+	ptest.Main(m)
+}
+
+func TestCreateEntries(t *testing.T) {
+	tests := []struct {
+		name     string
+		treeID   int64
+		metadata []Metadata
+
+		wantCount int
+	}{
+		{
+			name:   "single entry has 2 outputs",
+			treeID: 12345,
+			metadata: []Metadata{
+				{
+					Module:   "foo",
+					Version:  "1",
+					RepoHash: "abcdefab",
+					ModHash:  "deadbeef",
+				},
+			},
+			wantCount: 2,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			p, s := beam.NewPipelineWithRoot()
+			metadata := beam.CreateList(s, test.metadata)
+
+			entries := CreateEntries(s, test.treeID, metadata)
+
+			passert.Count(s, entries, "entries", test.wantCount)
+			err := ptest.Run(p)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/experimental/batchmap/sumdb/build/pipeline/log.go
+++ b/experimental/batchmap/sumdb/build/pipeline/log.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pipeline
 
 import (

--- a/experimental/batchmap/sumdb/build/pipeline/log.go
+++ b/experimental/batchmap/sumdb/build/pipeline/log.go
@@ -1,0 +1,79 @@
+package pipeline
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+
+	"github.com/google/trillian/experimental/batchmap"
+	"github.com/google/trillian/merkle/compact"
+
+	"golang.org/x/mod/sumdb/tlog"
+)
+
+func init() {
+	beam.RegisterType(reflect.TypeOf((*makeVersionListFn)(nil)).Elem())
+}
+
+func MakeVersionList(s beam.Scope, metadata beam.PCollection) beam.PCollection {
+	keyed := beam.ParDo(s, func(m Metadata) (string, Metadata) { return m.Module, m }, metadata)
+	return beam.ParDo(s, &makeVersionListFn{}, beam.GroupByKey(s, keyed))
+}
+
+type makeVersionListFn struct {
+	rf *compact.RangeFactory
+}
+
+func (fn *makeVersionListFn) Setup() {
+	fn.rf = &compact.RangeFactory{
+		Hash: func(left, right []byte) []byte {
+			// There is no particular need for using this hash function, but it was convenient.
+			var lHash, rHash tlog.Hash
+			copy(lHash[:], left)
+			copy(rHash[:], right)
+			thash := tlog.NodeHash(lHash, rHash)
+			return thash[:]
+		},
+	}
+}
+
+func (fn *makeVersionListFn) ProcessElement(module string, metadata func(*Metadata) bool) (*batchmap.Entry, error) {
+	// We need to ensure ordering by ID in the original log for stability.
+
+	// First build up a map from ID to hash.
+	mm := make(map[int64][]byte)
+	var m Metadata
+	for metadata(&m) {
+		h := hash.New()
+		h.Write([]byte(m.Version))
+
+		mm[m.ID] = h.Sum(nil)
+	}
+
+	// Now order the keyset.
+	keys := make([]int64, 0, len(mm))
+	for k := range mm {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+
+	// Now iterate the map in the right order to build the log.
+	logRange := fn.rf.NewEmptyRange(0)
+	for _, id := range keys {
+		logRange.Append(mm[id], nil)
+	}
+
+	// Construct the map entry for this module version log.
+	logRoot, err := logRange.GetRootHash(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create log for %q: %v", module, err)
+	}
+	h := hash.New()
+	h.Write([]byte(module))
+	return &batchmap.Entry{
+		HashKey:   h.Sum(nil),
+		HashValue: logRoot,
+	}, nil
+}

--- a/experimental/batchmap/sumdb/build/pipeline/log_test.go
+++ b/experimental/batchmap/sumdb/build/pipeline/log_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/google/trillian/experimental/batchmap"
 )
 
+const treeID = 12345
+
 func TestMakeVersionLogs(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -43,7 +45,7 @@ func TestMakeVersionLogs(t *testing.T) {
 				},
 			},
 			wantCount:    1,
-			wantRoot:     "26fd79084956a63e4b7f1899b889258865696ec84917d171aa41d710d44f8df0",
+			wantRoot:     "8656af15c0a3a4cde60b2d370f3b902618ef4959726a265d5ee51dcf16f4db6f",
 			wantVersions: []string{"v0.0.1"},
 		},
 		{
@@ -61,7 +63,7 @@ func TestMakeVersionLogs(t *testing.T) {
 				},
 			},
 			wantCount:    1,
-			wantRoot:     "fb687ea3931784e44d6c432af406a57e4ebc35cb53a8833569f6dfa086ebee93",
+			wantRoot:     "d6c627acd99922885984336b3b6168ea026cc09bf708e2fffaad423b225d738d",
 			wantVersions: []string{"1", "2"},
 		},
 		{
@@ -79,7 +81,7 @@ func TestMakeVersionLogs(t *testing.T) {
 				},
 			},
 			wantCount:    1,
-			wantRoot:     "fb687ea3931784e44d6c432af406a57e4ebc35cb53a8833569f6dfa086ebee93",
+			wantRoot:     "d6c627acd99922885984336b3b6168ea026cc09bf708e2fffaad423b225d738d",
 			wantVersions: []string{"1", "2"},
 		},
 		{
@@ -106,7 +108,7 @@ func TestMakeVersionLogs(t *testing.T) {
 			p, s := beam.NewPipelineWithRoot()
 			metadata := beam.CreateList(s, test.metadata)
 
-			entries, logs := MakeVersionLogs(s, metadata)
+			entries, logs := MakeVersionLogs(s, treeID, metadata)
 
 			passert.Count(s, entries, "entries", test.wantCount)
 			passert.Count(s, logs, "logs", test.wantCount)

--- a/experimental/batchmap/sumdb/build/pipeline/log_test.go
+++ b/experimental/batchmap/sumdb/build/pipeline/log_test.go
@@ -1,0 +1,118 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/testing/passert"
+	"github.com/apache/beam/sdks/go/pkg/beam/testing/ptest"
+	"github.com/google/trillian/experimental/batchmap"
+)
+
+func TestMakeVersionList(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata []Metadata
+
+		wantCount int
+		wantRoot  string
+	}{
+		{
+			name: "single module single metadata",
+			metadata: []Metadata{
+				{
+					Module:  "foo",
+					Version: "1",
+					ID:      1,
+				},
+			},
+			wantCount: 1,
+			wantRoot:  "18d27566bd1ac66b2332d8c54ad43f7bb22079c906d05f491f3f07a28d5c6990",
+		},
+		{
+			name: "single module two metadata (in order)",
+			metadata: []Metadata{
+				{
+					Module:  "foo",
+					Version: "1",
+					ID:      1,
+				},
+				{
+					Module:  "foo",
+					Version: "2",
+					ID:      2,
+				},
+			},
+			wantCount: 1,
+			wantRoot:  "fb687ea3931784e44d6c432af406a57e4ebc35cb53a8833569f6dfa086ebee93",
+		},
+		{
+			name: "single module two metadata (out of order)",
+			metadata: []Metadata{
+				{
+					Module:  "foo",
+					Version: "2",
+					ID:      2,
+				},
+				{
+					Module:  "foo",
+					Version: "1",
+					ID:      1,
+				},
+			},
+			wantCount: 1,
+			wantRoot:  "fb687ea3931784e44d6c432af406a57e4ebc35cb53a8833569f6dfa086ebee93",
+		},
+		{
+			name: "two modules",
+			metadata: []Metadata{
+				{
+					Module:  "foo",
+					Version: "1",
+					ID:      1,
+				},
+				{
+					Module:  "bar",
+					Version: "1",
+					ID:      2,
+				},
+			},
+			wantCount: 2,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			p, s := beam.NewPipelineWithRoot()
+			metadata := beam.CreateList(s, test.metadata)
+
+			entries := MakeVersionList(s, metadata)
+
+			passert.Count(s, entries, "entries", test.wantCount)
+			if len(test.wantRoot) > 0 {
+				roots := beam.ParDo(s, func(e *batchmap.Entry) string { return fmt.Sprintf("%x", e.HashValue) }, entries)
+				passert.Equals(s, roots, test.wantRoot)
+			}
+			err := ptest.Run(p)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/experimental/batchmap/sumdb/mapdb/tiledb.go
+++ b/experimental/batchmap/sumdb/mapdb/tiledb.go
@@ -55,12 +55,16 @@ func (d *TileDB) Init() error {
 	if _, err := d.db.Exec("CREATE TABLE IF NOT EXISTS tiles (revision INTEGER, path BLOB, tile BLOB, PRIMARY KEY (revision, path))"); err != nil {
 		return err
 	}
+	if _, err := d.db.Exec("CREATE TABLE IF NOT EXISTS logs (module TEXT, revision INTEGER, leaves BLOB, PRIMARY KEY (module, revision))"); err != nil {
+		return err
+	}
 	return nil
 }
 
 // NextWriteRevision gets the revision that the next generation of the map should be written at.
 func (d *TileDB) NextWriteRevision() (int, error) {
 	var rev sql.NullInt32
+	// TODO(mhutchinson): This should be updated to include the max of "tiles" or "logs".
 	if err := d.db.QueryRow("SELECT MAX(revision) FROM tiles").Scan(&rev); err != nil {
 		return 0, fmt.Errorf("failed to get max revision: %v", err)
 	}


### PR DESCRIPTION
If `build_version_list` is provided on the command line then in addition to the 2 hashes for each module+version being committed to in the map, the map will further commit to the list of versions for each module. This is done by building a log for each module, in which the leaves are the versions (in the same order they are found in the input log). The log root hash is committed to in the map under a key which is the hash of the module name.

The list of versions is written to the DB as a JSON serialized list of strings. This is enough information for the log to be reconstructed. This makes all versions for a module discoverable and verifiable.