### PR TITLE
Tool to list verified versions for a module

### DIFF
--- a/experimental/batchmap/sumdb/mapdb/tiledb.go
+++ b/experimental/batchmap/sumdb/mapdb/tiledb.go
@@ -110,3 +110,16 @@ func (d *TileDB) WriteRevision(rev int, logCheckpoint []byte, count int64) error
 	}
 	return nil
 }
+
+// Versions gets the log of versions for the given module in the given map revision.
+func (d *TileDB) Versions(revision int, module string) ([]string, error) {
+	var bs []byte
+	if err := d.db.QueryRow("SELECT leaves FROM logs WHERE revision=? AND module=?", revision, module).Scan(&bs); err != nil {
+		return nil, err
+	}
+	var versions []string
+	if err := json.Unmarshal(bs, &versions); err != nil {
+		return nil, fmt.Errorf("failed to parse tile at revision=%d, path=%x: %v", revision, module, err)
+	}
+	return versions, nil
+}

--- a/experimental/batchmap/sumdb/verification/inclusion.go
+++ b/experimental/batchmap/sumdb/verification/inclusion.go
@@ -1,0 +1,137 @@
+package verification
+
+import (
+	"bytes"
+	"crypto"
+	"fmt"
+	"math/big"
+
+	"github.com/google/trillian/experimental/batchmap"
+	"github.com/google/trillian/merkle"
+	"github.com/google/trillian/merkle/coniks"
+)
+
+// TileFetch gets the tile at the specified path in the given map revision.
+// There is currently an assumption that this is very fast and thus it looks
+// up tiles one at a time. This can be replaced with a batch version if that
+// assumption is invalidated (e.g. this method triggers network operations).
+type TileFetch func(revision int, path []byte) (*batchmap.Tile, error)
+
+// MapVerifier verifies inclusion of key/values in a map.
+type MapVerifier struct {
+	tileFetch    TileFetch
+	prefixStrata int
+	treeID       int64
+	hash         crypto.Hash
+}
+
+// NewMapVerifier returns a MapVerifier for the map at the given location and with the
+// configuration provided.
+func NewMapVerifier(tileFetch TileFetch, prefixStrata int, treeID int64, hash crypto.Hash) *MapVerifier {
+	return &MapVerifier{
+		tileFetch:    tileFetch,
+		prefixStrata: prefixStrata,
+		treeID:       treeID,
+		hash:         hash,
+	}
+}
+
+// CheckInclusion confirms that the key & value are committed to by the map in the given
+// directory, and returns the computed and confirmed root hash that commits to this.
+func (v *MapVerifier) CheckInclusion(rev int, key string, value []byte) ([]byte, error) {
+	// Determine the key/value we expect to find.
+	// Note that the map tiles do not contain raw values, but commitments to the values.
+	// If the map needs to return the values to clients then it is recommended that the
+	// map operator uses a Content Addressable Store to store these values.
+	h := v.hash.New()
+	h.Write([]byte(key))
+	keyPath := h.Sum(nil)
+
+	expectedValueHash := coniks.Default.HashLeaf(v.treeID, keyPath, value)
+
+	// Read the tiles required for this check from disk.
+	tiles, err := v.getTilesForKey(rev, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't load tiles: %v", err)
+	}
+
+	// Perform the verification.
+	// 1) Start at the leaf tile and check the key/value.
+	// 2) Compute the merkle root of the leaf tile
+	// 3) Check the computed root matches that reported in the tile
+	// 4) Check this root value is the key/value of the tile above.
+	// 5) Rinse and repeat until we reach the tree root.
+	hs2 := merkle.NewHStar2(v.treeID, coniks.Default)
+	needPath, needValue := keyPath, expectedValueHash
+
+	for i := v.prefixStrata; i >= 0; i-- {
+		tile := tiles[i]
+		// Check the prefix of what we are looking for matches the tile's path.
+		if got, want := tile.Path, needPath[:len(tile.Path)]; !bytes.Equal(got, want) {
+			return nil, fmt.Errorf("wrong tile found at index %d: got %x, want %x", i, got, want)
+		}
+		// Leaf paths within a tile are within the scope of the tile, so we can
+		// drop the prefix from the expected path now we have verified it.
+		needLeafPath := needPath[len(tile.Path):]
+
+		// Identify the leaf we need, and convert all leaves to the format needed for hashing.
+		var leaf *batchmap.TileLeaf
+		hs2Leaves := make([]*merkle.HStar2LeafHash, len(tile.Leaves))
+		for j, l := range tile.Leaves {
+			if bytes.Equal(l.Path, needLeafPath) {
+				leaf = l
+			}
+			hs2Leaves[j] = toHStar2(tile.Path, l)
+		}
+
+		// Confirm we found the leaf we needed, and that it had the value we expected.
+		if leaf == nil {
+			return nil, fmt.Errorf("couldn't find expected leaf %x in tile %x", needLeafPath, tile.Path)
+		}
+		if !bytes.Equal(leaf.Hash, needValue) {
+			return nil, fmt.Errorf("wrong leaf value in tile %x, leaf %x: got %x, want %x", tile.Path, leaf.Path, leaf.Hash, needValue)
+		}
+
+		// Hash this tile given its leaf values, and confirm that the value we compute
+		// matches the value reported in the tile.
+		root, err := hs2.HStar2Nodes(tile.Path, 8*len(leaf.Path), hs2Leaves, nil, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to hash tile %x: %v", tile.Path, err)
+		}
+		if !bytes.Equal(root, tile.RootHash) {
+			return nil, fmt.Errorf("wrong root hash for tile %x: got %x, calculated %x", tile.Path, tile.RootHash, root)
+		}
+
+		// Make the next iteration of the loop check that the tile above this has the
+		// root value of this tile stored as the value at the expected leaf index.
+		needPath, needValue = tile.Path, root
+	}
+
+	return needValue, nil
+}
+
+// getTilesForKey loads the tiles on the path from the root to the given leaf.
+func (v *MapVerifier) getTilesForKey(rev int, key []byte) ([]*batchmap.Tile, error) {
+	tiles := make([]*batchmap.Tile, v.prefixStrata+1)
+	for i := 0; i <= v.prefixStrata; i++ {
+		tilePath := key[0:i]
+		tile, err := v.tileFetch(rev, tilePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read tile %x @ revision %d: %v", tilePath, rev, err)
+		}
+		tiles[i] = tile
+	}
+	return tiles, nil
+}
+
+// toHStar2 converts a TileLeaf into the equivalent structure for HStar2.
+func toHStar2(prefix []byte, l *batchmap.TileLeaf) *merkle.HStar2LeafHash {
+	// In hstar2 all paths need to be 256 bit (32 bytes)
+	leafIndexBs := make([]byte, 32)
+	copy(leafIndexBs, prefix)
+	copy(leafIndexBs[len(prefix):], l.Path)
+	return &merkle.HStar2LeafHash{
+		Index:    new(big.Int).SetBytes(leafIndexBs),
+		LeafHash: l.Hash,
+	}
+}

--- a/experimental/batchmap/sumdb/verification/inclusion.go
+++ b/experimental/batchmap/sumdb/verification/inclusion.go
@@ -1,3 +1,19 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package verification contains verifiers for clients of the map to confirm
+// entries are committed to.
 package verification
 
 import (

--- a/experimental/batchmap/sumdb/verify/verify.go
+++ b/experimental/batchmap/sumdb/verify/verify.go
@@ -21,17 +21,13 @@ import (
 	"bytes"
 	"crypto"
 	"flag"
-	"fmt"
-	"math/big"
 	"os"
 	"strings"
 
 	"github.com/golang/glog"
-	"github.com/google/trillian/experimental/batchmap"
-	"github.com/google/trillian/merkle"
-	"github.com/google/trillian/merkle/coniks"
 
 	"github.com/google/trillian-examples/experimental/batchmap/sumdb/mapdb"
+	"github.com/google/trillian-examples/experimental/batchmap/sumdb/verification"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -65,6 +61,8 @@ func main() {
 		glog.Exitf("No revisions found in map DB at %q: %v", *mapDB, err)
 	}
 
+	mv := verification.NewMapVerifier(tiledb.Tile, *prefixStrata, *treeID, hash)
+
 	// Open the go.sum file for reading a line at a time.
 	file, err := os.Open(*sumFile)
 	if err != nil {
@@ -87,7 +85,7 @@ func main() {
 		key := line[:split]
 		expectedString := line[split+1:]
 		glog.V(1).Infof("checking key %q value %q", key, expectedString)
-		newRoot, err := checkInclusion(tiledb, rev, key, expectedString)
+		newRoot, err := mv.CheckInclusion(rev, key, []byte(expectedString))
 		if err != nil {
 			glog.Exitf("inclusion check failed for key %q value %q: %q", key, expectedString, err)
 		}
@@ -98,108 +96,4 @@ func main() {
 		count++
 	}
 	glog.Infof("Verified %d entries committed to by map rev %d root %x. Log checkpoint:\n%s", count, rev, root, logRoot)
-}
-
-// checkInclusion confirms that the key & value are committed to by the map in the given
-// directory, and returns the computed and confirmed root hash that commits to this.
-func checkInclusion(tiledb *mapdb.TileDB, rev int, key, value string) ([]byte, error) {
-	// Determine the key/value we expect to find.
-	// Note that the map tiles do not contain raw values, but commitments to the values.
-	// If the map needs to return the values to clients then it is recommended that the
-	// map operator uses a Content Addressable Store to store these values.
-	h := hash.New()
-	h.Write([]byte(key))
-	keyPath := h.Sum(nil)
-
-	expectedValueHash := coniks.Default.HashLeaf(*treeID, keyPath, []byte(value))
-
-	// Read the tiles required for this check from disk.
-	tiles, err := getTilesForKey(tiledb, rev, keyPath)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't load tiles: %v", err)
-	}
-
-	// Perform the verification.
-	// 1) Start at the leaf tile and check the key/value.
-	// 2) Compute the merkle root of the leaf tile
-	// 3) Check the computed root matches that reported in the tile
-	// 4) Check this root value is the key/value of the tile above.
-	// 5) Rinse and repeat until we reach the tree root.
-	hs2 := merkle.NewHStar2(*treeID, coniks.Default)
-	needPath, needValue := keyPath, expectedValueHash
-
-	for i := *prefixStrata; i >= 0; i-- {
-		tile := tiles[i]
-		// Check the prefix of what we are looking for matches the tile's path.
-		if got, want := tile.Path, needPath[:len(tile.Path)]; !bytes.Equal(got, want) {
-			return nil, fmt.Errorf("wrong tile found at index %d: got %x, want %x", i, got, want)
-		}
-		// Leaf paths within a tile are within the scope of the tile, so we can
-		// drop the prefix from the expected path now we have verified it.
-		needLeafPath := needPath[len(tile.Path):]
-
-		// Identify the leaf we need, and convert all leaves to the format needed for hashing.
-		var leaf *batchmap.TileLeaf
-		hs2Leaves := make([]*merkle.HStar2LeafHash, len(tile.Leaves))
-		for j, l := range tile.Leaves {
-			if bytes.Equal(l.Path, needLeafPath) {
-				leaf = l
-			}
-			hs2Leaves[j] = toHStar2(tile.Path, l)
-		}
-
-		// Confirm we found the leaf we needed, and that it had the value we expected.
-		if leaf == nil {
-			return nil, fmt.Errorf("couldn't find expected leaf %x in tile %x", needLeafPath, tile.Path)
-		}
-		if !bytes.Equal(leaf.Hash, needValue) {
-			return nil, fmt.Errorf("wrong leaf value in tile %x, leaf %x: got %x, want %x", tile.Path, leaf.Path, leaf.Hash, needValue)
-		}
-
-		// Hash this tile given its leaf values, and confirm that the value we compute
-		// matches the value reported in the tile.
-		root, err := hs2.HStar2Nodes(tile.Path, 8*len(leaf.Path), hs2Leaves, nil, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to hash tile %x: %v", tile.Path, err)
-		}
-		if !bytes.Equal(root, tile.RootHash) {
-			return nil, fmt.Errorf("wrong root hash for tile %x: got %x, calculated %x", tile.Path, tile.RootHash, root)
-		}
-
-		// Make the next iteration of the loop check that the tile above this has the
-		// root value of this tile stored as the value at the expected leaf index.
-		needPath, needValue = tile.Path, root
-	}
-
-	// If we get here then we have proved that the value was correct and that the map
-	// root commits to this value. Any other user with the same map root must see the
-	// same value under the same key we have checked.
-	glog.V(2).Infof("key %s found at path %x, with value %q (%x) committed to by map root %x", key, keyPath, value, expectedValueHash, needValue)
-	return needValue, nil
-}
-
-// getTilesForKey loads the tiles on the path from the root to the given leaf.
-func getTilesForKey(tiledb *mapdb.TileDB, rev int, key []byte) ([]*batchmap.Tile, error) {
-	tiles := make([]*batchmap.Tile, *prefixStrata+1)
-	for i := 0; i <= *prefixStrata; i++ {
-		tilePath := key[0:i]
-		tile, err := tiledb.Tile(rev, tilePath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read tile %x @ revision %d: %v", tilePath, rev, err)
-		}
-		tiles[i] = tile
-	}
-	return tiles, nil
-}
-
-// toHStar2 converts a TileLeaf into the equivalent structure for HStar2.
-func toHStar2(prefix []byte, l *batchmap.TileLeaf) *merkle.HStar2LeafHash {
-	// In hstar2 all paths need to be 256 bit (32 bytes)
-	leafIndexBs := make([]byte, 32)
-	copy(leafIndexBs, prefix)
-	copy(leafIndexBs[len(prefix):], l.Path)
-	return &merkle.HStar2LeafHash{
-		Index:    new(big.Int).SetBytes(leafIndexBs),
-		LeafHash: l.Hash,
-	}
 }

--- a/experimental/batchmap/sumdb/versions/versions.go
+++ b/experimental/batchmap/sumdb/versions/versions.go
@@ -19,6 +19,7 @@ import (
 	"crypto"
 	"flag"
 	"fmt"
+	"regexp"
 
 	"github.com/golang/glog"
 	"golang.org/x/mod/sumdb/tlog"
@@ -37,6 +38,7 @@ var (
 	mapDB        = flag.String("map_db", "", "sqlite DB containing the map tiles.")
 	treeID       = flag.Int64("tree_id", 12345, "The ID of the tree. Used as a salt in hashing.")
 	prefixStrata = flag.Int("prefix_strata", 2, "The number of strata of 8-bit strata before the final strata.")
+	showAll      = flag.Bool("all", false, "Only release versions are shown by default, but this will also show ephemeral versions.")
 )
 
 func main() {
@@ -89,9 +91,19 @@ func main() {
 	if err != nil {
 		glog.Exitf("Failed to verify inclusion: %v", err)
 	}
+
+	releaseRegex := regexp.MustCompile(`^v\d+.\d+.\d+$`)
 	var versionString string
+	var skipped int
 	for _, v := range versions {
-		versionString = fmt.Sprintf("%s\n * %s", versionString, v)
+		if *showAll || releaseRegex.MatchString(v) {
+			versionString = fmt.Sprintf("%s\n * %s", versionString, v)
+		} else {
+			skipped++
+		}
+	}
+	if skipped > 0 {
+		versionString = fmt.Sprintf("%s\n(%d omitted version)", versionString, skipped)
 	}
 	glog.Infof("Verified versions for %q in map with root %x: %s", *module, mr, versionString)
 }

--- a/experimental/batchmap/sumdb/versions/versions.go
+++ b/experimental/batchmap/sumdb/versions/versions.go
@@ -1,0 +1,97 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// versions lists the versions for a module and verifies this in the map.
+package main
+
+import (
+	"crypto"
+	"flag"
+	"fmt"
+
+	"github.com/golang/glog"
+	"golang.org/x/mod/sumdb/tlog"
+
+	"github.com/google/trillian-examples/experimental/batchmap/sumdb/mapdb"
+	"github.com/google/trillian-examples/experimental/batchmap/sumdb/verification"
+	"github.com/google/trillian/merkle/compact"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+const hash = crypto.SHA512_256
+
+var (
+	module       = flag.String("module", "", "module to get versions for.")
+	mapDB        = flag.String("map_db", "", "sqlite DB containing the map tiles.")
+	treeID       = flag.Int64("tree_id", 12345, "The ID of the tree. Used as a salt in hashing.")
+	prefixStrata = flag.Int("prefix_strata", 2, "The number of strata of 8-bit strata before the final strata.")
+)
+
+func main() {
+	flag.Parse()
+
+	if *mapDB == "" {
+		glog.Exitf("No map_db provided")
+	}
+	if *module == "" {
+		glog.Exitf("No module provided")
+	}
+
+	tiledb, err := mapdb.NewTileDB(*mapDB)
+	if err != nil {
+		glog.Exitf("Failed to open map DB at %q: %v", *mapDB, err)
+	}
+	var rev int
+	if rev, _, _, err = tiledb.LatestRevision(); err != nil {
+		glog.Exitf("No revisions found in map DB at %q: %v", *mapDB, err)
+	}
+
+	versions, err := tiledb.Versions(rev, *module)
+	if err != nil {
+		glog.Exitf("Failed to list versions for %q: %v", *module, err)
+	}
+
+	rf := &compact.RangeFactory{
+		// This needs to be the same function used in the log construction.
+		Hash: func(left, right []byte) []byte {
+			var lHash, rHash tlog.Hash
+			copy(lHash[:], left)
+			copy(rHash[:], right)
+			thash := tlog.NodeHash(lHash, rHash)
+			return thash[:]
+		},
+	}
+	logRange := rf.NewEmptyRange(0)
+	for _, v := range versions {
+		h := hash.New()
+		h.Write([]byte(v))
+		logRange.Append(h.Sum(nil), nil)
+	}
+	logRoot, err := logRange.GetRootHash(nil)
+	if err != nil {
+		glog.Exitf("Failed to calculate expected log root: %v", err)
+	}
+
+	mv := verification.NewMapVerifier(tiledb.Tile, *prefixStrata, *treeID, hash)
+	mr, err := mv.CheckInclusion(rev, *module, logRoot)
+	if err != nil {
+		glog.Exitf("Failed to verify inclusion: %v", err)
+	}
+	var versionString string
+	for _, v := range versions {
+		versionString = fmt.Sprintf("%s\n * %s", versionString, v)
+	}
+	glog.Infof("Verified versions for %q in map with root %x: %s", *module, mr, versionString)
+}

--- a/experimental/batchmap/sumdb/versions/versions.go
+++ b/experimental/batchmap/sumdb/versions/versions.go
@@ -38,7 +38,7 @@ var (
 	mapDB        = flag.String("map_db", "", "sqlite DB containing the map tiles.")
 	treeID       = flag.Int64("tree_id", 12345, "The ID of the tree. Used as a salt in hashing.")
 	prefixStrata = flag.Int("prefix_strata", 2, "The number of strata of 8-bit strata before the final strata.")
-	showAll      = flag.Bool("all", false, "Only release versions are shown by default, but this will also show ephemeral versions.")
+	showAll      = flag.Bool("all", false, "Only release versions are shown by default, but setting this flag will also show ephemeral versions.")
 )
 
 func main() {
@@ -103,7 +103,7 @@ func main() {
 		}
 	}
 	if skipped > 0 {
-		versionString = fmt.Sprintf("%s\n(%d omitted version)", versionString, skipped)
+		versionString = fmt.Sprintf("%s\n(%d omitted non-release versions)", versionString, skipped)
 	}
 	glog.Infof("Verified versions for %q in map with root %x: %s", *module, mr, versionString)
 }

--- a/experimental/batchmap/sumdb/versions/versions.go
+++ b/experimental/batchmap/sumdb/versions/versions.go
@@ -67,6 +67,7 @@ func main() {
 
 	rf := &compact.RangeFactory{
 		// This needs to be the same function used in the log construction.
+		// TODO(mhutchinson): change this (and the generation code) to apply domain separation prefix to leaves.
 		Hash: func(left, right []byte) []byte {
 			var lHash, rHash tlog.Hash
 			copy(lHash[:], left)


### PR DESCRIPTION
This builds on #224 by adding a tool to make use of the log of versions. It pulls the list of versions, constructs the log for it, and checks that the map commits to this log. By default it prints only release versions, but the `--all` flag can be used to list ephemeral versions too (e.g. `v0.0.0-20191025170756-f12f9191a1a4`).

This PR looks bigger than it is because the map verification code was extracted/refactored, and github isn't showing the diff.