### PR TITLE
Added support for client/server SQL databases

### DIFF
--- a/sumdbaudit/README.md
+++ b/sumdbaudit/README.md
@@ -59,7 +59,7 @@ This tool does **not** check any of the following:
 The following command will download all entries and store them in the database
 file provided:
 ```bash
-go run github.com/google/trillian-examples/sumdbaudit/cli/clone -db ~/sum.db -alsologtostderr -v=2
+go run github.com/google/trillian-examples/sumdbaudit/cli/clone -sqlite_file ~/sum.db -alsologtostderr -v=2
 ```
 This will take some time to complete on the first run. Latency and bandwidth
 between the auditor and SumDB will be a large factor, but for illustrative
@@ -96,7 +96,7 @@ After=network.target
 [Service]
 Type=simple
 User=sumdb
-ExecStart=/usr/local/bin/sumdbmirror -db /var/cache/sumdb/mirror.db -alsologtostderr -v=1
+ExecStart=/usr/local/bin/sumdbmirror -sqlite_file /var/cache/sumdb/mirror.db -alsologtostderr -v=1
 
 [Install]
 WantedBy=multi-user.target
@@ -139,7 +139,7 @@ is safe in relying on the data within (providing it trusts the verifer!).
 
 The service can be started with the command (assuming `~/sum.db` is the database):
 ```bash
-go run ./sumdbaudit/cli/witness -listen :8080 -db ~/sum.db -v=1 -alsologtostderr
+go run ./sumdbaudit/cli/witness -listen :8080 -sqlite_file ~/sum.db -v=1 -alsologtostderr
 ```
 
 This can be set up as a Linux service in much the same way as the `mirror` above.
@@ -167,6 +167,20 @@ sync completes:
 ```bash
 docker-compose -f sumdbaudit/docker/docker-compose.yml up --build
 ```
+
+### Using a client/server database
+
+The instructions above are for setting this up using sqlite with its storage on the local filesystem.
+To set this up using MariaDB, the database can be provisioned by logging into the instance as root user and running the following:
+
+```bash
+CREATE DATABASE sumdb;
+CREATE USER 'sumdb'@localhost IDENTIFIED BY 'letmein';
+GRANT ALL PRIVILEGES ON sumdb.* TO 'sumdb'@localhost;
+FLUSH PRIVILEGES;
+```
+
+Once set up, change the `sqlite_file` flag above for `mysql_uri` with a connection string like `'sumdb:letmein@tcp(127.0.0.1:3306)/sumdb?parseTime=true'`.
 
 ## Querying the database
 The number of leaves downloaded can be queried:

--- a/sumdbaudit/README.md
+++ b/sumdbaudit/README.md
@@ -203,8 +203,6 @@ sqlite3 ~/sum.db 'SELECT module, COUNT(*) cnt FROM leafMetadata GROUP BY module 
   be up to 2^height leaves missing from the database.
   These stragglers should be stored if the root hash checks out.
 * Only parse and process new leaves.
-* Support other SQL databases, e.g. MySQL
-  * This should be trivial to support in code, but sqlite was picked for simplicity of admin for a demo
 * Witness should return detailed responses
   * In the event of an inconsistency, both Checkpoints notes should be serialized and returned
   * Consistency should return a proof that the tree is consistent with the witnesses Golden Checkpoint

--- a/sumdbaudit/cli/clone/clone.go
+++ b/sumdbaudit/cli/clone/clone.go
@@ -22,13 +22,11 @@ import (
 	"github.com/golang/glog"
 
 	"github.com/google/trillian-examples/sumdbaudit/audit"
-	_ "github.com/mattn/go-sqlite3"
 )
 
 var (
 	height = flag.Int("h", 8, "tile height")
 	vkey   = flag.String("k", "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8", "key")
-	db     = flag.String("db", "./sum.db", "database file location (will be created if it doesn't exist)")
 	extraV = flag.Bool("x", false, "performs additional checks on each tile hashes")
 	force  = flag.Bool("f", false, "forces the auditor to run even if no new data is available")
 )
@@ -40,10 +38,11 @@ func main() {
 	ctx := context.Background()
 	flag.Parse()
 
-	db, err := audit.NewDatabase(*db)
+	db, err := audit.NewDatabaseFromFlags()
 	if err != nil {
-		glog.Exitf("failed to open DB: %v", err)
+		glog.Exitf("Failed to open DB: %v", err)
 	}
+
 	err = db.Init()
 	if err != nil {
 		glog.Exitf("failed to init DB: %v", err)

--- a/sumdbaudit/cli/mirror/mirror.go
+++ b/sumdbaudit/cli/mirror/mirror.go
@@ -21,13 +21,11 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/sumdbaudit/audit"
-	_ "github.com/mattn/go-sqlite3"
 )
 
 var (
 	height   = flag.Int("h", 8, "tile height")
 	vkey     = flag.String("k", "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8", "key")
-	db       = flag.String("db", "", "database file location (will be created if it doesn't exist)")
 	unpack   = flag.Bool("unpack", false, "if provided then the leafMetadata table will be populated by parsing the raw leaf data")
 	interval = flag.Duration("interval", 5*time.Minute, "how long to wait between runs")
 )
@@ -38,10 +36,7 @@ func main() {
 	ctx := context.Background()
 	flag.Parse()
 
-	if len(*db) == 0 {
-		glog.Exit("db must be provided")
-	}
-	db, err := audit.NewDatabase(*db)
+	db, err := audit.NewDatabaseFromFlags()
 	if err != nil {
 		glog.Exitf("Failed to open DB: %v", err)
 	}

--- a/sumdbaudit/cli/witness/witness.go
+++ b/sumdbaudit/cli/witness/witness.go
@@ -26,13 +26,11 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/sumdbaudit/audit"
 	"github.com/gorilla/mux"
-	_ "github.com/mattn/go-sqlite3"
 )
 
 var (
 	height = flag.Int("h", 8, "tile height")
 	vkey   = flag.String("k", "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8", "key")
-	db     = flag.String("db", "", "database file location (will be created if it doesn't exist)")
 
 	listenAddr = flag.String("listen", ":8000", "address:port to listen for requests on")
 )
@@ -88,13 +86,9 @@ func (s *server) checkConsistency(w http.ResponseWriter, r *http.Request) {
 func main() {
 	flag.Parse()
 
-	if len(*db) == 0 {
-		glog.Exit("db must be provided")
-	}
-
-	db, err := audit.NewDatabase(*db)
+	db, err := audit.NewDatabaseFromFlags()
 	if err != nil {
-		glog.Exitf("failed to open DB: %v", err)
+		glog.Exitf("Failed to open DB: %v", err)
 	}
 
 	sumDB := audit.NewSumDB(*height, *vkey)


### PR DESCRIPTION
Having the data in a client/server database opens the way for running a mirror in GCP which can be used to build a verifiable map in dataflow. This is infeasible when the database is a local file.

This has been tested with MariaDB 10.5.8.

N.B. This contains a breaking DB schema change. TEXT is not a great choice because at least MariaDB will group by this case insensitively, which surprisingly caused "duplicates" to be identified. Using a binary representation for these fields avoids such false positives.