### PR TITLE
Don't reprocess leaf metadata which is already processed

### DIFF
--- a/sumdbaudit/README.md
+++ b/sumdbaudit/README.md
@@ -202,7 +202,6 @@ sqlite3 ~/sum.db 'SELECT module, COUNT(*) cnt FROM leafMetadata GROUP BY module 
 * This only downloads complete tiles, which means that at any point there could
   be up to 2^height leaves missing from the database.
   These stragglers should be stored if the root hash checks out.
-* Only parse and process new leaves.
 * Witness should return detailed responses
   * In the event of an inconsistency, both Checkpoints notes should be serialized and returned
   * Consistency should return a proof that the tree is consistent with the witnesses Golden Checkpoint

--- a/sumdbaudit/audit/database.go
+++ b/sumdbaudit/audit/database.go
@@ -183,6 +183,19 @@ func (d *Database) SetLeafMetadata(ctx context.Context, start int64, metadata []
 	return tx.Commit()
 }
 
+// MaxLeafMetadata gets the ID of the last entry in the leafMetadata table.
+// If there is no data, then NoDataFound error is returned.
+func (d *Database) MaxLeafMetadata(ctx context.Context) (int64, error) {
+	var head sql.NullInt64
+	if err := d.db.QueryRow("SELECT MAX(id) AS head FROM leafMetadata").Scan(&head); err != nil {
+		return 0, fmt.Errorf("failed to get max metadata: %v", err)
+	}
+	if head.Valid {
+		return head.Int64, nil
+	}
+	return 0, NoDataFound(errors.New("no data found"))
+}
+
 // Tile gets the leaf hashes for the given tile, or returns an error.
 func (d *Database) Tile(height, level, offset int) ([][]byte, error) {
 	var res []byte

--- a/sumdbaudit/audit/service.go
+++ b/sumdbaudit/audit/service.go
@@ -383,9 +383,8 @@ func (s *Service) checkConsistency(ctx context.Context) error {
 			// storage is a new feature).
 			glog.Warning("Failed to find golden checkpoint!")
 			return nil
-		} else {
-			return fmt.Errorf("failed to query for golden checkpoint: %w", err)
 		}
+		return fmt.Errorf("failed to query for golden checkpoint: %w", err)
 	}
 	head, err := s.localDB.Head()
 	if err != nil {


### PR DESCRIPTION
This short circuit saves a lot of time for mirrors which are updating frequently.