### PR TITLE
Apply prefix domain separation to leaves in version log

### DIFF
--- a/experimental/batchmap/sumdb/build/pipeline/log.go
+++ b/experimental/batchmap/sumdb/build/pipeline/log.go
@@ -75,9 +75,8 @@ func (fn *moduleLogHashFn) Setup() {
 func (fn *moduleLogHashFn) ProcessElement(log *ModuleVersionLog) (*batchmap.Entry, error) {
 	logRange := fn.rf.NewEmptyRange(0)
 	for _, v := range log.Versions {
-		h := hash.New()
-		h.Write([]byte(v))
-		logRange.Append(h.Sum(nil), nil)
+		h := tlog.RecordHash([]byte(v))
+		logRange.Append(h[:], nil)
 	}
 	logRoot, err := logRange.GetRootHash(nil)
 	if err != nil {

--- a/experimental/batchmap/sumdb/build/pipeline/log_test.go
+++ b/experimental/batchmap/sumdb/build/pipeline/log_test.go
@@ -45,7 +45,7 @@ func TestMakeVersionLogs(t *testing.T) {
 				},
 			},
 			wantCount:    1,
-			wantRoot:     "8656af15c0a3a4cde60b2d370f3b902618ef4959726a265d5ee51dcf16f4db6f",
+			wantRoot:     "ab0fa665851a47dec50ff0a51e7dfbab747ff5a548dcfcc7bde213b571a8e6ae",
 			wantVersions: []string{"v0.0.1"},
 		},
 		{
@@ -63,7 +63,7 @@ func TestMakeVersionLogs(t *testing.T) {
 				},
 			},
 			wantCount:    1,
-			wantRoot:     "d6c627acd99922885984336b3b6168ea026cc09bf708e2fffaad423b225d738d",
+			wantRoot:     "7fadb0db3926ec36f4028452856670df932eacba6f624ed82284c4a63adc5f73",
 			wantVersions: []string{"1", "2"},
 		},
 		{
@@ -81,7 +81,7 @@ func TestMakeVersionLogs(t *testing.T) {
 				},
 			},
 			wantCount:    1,
-			wantRoot:     "d6c627acd99922885984336b3b6168ea026cc09bf708e2fffaad423b225d738d",
+			wantRoot:     "7fadb0db3926ec36f4028452856670df932eacba6f624ed82284c4a63adc5f73",
 			wantVersions: []string{"1", "2"},
 		},
 		{

--- a/experimental/batchmap/sumdb/versions/versions.go
+++ b/experimental/batchmap/sumdb/versions/versions.go
@@ -67,7 +67,6 @@ func main() {
 
 	rf := &compact.RangeFactory{
 		// This needs to be the same function used in the log construction.
-		// TODO(mhutchinson): change this (and the generation code) to apply domain separation prefix to leaves.
 		Hash: func(left, right []byte) []byte {
 			var lHash, rHash tlog.Hash
 			copy(lHash[:], left)
@@ -78,9 +77,8 @@ func main() {
 	}
 	logRange := rf.NewEmptyRange(0)
 	for _, v := range versions {
-		h := hash.New()
-		h.Write([]byte(v))
-		logRange.Append(h.Sum(nil), nil)
+		h := tlog.RecordHash([]byte(v))
+		logRange.Append(h[:], nil)
 	}
 	logRoot, err := logRange.GetRootHash(nil)
 	if err != nil {


### PR DESCRIPTION
This addresses the TODO and improves the security of the logs.