### PR TITLE
Update the flags in the docker configs

### DIFF
--- a/sumdbaudit/docker/docker-compose.yml
+++ b/sumdbaudit/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - sqlite-data:/var/cache/sumdb
     command: [
       "--alsologtostderr",
-      "--db=/var/cache/sumdb/mirror.db"
+      "--sqlite_file=/var/cache/sumdb/mirror.db"
     ]
     restart: always
   witness:
@@ -25,7 +25,7 @@ services:
       - sqlite-data:/var/cache/sumdb
     command: [
       "--alsologtostderr",
-      "--db=/var/cache/sumdb/mirror.db",
+      "--sqlite_file=/var/cache/sumdb/mirror.db",
       "--listen=:8080"
     ]
     ports:


### PR DESCRIPTION
This was missed in #228 when the flag was renamed.

The next step will be to change this docker deployment to use a client/server database, but this is an easy fix that should happen first.