### PR TITLE
Personality can be deployed in a single command

### DIFF
--- a/binary_transparency/firmware/README.md
+++ b/binary_transparency/firmware/README.md
@@ -105,36 +105,18 @@ Prerequisites:
   * [Trillian](https://github.com/google/trillian)
   * [Firmware Transparency (trillian-examples)](https://github.com/google/trillian-examples)
 
-#### Terminal 1 - Trillian:
-* Open terminal in root of `trillian` git repo, run:
+#### Terminal 1 - Set up Services:
+* Open terminal in a directory that you're happy to check out code to:
 
 ```bash
-export MYSQL_ROOT_PASSWORD="$(openssl rand -hex 16)"
-docker-compose -f examples/deployment/docker-compose.yml up trillian-log-server trillian-log-signer
+git checkout https://github.com/google/trillian
+git checkout https://github.com/google/trillian-examples
+docker-compose -f trillian/examples/deployment/docker-compose.yml -f trillian-examples/binary_transparency/firmware/docker-compose.override.yml up -d personality
 ```
 
-#### Terminal 1½ - Provision Log Tree:
-* Run the following command to create a new tree inside Trillian, this only needs to be done once:
+Trillian and the FT server will start in the background and provision a new log.
 
-```bash
-go run github.com/google/trillian/cmd/createtree --admin_server=localhost:8090
-```
-
-Record the tree ID that is returned by the command above, it will be referred to
-as $TREE_ID by subsequent commands:
-
-#### Terminal 2 - FT Personality:
-* Open a terminal in the `binary_transparency/firmware` directory.
-* A file is needed to hold the CAS DB which will back the log, this file
-  needs to be available for the duration of this log, so writing to '/tmp'
-  is considered risky. Choose a file path and add as below.
-
-```bash
-export CAS_DB_FILE='/full/path/to/file.db'
-go run ./cmd/ft_personality/main.go --logtostderr -v=2 --tree_id=$TREE_ID --cas_db_file=${CAS_DB_FILE}
-```
-
-#### Terminal 3 - FT monitor
+#### Terminal 2 - FT monitor
 > The monitor "tails" the log, fetching each of the added entries and checking
 > for inconsistencies in the structure and unexpected or malicious entries.
 
@@ -148,7 +130,7 @@ and consider that any binary containing that string is a bad one.
 go run ./cmd/ft_monitor/ --logtostderr --keyword="H4x0r3d"
 ```
 
-#### Terminal 4 - Firmware Vendor
+#### Terminal 3 - Firmware Vendor
 The vendor is going to publish a new, legitimate, firmware now.
 
 * cd to the root of `binary_transparency/firmware` for the following steps:
@@ -170,7 +152,7 @@ go run cmd/publisher/publish.go --logtostderr --v=2 --timestamp="2020-10-10T15:3
   > known-good build.  If they spot something _unexpected_ then they're
   > now aware that there is a problem which needs investigation...
 
-#### Terminal 5 - Device owner
+#### Terminal 4 - Device owner
 Through the power of scripted narrative, the owner of the target device now
 has a firmware update to install (we'll re-use the `/tmp/update.ota` file created
 in the last step).
@@ -238,7 +220,7 @@ echo "mwuhahahaha :eyes:"
 
 Let's watch as the device owner turns on their device in the next step...
 
-#### Terminal 5 - Device owner
+#### Terminal 4 - Device owner
 The device owner wants to use their device, however, unbeknownst to them it's
 been HACKED!
 
@@ -277,7 +259,7 @@ go run ./cmd/hacker/modify_bundle \
 
 Let's watch as the device owner turns on their device in the next step...
 
-#### Terminal 5 - Device owner
+#### Terminal 4 - Device owner
 
 Start the device:
 
@@ -311,7 +293,7 @@ go run ./cmd/hacker/modify_bundle \
 
 Let's watch as the device owner turns on their device in the next step...
 
-#### Terminal 5 - Device owner
+#### Terminal 4 - Device owner
 
 Start the device:
 

--- a/binary_transparency/firmware/cmd/ft_personality/Dockerfile
+++ b/binary_transparency/firmware/cmd/ft_personality/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.15 AS builder
+LABEL stage=builder
+
+ARG GOFLAGS=""
+ENV GOFLAGS=$GOFLAGS
+ENV GO111MODULE=on
+
+# Move to working directory /build
+WORKDIR /build
+
+# Copy and download dependency using go mod
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+# Copy the code into the container
+COPY . .
+
+# Build the application
+RUN go build ./binary_transparency/firmware/cmd/ft_personality
+
+# Build release image
+FROM golang:1.15-buster
+
+COPY --from=builder /build/ft_personality /bin/ft_personality
+ENTRYPOINT ["/bin/ft_personality"]

--- a/binary_transparency/firmware/cmd/ft_personality/ft_personality.go
+++ b/binary_transparency/firmware/cmd/ft_personality/ft_personality.go
@@ -15,8 +15,6 @@
 // This package is the entrypoint for the Firmware Transparency personality server.
 // This requires a Trillian instance to be reachable via gRPC and a tree to have
 // been provisioned. See the README in the root of this project for instructions.
-// Start the server using:
-// go run ./cmd/ft_personality/main.go --logtostderr -v=2 --tree_id=$TREE_ID
 package main
 
 import (
@@ -33,7 +31,6 @@ var (
 
 	connectTimeout = flag.Duration("connect_timeout", time.Second, "the timeout for connecting to the backend")
 	trillianAddr   = flag.String("trillian", ":8090", "address:port of Trillian Log gRPC service")
-	treeID         = flag.Int64("tree_id", -1, "the tree ID of the log to use")
 
 	casDBFile = flag.String("cas_db_file", "", "Path to a file to be used as sqlite3 storage for images, e.g. /tmp/ft.db")
 
@@ -48,7 +45,6 @@ func main() {
 		ListenAddr:     *listenAddr,
 		ConnectTimeout: *connectTimeout,
 		TrillianAddr:   *trillianAddr,
-		TreeID:         *treeID,
 		CASFile:        *casDBFile,
 		STHRefresh:     *sthRefresh,
 	}); err != nil {

--- a/binary_transparency/firmware/cmd/ft_personality/internal/trees/trees.go
+++ b/binary_transparency/firmware/cmd/ft_personality/internal/trees/trees.go
@@ -44,6 +44,10 @@ func NewTreeStorage(db *sql.DB) *TreeStorage {
 
 // EnsureTree gets the tree for this personality, creating it if necessary.
 // Takes a connection to Trillian to use for initialization.
+// This is only safe in a single-replica deployment. In a real production setup
+// this provisioning would likely be done by a human ahead of time, or if this
+// style of automatic deployment was required then some kind of locking would
+// be required to ensure that only one log was created and used by all frontends.
 func (s *TreeStorage) EnsureTree(ctx context.Context, conn grpc.ClientConnInterface) (*trillian.Tree, error) {
 	if err := s.init(); err != nil {
 		return nil, err

--- a/binary_transparency/firmware/cmd/ft_personality/internal/trees/trees.go
+++ b/binary_transparency/firmware/cmd/ft_personality/internal/trees/trees.go
@@ -1,0 +1,123 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package trees contains the personality tree configuration.
+package trees
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/google/trillian"
+	"github.com/google/trillian/client"
+	"github.com/google/trillian/crypto/keyspb"
+	"github.com/google/trillian/crypto/sigpb"
+	"google.golang.org/grpc"
+)
+
+// TreeStorage allows access to the configuration.
+type TreeStorage struct {
+	db *sql.DB
+}
+
+// NewTreeStorage sets up a TreeStorage using the given DB.
+func NewTreeStorage(db *sql.DB) *TreeStorage {
+	return &TreeStorage{
+		db: db,
+	}
+}
+
+// EnsureTree gets the tree for this personality, creating it if necessary.
+// Takes a connection to Trillian to use for initialization.
+func (s *TreeStorage) EnsureTree(ctx context.Context, conn grpc.ClientConnInterface) (*trillian.Tree, error) {
+	if err := s.init(); err != nil {
+		return nil, err
+	}
+	res, err := s.getTree()
+	if err == nil {
+		return res, nil
+	}
+	if err == sql.ErrNoRows {
+		tree, err := s.createTree(ctx, conn)
+		if err != nil {
+			return nil, err
+		}
+		return tree, s.setTree(tree)
+	}
+	return nil, err
+}
+
+func (s *TreeStorage) createTree(ctx context.Context, conn grpc.ClientConnInterface) (*trillian.Tree, error) {
+	// N.B. Using the admin interface from the personality is not good practice for
+	// a production system. This simply allows a convenient way of getting the tree
+	// for the sake of getting the FT demo up and running.
+
+	ctr := &trillian.CreateTreeRequest{
+		Tree: &trillian.Tree{
+			TreeState:          trillian.TreeState_ACTIVE,
+			TreeType:           trillian.TreeType_LOG,
+			HashStrategy:       trillian.HashStrategy_RFC6962_SHA256,
+			HashAlgorithm:      sigpb.DigitallySigned_SHA256,
+			SignatureAlgorithm: sigpb.DigitallySigned_ECDSA,
+			DisplayName:        "ft",
+			Description:        "binary transparency log",
+			MaxRootDuration:    ptypes.DurationProto(time.Hour),
+		},
+		KeySpec: &keyspb.Specification{
+			Params: &keyspb.Specification_EcdsaParams{
+				EcdsaParams: &keyspb.Specification_ECDSA{},
+			},
+		},
+	}
+
+	adminClient := trillian.NewTrillianAdminClient(conn)
+	mapClient := trillian.NewTrillianMapClient(conn)
+	logClient := trillian.NewTrillianLogClient(conn)
+
+	return client.CreateAndInitTree(ctx, ctr, adminClient, mapClient, logClient)
+}
+
+func (s *TreeStorage) getTree() (*trillian.Tree, error) {
+	var raw []byte
+	if err := s.db.QueryRow("SELECT config FROM trees WHERE key = 'ft'").Scan(&raw); err != nil {
+		return nil, err
+	}
+
+	var res *trillian.Tree
+	if err := proto.Unmarshal(raw, res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (s *TreeStorage) setTree(tree *trillian.Tree) error {
+	bs, err := proto.Marshal(tree)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec("INSERT INTO trees (key, config) VALUES (?, ?)", "ft", bs)
+	if err != nil {
+		return fmt.Errorf("failed to set tree: %w", err)
+	}
+	return nil
+}
+
+func (s *TreeStorage) init() error {
+	_, err := s.db.Exec("CREATE TABLE IF NOT EXISTS trees (key BLOB PRIMARY KEY, config BLOB)")
+	return err
+}

--- a/binary_transparency/firmware/docker-compose.override.yml
+++ b/binary_transparency/firmware/docker-compose.override.yml
@@ -1,4 +1,4 @@
-version: "3.9"
+version: "3.1"
 
 # This expects to be run as an override of trillian's example docker deployment.
 # See the README in the main directory for instructions.

--- a/binary_transparency/firmware/docker-compose.override.yml
+++ b/binary_transparency/firmware/docker-compose.override.yml
@@ -1,0 +1,26 @@
+version: "3.9"
+
+# This expects to be run as an override of trillian's example docker deployment.
+# See the README in the main directory for instructions.
+# This won't scale to multiple replicas without much more work.
+
+services:
+  personality:
+    build: 
+      context: ../../../trillian-examples
+      dockerfile: ./binary_transparency/firmware/cmd/ft_personality/Dockerfile
+    command: [
+      "--alsologtostderr",
+      "--v=2",
+      "--listen=:8000",
+      "--trillian=trillian-log-server:8090",
+      "--connect_timeout=30s",
+      "--cas_db_file=/opt/ft.db"
+    ]
+    ports:
+     - "8000:8000"
+    restart: always
+    depends_on:
+      - mysql
+      - trillian-log-server
+      - trillian-log-signer

--- a/go.sum
+++ b/go.sum
@@ -502,8 +502,6 @@ github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.8 h1:3tS41NlGYSmhhe/8fhGRzc+z3AYCw1Fe1WAyLuujKs0=
 github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/mattn/go-sqlite3 v1.14.5 h1:1IdxlwTNazvbKJQSxoJ5/9ECbEeaTTyeU7sEAZ5KKTQ=
-github.com/mattn/go-sqlite3 v1.14.5/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGwNd0Lj+XmI=
 github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRUbg=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=

--- a/go.sum
+++ b/go.sum
@@ -502,6 +502,8 @@ github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.8 h1:3tS41NlGYSmhhe/8fhGRzc+z3AYCw1Fe1WAyLuujKs0=
 github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-sqlite3 v1.14.5 h1:1IdxlwTNazvbKJQSxoJ5/9ECbEeaTTyeU7sEAZ5KKTQ=
+github.com/mattn/go-sqlite3 v1.14.5/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGwNd0Lj+XmI=
 github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRUbg=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=


### PR DESCRIPTION
The personality is now deployed at the same time as Trillian if the docker command in the README is followed.

This requires an extra table of storage for the tree details so that the container can be restarted. The service will now create the tree if it hasn't done so already. This saves quite a lot of human-driven configuration from the start of the demo, which massively streamlines it (and mitigates the risk of anything going wrong from incorrect configuration). Having fewer terminals also lowers the cognitive cost for the audience.