### PR TITLE
Rely on default value in depguard list type config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,7 +9,6 @@ linters-settings:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
     min-complexity: 25
   depguard:
-    list-type: blacklist
     packages:
       - golang.org/x/net/context
       - github.com/gogo/protobuf/proto


### PR DESCRIPTION
Can revisit if we need different behaviour or upstream adds support for an inclusive language term.