### PR TITLE
Construct a map of logs from FT log

### DIFF
--- a/binary_transparency/firmware/README.md
+++ b/binary_transparency/firmware/README.md
@@ -339,3 +339,29 @@ go run cmd/publisher/publish.go --logtostderr --v=2 --timestamp="2020-10-10T23:0
 >
 > Anybody else running a monitor also knows that malicious firmware has been
 > logged and can raise the alarm.
+
+Generating a Verifiable Map
+---------------------------
+
+There are some pre-requisites to running this part of the demo:
+ 1. Have set up the environment and successfully run the [Trillian batchmap demo](https://github.com/google/trillian/tree/master/experimental/batchmap)
+ 2. Keep the Python Portable Beam Runner listening on port `8099`
+ 3. Have deployed the FT demo above using Docker, and have some firmware in there
+
+The following command will generate a verifiable map:
+
+* `go run ./cmd/ftmap --alsologtostderr --v=2 --runner=universal --endpoint=localhost:8099 --environment_type=LOOPBACK --map_db ~/ftmap.db --trillian_mysql="test:zaphod@tcp(127.0.0.1:3336)/test"`
+
+TODO(mhutchinson): Enhance the demo to show how devices can use this map to be convinced of useful aggregations across the log.
+
+Developer Notes
+---------------
+
+This section is not intended for a general audience.
+The intended audience is developers of FT that have a deployment and need to inspect or modify it.
+
+#### Docker
+
+Connecting to the Trillian database:
+
+`docker run -it --network deployment_default --rm mariadb mysql -hdeployment_mysql_1 -utest -pzaphod test`

--- a/binary_transparency/firmware/README.md
+++ b/binary_transparency/firmware/README.md
@@ -340,20 +340,6 @@ go run cmd/publisher/publish.go --logtostderr --v=2 --timestamp="2020-10-10T23:0
 > Anybody else running a monitor also knows that malicious firmware has been
 > logged and can raise the alarm.
 
-Generating a Verifiable Map
----------------------------
-
-There are some pre-requisites to running this part of the demo:
- 1. Have set up the environment and successfully run the [Trillian batchmap demo](https://github.com/google/trillian/tree/master/experimental/batchmap)
- 2. Keep the Python Portable Beam Runner listening on port `8099`
- 3. Have deployed the FT demo above using Docker, and have some firmware in there
-
-The following command will generate a verifiable map:
-
-* `go run ./cmd/ftmap --alsologtostderr --v=2 --runner=universal --endpoint=localhost:8099 --environment_type=LOOPBACK --map_db ~/ftmap.db --trillian_mysql="test:zaphod@tcp(127.0.0.1:3336)/test"`
-
-TODO(mhutchinson): Enhance the demo to show how devices can use this map to be convinced of useful aggregations across the log.
-
 Developer Notes
 ---------------
 

--- a/binary_transparency/firmware/cmd/ftmap/README.md
+++ b/binary_transparency/firmware/cmd/ftmap/README.md
@@ -1,0 +1,18 @@
+Verifiable Maps
+===============
+
+This is a work in progress.
+
+Generating a Verifiable Map
+---------------------------
+
+There are some pre-requisites to running this part of the demo:
+ 1. Have set up the environment and successfully run the [Trillian batchmap demo](https://github.com/google/trillian/tree/master/experimental/batchmap)
+ 2. Keep the Python Portable Beam Runner listening on port `8099`
+ 3. Have deployed the FT demo above using Docker, and have some firmware in there
+
+The following command will generate a verifiable map:
+
+* `go run ./cmd/ftmap --alsologtostderr --v=2 --runner=universal --endpoint=localhost:8099 --environment_type=LOOPBACK --map_db ~/ftmap.db --trillian_mysql="test:zaphod@tcp(127.0.0.1:3336)/test"`
+
+TODO(mhutchinson): Enhance the demo to show how devices can use this map to be convinced of useful aggregations across the log.

--- a/binary_transparency/firmware/cmd/ftmap/map.go
+++ b/binary_transparency/firmware/cmd/ftmap/map.go
@@ -1,0 +1,234 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// map constructs a verifiable map from the firmware in the FT log.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"reflect"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/io/databaseio"
+	beamlog "github.com/apache/beam/sdks/go/pkg/beam/log"
+	"github.com/apache/beam/sdks/go/pkg/beam/x/beamx"
+
+	"github.com/golang/glog"
+
+	"github.com/google/trillian/experimental/batchmap"
+
+	"github.com/google/trillian-examples/binary_transparency/firmware/internal/ftmap"
+
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+var (
+	trillianMySQL = flag.String("trillian_mysql", "", "The connection string to the Trillian MySQL database.")
+	mapDBString   = flag.String("map_db", "", "File path for output database where the map tiles will be written.") // TODO(mhutchinson): this needs to be able to sink to a client/server database
+	count         = flag.Int64("count", -1, "The total number of entries starting from the beginning of the log to use, or -1 to use all. This can be used to independently create maps of the same size.")
+	treeID        = flag.Int64("tree_id", 12345, "The ID of the tree. Used as a salt in hashing.")
+	prefixStrata  = flag.Int("prefix_strata", 2, "The number of strata of 8-bit strata before the final strata.")
+	batchSize     = flag.Int("write_batch_size", 250, "Number of tiles to write per batch")
+)
+
+func init() {
+	beam.RegisterType(reflect.TypeOf((*tileToDBRowFn)(nil)).Elem())
+	beam.RegisterType(reflect.TypeOf((*logToDBRowFn)(nil)).Elem())
+}
+
+func main() {
+	flag.Parse()
+
+	// Connect to where we will read from and write to.
+	sumDB, err := newTrillianDBFromFlags()
+	if err != nil {
+		glog.Exitf("Failed to initialize from local SumDB: %v", err)
+	}
+	mapDB, rev, err := sinkFromFlags()
+	if err != nil {
+		glog.Exitf("Failed to initialize Map DB: %v", err)
+	}
+
+	pb := ftmap.NewMapBuilder(sumDB, *treeID, *prefixStrata)
+
+	beam.Init()
+	beamlog.SetLogger(&BeamGLogger{InfoLogAtVerbosity: 2})
+	p, s := beam.NewPipelineWithRoot()
+
+	var tiles, logs beam.PCollection
+	var inputLogMetadata ftmap.InputLogMetadata
+
+	tiles, logs, inputLogMetadata, err = pb.Create(s, *count)
+	if err != nil {
+		glog.Exitf("Failed to build Create pipeline: %v", err)
+	}
+
+	tileRows := beam.ParDo(s.Scope("convertoutput"), &tileToDBRowFn{Revision: rev}, tiles)
+	databaseio.WriteWithBatchSize(s.Scope("sink"), *batchSize, "sqlite3", *mapDBString, "tiles", []string{}, tileRows)
+	logRows := beam.ParDo(s, &logToDBRowFn{rev}, logs)
+	databaseio.WriteWithBatchSize(s.Scope("sinkLogs"), *batchSize, "sqlite3", *mapDBString, "logs", []string{}, logRows)
+
+	// All of the above constructs the pipeline but doesn't run it. Now we run it.
+	if err := beamx.Run(context.Background(), p); err != nil {
+		glog.Exitf("Failed to execute job: %q", err)
+	}
+
+	// Now write the revision metadata to finalize this map construction.
+	if err := mapDB.WriteRevision(rev, inputLogMetadata.Checkpoint, inputLogMetadata.Entries); err != nil {
+		glog.Exitf("Failed to finalize map revison %d: %v", rev, err)
+	}
+}
+
+func sinkFromFlags() (*ftmap.MapDB, int, error) {
+	if len(*mapDBString) == 0 {
+		return nil, 0, fmt.Errorf("missing flag: map_db")
+	}
+
+	mapDB, err := ftmap.NewMapDB(*mapDBString)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to open map DB at %q: %v", *mapDBString, err)
+	}
+	if err := mapDB.Init(); err != nil {
+		return nil, 0, fmt.Errorf("failed to Init map DB at %q: %v", *mapDBString, err)
+	}
+
+	var rev int
+	if rev, err = mapDB.NextWriteRevision(); err != nil {
+		return nil, 0, fmt.Errorf("failed to query for next write revision: %v", err)
+
+	}
+	return mapDB, rev, nil
+}
+
+// LogDBRow adapts DeviceReleaseLog to the schema format of the Map database to allow for databaseio writing.
+type LogDBRow struct {
+	Revision int
+	DeviceID string
+	Leaves   []byte
+}
+
+type logToDBRowFn struct {
+	Revision int
+}
+
+func (fn *logToDBRowFn) ProcessElement(ctx context.Context, l *ftmap.DeviceReleaseLog) (LogDBRow, error) {
+	bs, err := json.Marshal(l.Revisions)
+	if err != nil {
+		return LogDBRow{}, err
+	}
+	return LogDBRow{
+		Revision: fn.Revision,
+		DeviceID: l.DeviceID,
+		Leaves:   bs,
+	}, nil
+}
+
+// MapTile is the schema format of the Map database to allow for databaseio writing.
+type MapTile struct {
+	Revision int
+	Path     []byte
+	Tile     []byte
+}
+
+type tileToDBRowFn struct {
+	Revision int
+}
+
+func (fn *tileToDBRowFn) ProcessElement(ctx context.Context, t *batchmap.Tile) (MapTile, error) {
+	bs, err := json.Marshal(t)
+	if err != nil {
+		return MapTile{}, err
+	}
+	return MapTile{
+		Revision: fn.Revision,
+		Path:     t.Path,
+		Tile:     bs,
+	}, nil
+}
+
+func tileFromDBRowFn(t MapTile) (*batchmap.Tile, error) {
+	var res batchmap.Tile
+	if err := json.Unmarshal(t.Tile, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+// TODO(mhutchinson): This only works if the Trillian DB has a single tree.
+type trillianDB struct {
+	dbString string
+	db       *sql.DB
+}
+
+func newTrillianDBFromFlags() (*trillianDB, error) {
+	if len(*trillianMySQL) == 0 {
+		return nil, fmt.Errorf("missing flag: trillian_mysql")
+	}
+	db, err := sql.Open("mysql", *trillianMySQL)
+	return &trillianDB{
+		dbString: *trillianMySQL,
+		db:       db,
+	}, err
+}
+
+// Head gets the STH and the total number of entries available to process.
+func (m *trillianDB) Head() ([]byte, int64, error) {
+	var cp []byte
+	var leafCount int64
+
+	// TODO(mhutchinson): This should construct the full signed root; see Trillian's storage/mysql/log_storage.go#fetchLatestRoot
+	return cp, leafCount, m.db.QueryRow("SELECT TreeSize, RootHash From TreeHead ORDER BY TreeRevision DESC LIMIT 1").Scan(&leafCount, &cp)
+}
+
+const sequencedLeafDataQuery = `
+SELECT
+  s.SequenceNumber AS Seq,
+  l.LeafValue AS Data
+FROM SequencedLeafData s INNER JOIN LeafData l
+  ON s.TreeId = l.TreeId AND s.LeafIdentityHash = l.LeafIdentityHash 
+WHERE
+  s.SequenceNumber >= %d AND s.SequenceNumber < %d
+`
+
+// Entries returns a PCollection of InputLogLeaf, containing entries in range [start, end).
+func (m *trillianDB) Entries(s beam.Scope, start, end int64) beam.PCollection {
+	return databaseio.Query(s, "mysql", m.dbString, fmt.Sprintf(sequencedLeafDataQuery, start, end), reflect.TypeOf(ftmap.InputLogLeaf{}))
+}
+
+// BeamGLogger allows Beam to log via the glog mechanism.
+// This is used to allow the very verbose logging output from Beam to be switched off.
+type BeamGLogger struct {
+	InfoLogAtVerbosity glog.Level
+}
+
+// Log logs.
+func (l *BeamGLogger) Log(ctx context.Context, sev beamlog.Severity, _ int, msg string) {
+	switch sev {
+	case beamlog.SevDebug:
+		glog.V(3).Info(msg)
+	case beamlog.SevInfo:
+		glog.V(l.InfoLogAtVerbosity).Info(msg)
+	case beamlog.SevError:
+		glog.Error(msg)
+	case beamlog.SevWarn:
+		glog.Warning(msg)
+	default:
+		glog.V(5).Infof("?? %s", msg)
+	}
+}

--- a/binary_transparency/firmware/cmd/ftmap/map.go
+++ b/binary_transparency/firmware/cmd/ftmap/map.go
@@ -56,16 +56,16 @@ func main() {
 	flag.Parse()
 
 	// Connect to where we will read from and write to.
-	sumDB, err := newTrillianDBFromFlags()
+	trillianDB, err := newTrillianDBFromFlags()
 	if err != nil {
-		glog.Exitf("Failed to initialize from local SumDB: %v", err)
+		glog.Exitf("Failed to initialize Trillian connection: %v", err)
 	}
 	mapDB, rev, err := sinkFromFlags()
 	if err != nil {
 		glog.Exitf("Failed to initialize Map DB: %v", err)
 	}
 
-	pb := ftmap.NewMapBuilder(sumDB, *treeID, *prefixStrata)
+	pb := ftmap.NewMapBuilder(trillianDB, *treeID, *prefixStrata)
 
 	beam.Init()
 	beamlog.SetLogger(&BeamGLogger{InfoLogAtVerbosity: 2})

--- a/binary_transparency/firmware/cmd/ftmap/map.go
+++ b/binary_transparency/firmware/cmd/ftmap/map.go
@@ -162,14 +162,6 @@ func (fn *tileToDBRowFn) ProcessElement(ctx context.Context, t *batchmap.Tile) (
 	}, nil
 }
 
-func tileFromDBRowFn(t MapTile) (*batchmap.Tile, error) {
-	var res batchmap.Tile
-	if err := json.Unmarshal(t.Tile, &res); err != nil {
-		return nil, err
-	}
-	return &res, nil
-}
-
 // TODO(mhutchinson): This only works if the Trillian DB has a single tree.
 type trillianDB struct {
 	dbString string

--- a/binary_transparency/firmware/docker-compose.override.yml
+++ b/binary_transparency/firmware/docker-compose.override.yml
@@ -5,6 +5,12 @@ version: "3.1"
 # This won't scale to multiple replicas without much more work.
 
 services:
+  mysql:
+    # Expose the mysql port for the verifiable map on 3336 outside of the docker network.
+    # This avoids conflicting with any other mysql instance running on the host machine.
+    ports:
+      - "3336:3306"
+
   personality:
     build: 
       context: ../../../trillian-examples

--- a/binary_transparency/firmware/internal/ftmap/mapdb.go
+++ b/binary_transparency/firmware/internal/ftmap/mapdb.go
@@ -1,0 +1,122 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ftmap
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/trillian/experimental/batchmap"
+)
+
+// NoRevisionsFound is returned when the DB appears valid but has no revisions in it.
+type NoRevisionsFound = error
+
+// MapDB provides read/write access to the generated Map tiles.
+type MapDB struct {
+	db *sql.DB
+}
+
+// NewMapDB creates a MapDB using a file at the given location.
+// If the file doesn't exist it will be created.
+func NewMapDB(location string) (*MapDB, error) {
+	db, err := sql.Open("sqlite3", location)
+	if err != nil {
+		return nil, err
+	}
+	return &MapDB{
+		db: db,
+	}, nil
+}
+
+// Init creates the database tables if needed.
+func (d *MapDB) Init() error {
+	if _, err := d.db.Exec("CREATE TABLE IF NOT EXISTS revisions (revision INTEGER PRIMARY KEY, datetime TIMESTAMP, logroot BLOB, count INTEGER)"); err != nil {
+		return err
+	}
+	if _, err := d.db.Exec("CREATE TABLE IF NOT EXISTS tiles (revision INTEGER, path BLOB, tile BLOB, PRIMARY KEY (revision, path))"); err != nil {
+		return err
+	}
+	if _, err := d.db.Exec("CREATE TABLE IF NOT EXISTS logs (deviceID BLOB, revision INTEGER, leaves BLOB, PRIMARY KEY (deviceID, revision))"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// NextWriteRevision gets the revision that the next generation of the map should be written at.
+func (d *MapDB) NextWriteRevision() (int, error) {
+	var rev sql.NullInt32
+	// TODO(mhutchinson): This should be updated to include the max of "tiles" or "logs".
+	if err := d.db.QueryRow("SELECT MAX(revision) FROM tiles").Scan(&rev); err != nil {
+		return 0, fmt.Errorf("failed to get max revision: %v", err)
+	}
+	if rev.Valid {
+		return int(rev.Int32) + 1, nil
+	}
+	return 0, nil
+}
+
+// LatestRevision gets the metadata for the last completed write.
+func (d *MapDB) LatestRevision() (rev int, logroot []byte, count int64, err error) {
+	var sqlRev sql.NullInt32
+	if err := d.db.QueryRow("SELECT revision, logroot, count FROM revisions ORDER BY revision DESC LIMIT 1").Scan(&sqlRev, &logroot, &count); err != nil {
+		return 0, nil, 0, fmt.Errorf("failed to get latest revision: %v", err)
+	}
+	if sqlRev.Valid {
+		return int(sqlRev.Int32), logroot, count, nil
+	}
+	return 0, nil, 0, NoRevisionsFound(errors.New("no revisions found"))
+}
+
+// Tile gets the tile at the given path in the given revision of the map.
+func (d *MapDB) Tile(revision int, path []byte) (*batchmap.Tile, error) {
+	var bs []byte
+	if err := d.db.QueryRow("SELECT tile FROM tiles WHERE revision=? AND path=?", revision, path).Scan(&bs); err != nil {
+		return nil, err
+	}
+	tile := &batchmap.Tile{}
+	if err := json.Unmarshal(bs, tile); err != nil {
+		return nil, fmt.Errorf("failed to parse tile at revision=%d, path=%x: %v", revision, path, err)
+	}
+	return tile, nil
+}
+
+// WriteRevision writes the metadata for a completed run into the database.
+// If this method isn't called then the tiles may be written but this revision will be
+// skipped by sensible readers because the provenance information isn't available.
+func (d *MapDB) WriteRevision(rev int, logCheckpoint []byte, count int64) error {
+	now := time.Now()
+	_, err := d.db.Exec("INSERT INTO revisions (revision, datetime, logroot, count) VALUES (?, ?, ?, ?)", rev, now, logCheckpoint, count)
+	if err != nil {
+		return fmt.Errorf("failed to write revision: %w", err)
+	}
+	return nil
+}
+
+// Versions gets the log of versions for the given module in the given map revision.
+func (d *MapDB) Versions(revision int, module string) ([]string, error) {
+	var bs []byte
+	if err := d.db.QueryRow("SELECT leaves FROM logs WHERE revision=? AND module=?", revision, module).Scan(&bs); err != nil {
+		return nil, err
+	}
+	var versions []string
+	if err := json.Unmarshal(bs, &versions); err != nil {
+		return nil, fmt.Errorf("failed to parse tile at revision=%d, path=%x: %v", revision, module, err)
+	}
+	return versions, nil
+}

--- a/binary_transparency/firmware/internal/ftmap/pipeline.go
+++ b/binary_transparency/firmware/internal/ftmap/pipeline.go
@@ -1,0 +1,138 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ftmap contains Beam pipeline library functions for the FT
+// verifiable map.
+package ftmap
+
+import (
+	"crypto"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/binary_transparency/firmware/api"
+	"github.com/google/trillian/experimental/batchmap"
+)
+
+func init() {
+	beam.RegisterFunction(parseLogEntryFn)
+	beam.RegisterType(reflect.TypeOf((*InputLogMetadata)(nil)).Elem())
+	beam.RegisterType(reflect.TypeOf((*InputLogLeaf)(nil)).Elem())
+	beam.RegisterType(reflect.TypeOf((*firmwareLogEntry)(nil)).Elem())
+}
+
+// InputLog allows access to entries from the FT Log.
+type InputLog interface {
+	// Head returns the metadata of available entries.
+	Head() (checkpoint []byte, count int64, err error)
+	// Entries returns a PCollection of InputLogLeaf, containing entries in range [start, end).
+	Entries(s beam.Scope, start, end int64) beam.PCollection
+}
+
+// InputLogMetadata describes the provenance information of the input
+// log to be passed around atomically.
+type InputLogMetadata struct {
+	Checkpoint []byte
+	Entries    int64
+}
+
+// InputLogLeaf is a leaf in an input log, with its sequence index and data.
+type InputLogLeaf struct {
+	Seq  int64
+	Data []byte
+}
+
+// MapBuilder contains the static configuration for a map, and allows
+// maps at different log sizes to be built using its methods.
+type MapBuilder struct {
+	source       InputLog
+	treeID       int64
+	prefixStrata int
+}
+
+// NewMapBuilder returns a MapBuilder for a map with the given configuration.
+func NewMapBuilder(source InputLog, treeID int64, prefixStrata int) MapBuilder {
+	return MapBuilder{
+		source:       source,
+		treeID:       treeID,
+		prefixStrata: prefixStrata,
+	}
+}
+
+// Create builds a map from scratch, using the first `size` entries in the
+// input log. If there aren't enough entries then it will fail.
+// It returns a PCollection of *Tile as the first output, and any logs built
+// will be output in the second PCollection (of type DeviceReleaseLog).
+func (b *MapBuilder) Create(s beam.Scope, size int64) (beam.PCollection, beam.PCollection, InputLogMetadata, error) {
+	var tiles, logs beam.PCollection
+
+	endID, golden, err := b.getLogEnd(size)
+	if err != nil {
+		return tiles, logs, InputLogMetadata{}, err
+	}
+
+	inputLeaves := b.source.Entries(s.Scope("source"), 0, endID)
+	fws := beam.ParDo(s.Scope("parse"), parseLogEntryFn, inputLeaves)
+	entries, logs := MakeReleaseLogs(s.Scope("makeLogs"), b.treeID, fws)
+
+	glog.Infof("Creating new map revision from range [0, %d)", endID)
+	tiles, err = batchmap.Create(s, entries, b.treeID, crypto.SHA512_256, b.prefixStrata)
+
+	return tiles, logs, InputLogMetadata{
+		Checkpoint: golden,
+		Entries:    endID,
+	}, err
+}
+
+func (b *MapBuilder) getLogEnd(requiredEntries int64) (int64, []byte, error) {
+	golden, totalLeaves, err := b.source.Head()
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to get Head of input log: %v", err)
+	}
+
+	if requiredEntries < 0 {
+		return totalLeaves, golden, nil
+	}
+
+	if totalLeaves < requiredEntries {
+		return 0, nil, fmt.Errorf("wanted %d leaves but only %d available", requiredEntries, totalLeaves)
+	}
+
+	return requiredEntries, golden, nil
+}
+
+// firmwareLogEntry is a parsed version of InputLogLeaf.
+type firmwareLogEntry struct {
+	Index    int64
+	Firmware api.FirmwareMetadata
+}
+
+func parseLogEntryFn(l InputLogLeaf) (*firmwareLogEntry, error) {
+	var s api.FirmwareStatement
+	if err := json.Unmarshal(l.Data, &s); err != nil {
+		return nil, err
+	}
+
+	var m api.FirmwareMetadata
+	if err := json.Unmarshal(s.Metadata, &m); err != nil {
+		return nil, err
+	}
+	return &firmwareLogEntry{
+		Index:    l.Seq,
+		Firmware: m,
+	}, nil
+}

--- a/binary_transparency/firmware/internal/ftmap/pipeline_test.go
+++ b/binary_transparency/firmware/internal/ftmap/pipeline_test.go
@@ -1,0 +1,125 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ftmap
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/testing/passert"
+	"github.com/apache/beam/sdks/go/pkg/beam/testing/ptest"
+	"github.com/google/trillian-examples/binary_transparency/firmware/api"
+	"github.com/google/trillian/experimental/batchmap"
+)
+
+func TestCreate(t *testing.T) {
+	tests := []struct {
+		name   string
+		treeID int64
+		count  int64
+
+		wantRoot string
+		wantLogs []string
+	}{
+		{
+			name:   "One entry",
+			treeID: 12345,
+			count:  1,
+
+			wantRoot: "85749402df8a992bbce4d3cd5a8205421b73dcc6df860253ddcbceddf60ed903",
+			wantLogs: []string{"dummy: [1]"},
+		},
+		{
+			name:   "All entries",
+			treeID: 12345,
+			count:  -1,
+
+			wantRoot: "eb994efa95861a85b0a463f1499af81c41370882abb715e456ba79813f3a88d2",
+			wantLogs: []string{"dummy: [1 5 3]", "fish: [42]"},
+		},
+	}
+
+	inputLog := fakeLog{
+		leaves: []api.FirmwareMetadata{
+			{
+				DeviceID:         "dummy",
+				FirmwareRevision: 1,
+			},
+			{
+				DeviceID:         "dummy",
+				FirmwareRevision: 5,
+			},
+			{
+				DeviceID:         "fish",
+				FirmwareRevision: 42,
+			},
+			{
+				DeviceID:         "dummy",
+				FirmwareRevision: 3,
+			},
+		},
+		head: []byte("this is just passed around"),
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			mb := NewMapBuilder(inputLog, test.treeID, 0)
+			p, s := beam.NewPipelineWithRoot()
+
+			tiles, logs, _, err := mb.Create(s, test.count)
+			if err != nil {
+				t.Errorf("failed to Create(): %v", err)
+			}
+
+			rootToString := func(t *batchmap.Tile) string { return fmt.Sprintf("%x", t.RootHash) }
+			passert.Equals(s, beam.ParDo(s, rootToString, tiles), test.wantRoot)
+
+			logToString := func(l *DeviceReleaseLog) string { return fmt.Sprintf("%s: %v", l.DeviceID, l.Revisions) }
+			passert.Equals(s, beam.ParDo(s, logToString, logs), beam.CreateList(s, test.wantLogs))
+
+			err = ptest.Run(p)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+type fakeLog struct {
+	leaves []api.FirmwareMetadata
+	head   []byte
+}
+
+func (l fakeLog) Head() ([]byte, int64, error) {
+	return l.head, int64(len(l.leaves)), nil
+}
+
+func (l fakeLog) Entries(s beam.Scope, start, end int64) beam.PCollection {
+	count := int(end - start)
+	entries := make([]InputLogLeaf, count)
+	for i := 0; i < count; i++ {
+		// This swallows the error, but the test will fail anyway. YOLO.
+		index := start + int64(i)
+		fwbs, _ := json.Marshal(l.leaves[int(index)])
+		bs, _ := json.Marshal(api.FirmwareStatement{Metadata: fwbs})
+		entries[i] = InputLogLeaf{
+			Seq:  index,
+			Data: bs,
+		}
+	}
+	return beam.CreateList(s, entries)
+}


### PR DESCRIPTION
The map is keyed by device ID, and the value is a log which contains the firmware revisions for that device. The log is stored in the database as a flat JSON list of leaf values, and will need to be rehydrated (i.e. the merkle tree recalculated) each time it is used. This puts a limit on how big the sub-logs can be, but that limit is much higher than the cardinalities we'll use for demos.

This requires that the `mysql` docker container has a port exposed outside of the docker network so that the Beam pipeline can access the DB to source the log data.

This pipeline is something of a strawman. By starting with a map of logs, this demonstrates the most complicated map construction and thus all the raw material should be here to allow developers with less experience with Beam to mould this to take whatever shape of Map we decide is required for a convincing demo.