### PR TITLE
Added a LogFollower class to encapsulate common logic

### DIFF
--- a/binary_transparency/firmware/api/http.go
+++ b/binary_transparency/firmware/api/http.go
@@ -76,3 +76,8 @@ type InclusionProof struct {
 	LeafIndex uint64
 	Proof     [][]byte
 }
+
+// String returns a compact printable representation of an InclusionProof.
+func (l InclusionProof) String() string {
+	return fmt.Sprintf("{index %d, value: 0x%x, proof: %x}", l.LeafIndex, l.Value, l.Proof)
+}

--- a/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
+++ b/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
@@ -126,5 +126,4 @@ func Main(ctx context.Context, opts MonitorOpts) error {
 		}
 
 	}
-	return nil
 }

--- a/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
+++ b/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
@@ -35,8 +35,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/binary_transparency/firmware/api"
 	"github.com/google/trillian-examples/binary_transparency/firmware/internal/client"
-	"github.com/google/trillian-examples/binary_transparency/firmware/internal/crypto"
-	"github.com/google/trillian-examples/binary_transparency/firmware/internal/verify"
 )
 
 // MatchFunc is the signature of a function which can be called by the monitor
@@ -52,7 +50,6 @@ type MonitorOpts struct {
 }
 
 func Main(ctx context.Context, opts MonitorOpts) error {
-
 	if len(opts.LogURL) == 0 {
 		return errors.New("log URL is required")
 	}
@@ -62,132 +59,71 @@ func Main(ctx context.Context, opts MonitorOpts) error {
 		return fmt.Errorf("failed to parse FT log URL: %w", err)
 	}
 
-	glog.Infof("Monitoring FT log %q...", opts.LogURL)
-	ticker := time.NewTicker(opts.PollInterval)
-
-	c := client.ReadonlyClient{LogURL: ftURL}
-	var latestCP api.LogCheckpoint
-
-	lv := verify.NewLogVerifier()
-
 	// Parse the input keywords as regular expression
 	var ftKeywords []*regexp.Regexp
 	for _, k := range strings.Fields(opts.Keyword) {
 		ftKeywords = append(ftKeywords, regexp.MustCompile(k))
 	}
 
-	for {
+	c := client.ReadonlyClient{LogURL: ftURL}
+
+	// TODO(mhutchinson): This checkpoint and tracker for number of processed entries
+	// should be serialized so the monitor persists its golden state between runs.
+	var latestCP api.LogCheckpoint
+	var head uint64
+	follow := client.NewLogFollower(c, opts.PollInterval, latestCP)
+
+	glog.Infof("Monitoring FT log %q...", opts.LogURL)
+	cpc, cperrc := follow.Checkpoints(ctx)
+	ec, eerrc := follow.Entries(ctx, cpc, head)
+
+	for entry := range ec {
 		select {
-		case <-ticker.C:
-			//
+		case err = <-cperrc:
+			return err
+		case err = <-eerrc:
+			return err
 		case <-ctx.Done():
 			return ctx.Err()
+		default:
 		}
 
-		cp, err := c.GetCheckpoint()
+		stmt := entry.Value
+		if stmt.Type != api.FirmwareMetadataType {
+			// TODO(mhutchinson): Process annotations in the monitor?
+			continue
+		}
+
+		// Parse the firmware metadata:
+		var meta api.FirmwareMetadata
+		if err := json.Unmarshal(stmt.Statement, &meta); err != nil {
+			glog.Warningf("Unable to decode FW Metadata from Statement %q", err)
+			continue
+		}
+
+		glog.Infof("Found firmware (@%d): %s", entry.Index, meta)
+
+		// Fetch the Image from FT Personality
+		image, err := c.GetFirmwareImage(meta.FirmwareImageSHA512)
 		if err != nil {
-			glog.Warningf("Failed to update LogCheckpoint: %q", err)
+			glog.Warningf("Unable to GetFirmwareImage for Firmware with Hash 0x%x , reason %q", meta.FirmwareImageSHA512, err)
 			continue
 		}
-		// TODO(al): check signature on checkpoint when they're added.
-
-		if cp.TreeSize <= latestCP.TreeSize {
+		// Verify Image Hash from log Manifest matches the actual image hash
+		h := sha512.Sum512(image)
+		if !bytes.Equal(h[:], meta.FirmwareImageSHA512) {
+			glog.Warningf("downloaded image does not match SHA512 in metadata (%x != %x)", h[:], meta.FirmwareImageSHA512)
 			continue
 		}
-		glog.V(1).Infof("Got newer checkpoint %s", cp)
+		glog.V(1).Infof("Image Hash Verified for image at leaf index %d", entry.Index)
 
-		// Fetch all the manifests from now till new checkpoint
-		for idx := latestCP.TreeSize; idx < cp.TreeSize; idx++ {
-
-			manifest, err := c.GetManifestEntryAndProof(api.GetFirmwareManifestRequest{Index: idx, TreeSize: cp.TreeSize})
-			if err != nil {
-				glog.Warningf("Failed to fetch the Manifest: %q", err)
-				continue
-			}
-			glog.V(1).Infof("Received New Manifest with Information=")
-			glog.V(1).Infof("Manifest Value = %s", manifest.Value)
-			glog.V(1).Infof("LeafIndex = %d", manifest.LeafIndex)
-			glog.V(1).Infof("Proof = %x", manifest.Proof)
-
-			lh := verify.HashLeaf(manifest.Value)
-			if err := lv.VerifyInclusionProof(int64(manifest.LeafIndex), int64(cp.TreeSize), manifest.Proof, cp.RootHash, lh); err != nil {
-				// Report Failed Inclusion Proof
-				glog.Warningf("Invalid inclusion proof received for LeafIndex %d", manifest.LeafIndex)
-				continue
-			}
-
-			glog.V(1).Infof("Inclusion proof for leafhash 0x%x verified", lh)
-
-			statement := manifest.Value
-			stmt := api.SignedStatement{}
-			if err := json.NewDecoder(bytes.NewReader(statement)).Decode(&stmt); err != nil {
-				glog.Warningf("SignedStatement decoding failed: %q", err)
-				continue
-			}
-
-			// Verify the signature:
-			if err := crypto.Publisher.VerifySignature(stmt.Type, stmt.Statement, stmt.Signature); err != nil {
-				glog.Warningf("Signature verification failed: %q", err)
-				continue
-			}
-			glog.V(1).Infof("Signature verification SUCCESS")
-
-			if stmt.Type != api.FirmwareMetadataType {
-				// TODO(mhutchinson): Process annotations in the monitor?
-				continue
-			}
-
-			// Parse the firmware metadata:
-			var meta api.FirmwareMetadata
-			if err := json.Unmarshal(stmt.Statement, &meta); err != nil {
-				glog.Warningf("Unable to decode FW Metadata from Statement %q", err)
-				continue
-			}
-
-			glog.Infof("Found firmware (@%d): %s", idx, meta)
-
-			// Fetch the Image from FT Personality
-			image, err := c.GetFirmwareImage(meta.FirmwareImageSHA512)
-			if err != nil {
-				glog.Warningf("Unable to GetFirmwareImage for Firmware with Hash 0x%x , reason %q", meta.FirmwareImageSHA512, err)
-				continue
-			}
-			// Verify Image Hash from log Manifest matches the actual image hash
-			h := sha512.Sum512(image)
-			if !bytes.Equal(h[:], meta.FirmwareImageSHA512) {
-				glog.Warningf("downloaded image does not match SHA512 in metadata (%x != %x)", h[:], meta.FirmwareImageSHA512)
-				continue
-			}
-			glog.V(1).Infof("Image Hash Verified for image at leaf index %d", manifest.LeafIndex)
-
-			//Search for specific keywords inside firmware image
-			for _, m := range ftKeywords {
-				if m.Match(image) {
-					opts.Matched(idx, meta)
-				}
+		// Search for specific keywords inside firmware image
+		for _, m := range ftKeywords {
+			if m.Match(image) {
+				opts.Matched(entry.Index, meta)
 			}
 		}
 
-		// Perform consistency check only for non-zero initial tree size
-		if latestCP.TreeSize != 0 {
-			consistency, err := c.GetConsistencyProof(api.GetConsistencyRequest{From: latestCP.TreeSize, To: cp.TreeSize})
-			if err != nil {
-				glog.Warningf("Failed to fetch the Consistency: %q", err)
-				continue
-			}
-			glog.V(1).Infof("Printing the latest Consistency Proof Information")
-			glog.V(1).Infof("Consistency Proof = %x", consistency.Proof)
-
-			//Verify the fetched consistency proof
-			if err := lv.VerifyConsistencyProof(int64(latestCP.TreeSize), int64(cp.TreeSize), latestCP.RootHash, cp.RootHash, consistency.Proof); err != nil {
-				// Verification of Consistency Proof failed!!
-				glog.Warningf("Failed verification of Consistency proof %q", err)
-				continue
-			}
-			glog.V(1).Infof("Consistency proof for Treesize %d verified", cp.TreeSize)
-		}
-
-		latestCP = *cp
 	}
-	// unreachable
+	return nil
 }

--- a/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
+++ b/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
@@ -77,7 +77,8 @@ func Main(ctx context.Context, opts MonitorOpts) error {
 	cpc, cperrc := follow.Checkpoints(ctx, opts.PollInterval, latestCP)
 	ec, eerrc := follow.Entries(ctx, cpc, head)
 
-	for entry := range ec {
+	for {
+		var entry client.LogEntry
 		select {
 		case err = <-cperrc:
 			return err
@@ -85,7 +86,7 @@ func Main(ctx context.Context, opts MonitorOpts) error {
 			return err
 		case <-ctx.Done():
 			return ctx.Err()
-		default:
+		case entry = <-ec:
 		}
 
 		stmt := entry.Value

--- a/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
+++ b/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
@@ -71,10 +71,10 @@ func Main(ctx context.Context, opts MonitorOpts) error {
 	// should be serialized so the monitor persists its golden state between runs.
 	var latestCP api.LogCheckpoint
 	var head uint64
-	follow := client.NewLogFollower(c, opts.PollInterval, latestCP)
+	follow := client.NewLogFollower(c)
 
 	glog.Infof("Monitoring FT log %q...", opts.LogURL)
-	cpc, cperrc := follow.Checkpoints(ctx)
+	cpc, cperrc := follow.Checkpoints(ctx, opts.PollInterval, latestCP)
 	ec, eerrc := follow.Entries(ctx, cpc, head)
 
 	for entry := range ec {

--- a/binary_transparency/firmware/cmd/ft_witness/internal/http/witness.go
+++ b/binary_transparency/firmware/cmd/ft_witness/internal/http/witness.go
@@ -87,10 +87,10 @@ func (s *Witness) Poll(ctx context.Context) error {
 		return fmt.Errorf("failed to parse FT log URL: %w", err)
 	}
 	c := client.ReadonlyClient{LogURL: ftURL}
-	follow := client.NewLogFollower(c, s.pollInterval, s.gcp)
+	follow := client.NewLogFollower(c)
 
 	glog.Infof("Polling FT log %q...", ftURL)
-	cpc, cperrc := follow.Checkpoints(ctx)
+	cpc, cperrc := follow.Checkpoints(ctx, s.pollInterval, s.gcp)
 
 	for cp := range cpc {
 		select {

--- a/binary_transparency/firmware/cmd/ft_witness/internal/http/witness.go
+++ b/binary_transparency/firmware/cmd/ft_witness/internal/http/witness.go
@@ -27,7 +27,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/binary_transparency/firmware/api"
 	"github.com/google/trillian-examples/binary_transparency/firmware/internal/client"
-	"github.com/google/trillian-examples/binary_transparency/firmware/internal/verify"
 	"github.com/gorilla/mux"
 )
 
@@ -83,57 +82,33 @@ func (s *Witness) RegisterHandlers(r *mux.Router) {
 // Poll periodically polls the FT log for updating the witness checkpoint.
 // It only returns on error (when it doesn't start its own polling thread)
 func (s *Witness) Poll(ctx context.Context) error {
-	ticker := time.NewTicker(s.pollInterval)
 	ftURL, err := url.Parse(s.logURL)
 	if err != nil {
 		return fmt.Errorf("failed to parse FT log URL: %w", err)
 	}
-	glog.Infof("Polling FT log %q...", ftURL)
 	c := client.ReadonlyClient{LogURL: ftURL}
-	lv := verify.NewLogVerifier()
-	wcp := s.gcp
-	for {
+	follow := client.NewLogFollower(c, s.pollInterval, s.gcp)
 
+	glog.Infof("Polling FT log %q...", ftURL)
+	cpc, cperrc := follow.Checkpoints(ctx)
+
+	for cp := range cpc {
 		select {
-		case <-ticker.C:
-			//
+		case err = <-cperrc:
+			return err
 		case <-ctx.Done():
 			return ctx.Err()
+		default:
 		}
-		cp, err := c.GetCheckpoint()
-		if err != nil {
-			glog.Warningf("Failed to get logcheckpoint: %q", err)
-			continue
-		}
-		if cp.TreeSize <= wcp.TreeSize {
-			continue
-		}
-		glog.V(1).Infof("Got newer checkpoint %s", cp)
-		// Perform consistency check only for non-zero saved witness tree size
-		if wcp.TreeSize != 0 {
-			consistency, err := c.GetConsistencyProof(api.GetConsistencyRequest{From: wcp.TreeSize, To: cp.TreeSize})
-			if err != nil {
-				glog.Warningf("Failed to fetch the Consistency: %q", err)
-				continue
-			}
-			glog.V(2).Infof("Printing the latest Consistency Proof Information")
-			glog.V(2).Infof("Consistency Proof = %x", consistency.Proof)
 
-			//Verify the fetched consistency proof
-			if err := lv.VerifyConsistencyProof(int64(wcp.TreeSize), int64(cp.TreeSize), wcp.RootHash, cp.RootHash, consistency.Proof); err != nil {
-				// Verification of Consistency Proof failed!!
-				glog.Warningf("Failed verification of Consistency proof %q", err)
-				continue
-			}
-			glog.V(1).Infof("Consistency proof for Treesize %d verified", cp.TreeSize)
-		}
 		s.witnessLock.Lock()
-		if err = s.ws.StoreCP(*cp); err != nil {
+		if err = s.ws.StoreCP(cp); err != nil {
 			glog.Warningf("Failed to save new logcheckpoint into store: %q", err)
 			s.witnessLock.Unlock()
 			continue
 		}
-		s.gcp = (*cp)
+		s.gcp = cp
 		s.witnessLock.Unlock()
 	}
+	return nil
 }

--- a/binary_transparency/firmware/cmd/ft_witness/internal/http/witness.go
+++ b/binary_transparency/firmware/cmd/ft_witness/internal/http/witness.go
@@ -111,5 +111,4 @@ func (s *Witness) Poll(ctx context.Context) error {
 		s.gcp = cp
 		s.witnessLock.Unlock()
 	}
-	return nil
 }

--- a/binary_transparency/firmware/cmd/ft_witness/internal/http/witness.go
+++ b/binary_transparency/firmware/cmd/ft_witness/internal/http/witness.go
@@ -92,13 +92,14 @@ func (s *Witness) Poll(ctx context.Context) error {
 	glog.Infof("Polling FT log %q...", ftURL)
 	cpc, cperrc := follow.Checkpoints(ctx, s.pollInterval, s.gcp)
 
-	for cp := range cpc {
+	for {
+		var cp api.LogCheckpoint
 		select {
 		case err = <-cperrc:
 			return err
 		case <-ctx.Done():
 			return ctx.Err()
-		default:
+		case cp = <-cpc:
 		}
 
 		s.witnessLock.Lock()

--- a/binary_transparency/firmware/internal/client/client.go
+++ b/binary_transparency/firmware/internal/client/client.go
@@ -144,6 +144,7 @@ func (c ReadonlyClient) GetInclusion(statement []byte, cp api.LogCheckpoint) (ap
 }
 
 // GetManifestEntryAndProof returns the manifest and proof from the server, for given Index and TreeSize
+// TODO(mhutchinson): Rename this as leaf values can also be annotations.
 func (c ReadonlyClient) GetManifestEntryAndProof(request api.GetFirmwareManifestRequest) (*api.InclusionProof, error) {
 	url := fmt.Sprintf("%s/at/%d/in-tree-of/%d", api.HTTPGetManifestEntryAndProof, request.Index, request.TreeSize)
 

--- a/binary_transparency/firmware/internal/client/follower.go
+++ b/binary_transparency/firmware/internal/client/follower.go
@@ -1,0 +1,185 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/binary_transparency/firmware/api"
+	"github.com/google/trillian-examples/binary_transparency/firmware/internal/crypto"
+	"github.com/google/trillian-examples/binary_transparency/firmware/internal/verify"
+	"github.com/google/trillian/merkle/logverifier"
+)
+
+type ErrConsistency struct {
+	Golden, Latest api.LogCheckpoint
+}
+
+func (e ErrConsistency) Error() string {
+	return fmt.Sprintf("failed to verify consistency proof from %s to %s", e.Golden, e.Latest)
+}
+
+type ErrInclusion struct {
+	Checkpoint api.LogCheckpoint
+	Proof      api.InclusionProof
+}
+
+func (e ErrInclusion) Error() string {
+	return fmt.Sprintf("failed to verify inclusion proof %s in root %s", e.Proof, e.Checkpoint)
+}
+
+// LogEntry wraps up a leaf value with its position in the log.
+type LogEntry struct {
+	Root  api.LogCheckpoint
+	Index uint64
+	Value api.SignedStatement
+}
+
+// LogFollower follows a log for new data becoming available.
+type LogFollower struct {
+	c            ReadonlyClient
+	lv           logverifier.LogVerifier
+	pollInterval time.Duration
+	golden       api.LogCheckpoint
+}
+
+func NewLogFollower(c ReadonlyClient, pollInterval time.Duration, golden api.LogCheckpoint) LogFollower {
+	return LogFollower{
+		c:            c,
+		lv:           verify.NewLogVerifier(),
+		pollInterval: pollInterval,
+		golden:       golden,
+	}
+}
+
+// Checkpoints polls the log according to the configured interval, returning roots consistent
+// with the current golden checkpoint. Should any valid roots be found which are inconsistent
+// then an error is returned. The log being unavailable will just cause a retry, giving it
+// the benefit of the doubt.
+func (f *LogFollower) Checkpoints(ctx context.Context) (<-chan api.LogCheckpoint, <-chan error) {
+	ticker := time.NewTicker(f.pollInterval)
+
+	outc := make(chan api.LogCheckpoint, 1)
+	errc := make(chan error, 1)
+
+	// Push the starting checkpoint into the channel here to kick off the pipeline
+	outc <- f.golden
+
+	go func() {
+		defer close(outc)
+		// Now keep looking for newer, consistent checkpoints
+		for {
+			select {
+			case <-ticker.C:
+				// Wait until the next tick.
+			case <-ctx.Done():
+				errc <- ctx.Err()
+				return
+			}
+
+			cp, err := f.c.GetCheckpoint()
+			if err != nil {
+				glog.Warningf("Failed to get latest Checkpoint: %q", err)
+				continue
+			}
+			// TODO(al): check signature on checkpoint when they're added.
+
+			if cp.TreeSize <= f.golden.TreeSize {
+				continue
+			}
+			glog.V(1).Infof("Got newer checkpoint %s", cp)
+
+			// Perform consistency check only for non-zero initial tree size
+			if f.golden.TreeSize != 0 {
+				consistency, err := f.c.GetConsistencyProof(api.GetConsistencyRequest{From: f.golden.TreeSize, To: cp.TreeSize})
+				if err != nil {
+					glog.Warningf("Failed to fetch the Consistency: %q", err)
+					continue
+				}
+				glog.V(1).Infof("Printing the latest Consistency Proof Information")
+				glog.V(1).Infof("Consistency Proof = %x", consistency.Proof)
+
+				// Verify the fetched consistency proof
+				if err := f.lv.VerifyConsistencyProof(int64(f.golden.TreeSize), int64(cp.TreeSize), f.golden.RootHash, cp.RootHash, consistency.Proof); err != nil {
+					errc <- ErrConsistency{
+						Golden: f.golden,
+						Latest: *cp,
+					}
+					return
+				}
+				glog.V(1).Infof("Consistency proof for Treesize %d verified", cp.TreeSize)
+			}
+			f.golden = *cp
+			outc <- *cp
+		}
+	}()
+	return outc, errc
+}
+
+func (f *LogFollower) Entries(ctx context.Context, cpc <-chan api.LogCheckpoint, head uint64) (<-chan LogEntry, <-chan error) {
+	outc := make(chan LogEntry, 1)
+	errc := make(chan error, 1)
+
+	go func() {
+		defer close(outc)
+		for cp := range cpc {
+			for ; head < cp.TreeSize; head++ {
+				proof, err := f.c.GetManifestEntryAndProof(api.GetFirmwareManifestRequest{Index: head, TreeSize: cp.TreeSize})
+				if err != nil {
+					glog.Warningf("Failed to fetch the Manifest: %q", err)
+					continue
+				}
+				lh := verify.HashLeaf(proof.Value)
+				if err := f.lv.VerifyInclusionProof(int64(proof.LeafIndex), int64(cp.TreeSize), proof.Proof, cp.RootHash, lh); err != nil {
+					errc <- ErrInclusion{
+						Checkpoint: cp,
+						Proof:      *proof,
+					}
+					return
+				}
+				glog.V(1).Infof("Inclusion proof for leafhash 0x%x verified", lh)
+
+				statement := proof.Value
+				stmt := api.SignedStatement{}
+				if err := json.NewDecoder(bytes.NewReader(statement)).Decode(&stmt); err != nil {
+					errc <- fmt.Errorf("failed to decode SignedStatement: %q", err)
+					return
+				}
+
+				claimant, err := crypto.ClaimantForType(stmt.Type)
+				if err != nil {
+					errc <- err
+					return
+				}
+				// Verify the signature:
+				if err := claimant.VerifySignature(stmt.Type, stmt.Statement, stmt.Signature); err != nil {
+					errc <- fmt.Errorf("failed to verify signature: %q", err)
+					return
+				}
+				outc <- LogEntry{
+					Root:  cp,
+					Index: head,
+					Value: stmt,
+				}
+			}
+		}
+	}()
+	return outc, errc
+}

--- a/binary_transparency/firmware/internal/crypto/signature.go
+++ b/binary_transparency/firmware/internal/crypto/signature.go
@@ -179,6 +179,7 @@ func (c *Claimant) VerifySignature(stype api.StatementType, stmt []byte, signatu
 	return nil
 }
 
+// ClaimantForType returns the relevant Claimant for the given Statement type.
 func ClaimantForType(t api.StatementType) (*Claimant, error) {
 	switch t {
 	case api.FirmwareMetadataType:
@@ -186,6 +187,6 @@ func ClaimantForType(t api.StatementType) (*Claimant, error) {
 	case api.MalwareStatementType:
 		return &AnnotatorMalware, nil
 	default:
-		return nil, fmt.Errorf("Unknown type %v", t)
+		return nil, fmt.Errorf("Unknown Claimant type %v", t)
 	}
 }

--- a/binary_transparency/firmware/internal/crypto/signature.go
+++ b/binary_transparency/firmware/internal/crypto/signature.go
@@ -178,3 +178,14 @@ func (c *Claimant) VerifySignature(stype api.StatementType, stmt []byte, signatu
 	// signature is valid
 	return nil
 }
+
+func ClaimantForType(t api.StatementType) (*Claimant, error) {
+	switch t {
+	case api.FirmwareMetadataType:
+		return &Publisher, nil
+	case api.MalwareStatementType:
+		return &AnnotatorMalware, nil
+	default:
+		return nil, fmt.Errorf("Unknown type %v", t)
+	}
+}


### PR DESCRIPTION
This will need to be written again for the annotator client, so factoring this out now to avoid yet more duplication of critical code.

This implementation uses go channels to improve separation of concerns.