### PR TITLE
Upgrade monitor to support annotating

### DIFF
--- a/binary_transparency/firmware/api/annotation.go
+++ b/binary_transparency/firmware/api/annotation.go
@@ -14,6 +14,8 @@
 
 package api
 
+import "fmt"
+
 // StatementType is an enum that describes the type of statement in a SignedStatement.
 type StatementType byte
 
@@ -40,8 +42,12 @@ type SignedStatement struct {
 // FirmwareID is a pointer to a firmware version.
 // It will be a SignedStatement of type FirmwareMetadataType.
 type FirmwareID struct {
-	LogIndex int64
-	LeafHash []byte
+	LogIndex            uint64
+	FirmwareImageSHA512 []byte
+}
+
+func (id FirmwareID) String() string {
+	return fmt.Sprintf("FirmwareID{index %d, hash %x}", id.LogIndex, id.FirmwareImageSHA512)
 }
 
 // MalwareStatement is an annotation about malware checks in a firmware version.
@@ -52,6 +58,10 @@ type MalwareStatement struct {
 	// Good is a crude signal of goodness.
 	// TODO(mhutchinson): Add more fields as needed for the demo (e.g. Timestamp).
 	Good bool
+}
+
+func (s MalwareStatement) String() string {
+	return fmt.Sprintf("MalwareStatement{fw %s, good %t}", s.FirmwareID, s.Good)
 }
 
 // RevocationStatement is an annotation that marks a build as revoked.

--- a/binary_transparency/firmware/cmd/ft_monitor/ft_monitor.go
+++ b/binary_transparency/firmware/cmd/ft_monitor/ft_monitor.go
@@ -37,6 +37,7 @@ var (
 	ftLog        = flag.String("ftlog", "http://localhost:8000", "Base URL of FT Log server")
 	pollInterval = flag.Duration("poll_interval", 5*time.Second, "Duration to wait between polling for new entries")
 	keyWord      = flag.String("keyword", "trojan", "Example keyword for malware")
+	annotate     = flag.Bool("annotate", false, "If true then this will add annotations to the log in addition to local logging")
 )
 
 func main() {
@@ -49,6 +50,7 @@ func main() {
 		Matched: func(idx uint64, fw api.FirmwareMetadata) {
 			glog.Warningf("Malware detected at log index %d, in firmware: %v", idx, fw)
 		},
+		Annotate: *annotate,
 	}); err != nil {
 		glog.Exitf(err.Error())
 	}

--- a/binary_transparency/firmware/internal/client/client.go
+++ b/binary_transparency/firmware/internal/client/client.go
@@ -100,6 +100,23 @@ func (c SubmitClient) PublishFirmware(manifest, image []byte) error {
 	return nil
 }
 
+// PublishAnnotationMalware publishes the serialized annotation to the log.
+func (c SubmitClient) PublishAnnotationMalware(stmt []byte) error {
+	u, err := c.LogURL.Parse(api.HTTPAddAnnotationMalware)
+	if err != nil {
+		return err
+	}
+	glog.V(1).Infof("Submitting to %v", u.String())
+	r, err := http.Post(u.String(), "application/json", bytes.NewBuffer(stmt))
+	if err != nil {
+		return fmt.Errorf("failed to publish to log endpoint (%s): %w", u, err)
+	}
+	if r.StatusCode != http.StatusOK {
+		return errFromResponse("failed to submit to log", r)
+	}
+	return nil
+}
+
 // GetCheckpoint returns a new LogCheckPoint from the server.
 func (c ReadonlyClient) GetCheckpoint() (*api.LogCheckpoint, error) {
 	u, err := c.LogURL.Parse(api.HTTPGetRoot)

--- a/binary_transparency/firmware/internal/crypto/signature.go
+++ b/binary_transparency/firmware/internal/crypto/signature.go
@@ -133,7 +133,7 @@ func (c *Claimant) getPublicKey() (*rsa.PublicKey, error) {
 	return pubKey, nil
 }
 
-//SignMessage is used to sign the Statement
+// SignMessage is used to sign the Statement
 func (c *Claimant) SignMessage(stype api.StatementType, msg []byte) ([]byte, error) {
 	bs := make([]byte, len(msg)+1)
 	bs[0] = byte(stype)
@@ -156,7 +156,7 @@ func (c *Claimant) SignMessage(stype api.StatementType, msg []byte) ([]byte, err
 	return signature, nil
 }
 
-//VerifySignature is used to verify the incoming message
+// VerifySignature is used to verify the incoming message
 func (c *Claimant) VerifySignature(stype api.StatementType, stmt []byte, signature []byte) error {
 	// Get the required key for signing
 	key, err := c.getPublicKey()


### PR DESCRIPTION
The monitor was already following the log and making judgements on the claims within it. This flag allows the monitor to also function as an annotator and push these judgements back to the log where other parties in the ecosystem can use them.