### PR TITLE
Aggregate the FW with the annotations

### DIFF
--- a/binary_transparency/firmware/api/map.go
+++ b/binary_transparency/firmware/api/map.go
@@ -1,0 +1,30 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+// AggregatedFirmware represents the results of aggregating a single piece of firmware
+// according to the rules described in #Aggregate().
+type AggregatedFirmware struct {
+	Index    uint64
+	Firmware *FirmwareMetadata
+	Good     bool
+}
+
+// DeviceReleaseLog represents firmware releases found for a single device ID.
+// Entries are ordered by their sequence in the original log.
+type DeviceReleaseLog struct {
+	DeviceID  string
+	Revisions []uint64
+}

--- a/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
+++ b/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
@@ -107,6 +107,10 @@ func Main(opts FlashOpts) error {
 		}
 	}
 
+	// TODO(mhutchinson): query the map:
+	// 1. Check that the map root commits to a log root consistent with the checkpoints above
+	// 2. Look up the aggregation under the key: fmt.Sprintf("summary:%d", pb.InclusionProof.LeafIndex)
+
 	glog.Info("Update verified, about to apply to device...")
 
 	if err := dev.ApplyUpdate(up); err != nil {

--- a/binary_transparency/firmware/cmd/ftmap/README.md
+++ b/binary_transparency/firmware/cmd/ftmap/README.md
@@ -3,16 +3,38 @@ Verifiable Maps
 
 This is a work in progress.
 
-Generating a Verifiable Map
----------------------------
+Preconditions
+-------------
 
 There are some pre-requisites to running this part of the demo:
  1. Have set up the environment and successfully run the [Trillian batchmap demo](https://github.com/google/trillian/tree/master/experimental/batchmap)
  2. Keep the Python Portable Beam Runner listening on port `8099`
  3. Have deployed the FT demo above using Docker, and have some firmware in there
 
-The following command will generate a verifiable map:
+Example Workflow
+----------------
+
+First add some good and bad firmware to the log, and then ensure the malware annotator has seen this and pushed its findings to the log.
+The workflow script in the README in the `firmware` directory does this, but if you're short on time the following is a minimum set of client calls:
+
+```bash
+# Put a good piece of firmware in the log
+go run ./cmd/publisher/publish.go --logtostderr --v=2 --timestamp="2021-10-10T15:30:20.19Z" --binary_path=./testdata/firmware/dummy_device/example.wasm --output_path=/tmp/update.ota --device=dummy
+
+# Put a bad piece of firmware in the log
+go run ./cmd/publisher/publish.go --logtostderr --v=2 --timestamp="2020-10-10T23:00:00.00Z" --binary_path=./testdata/firmware/dummy_device/hacked.wasm --output_path=/tmp/bad_update.ota --device=dummy
+
+# Run the monitor to annotate
+go run ./cmd/ft_monitor/ --logtostderr --v=1 --keyword="H4x0r3d" --annotate
+```
+
+Now to generate the map:
 
 * `go run ./cmd/ftmap --alsologtostderr --v=2 --runner=universal --endpoint=localhost:8099 --environment_type=LOOPBACK --map_db ~/ftmap.db --trillian_mysql="test:zaphod@tcp(127.0.0.1:3336)/test"`
 
-TODO(mhutchinson): Enhance the demo to show how devices can use this map to be convinced of useful aggregations across the log.
+> :warning: this section still in progress
+
+TODO(mhutchinson): serve the aggregated information back to clients with inclusion proofs in the map tiles.
+
+It's possible to confirm that the aggregation has compiled the correct result by looking into the DB:
+`sqlite3 ~/ftmap.db 'SELECT * FROM aggregations;'`

--- a/binary_transparency/firmware/cmd/ftmap/README.md
+++ b/binary_transparency/firmware/cmd/ftmap/README.md
@@ -34,7 +34,7 @@ Now to generate the map:
 
 > :warning: this section still in progress
 
-TODO(mhutchinson): serve the aggregated information back to clients with inclusion proofs in the map tiles.
+TODO(mhutchinson): serve the map tiles; clients need map inclusion proofs for this aggregated information.
 
 It's possible to confirm that the aggregation has compiled the correct result by looking into the DB:
 `sqlite3 ~/ftmap.db 'SELECT * FROM aggregations;'`

--- a/binary_transparency/firmware/internal/ftmap/aggregate.go
+++ b/binary_transparency/firmware/internal/ftmap/aggregate.go
@@ -1,0 +1,95 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ftmap
+
+import (
+	"crypto/sha512"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+
+	"github.com/google/trillian-examples/binary_transparency/firmware/api"
+	"github.com/google/trillian/experimental/batchmap"
+	"github.com/google/trillian/merkle/coniks"
+	"github.com/google/trillian/storage/tree"
+)
+
+func init() {
+	beam.RegisterFunction(aggregationFn)
+	beam.RegisterType(reflect.TypeOf((*api.AggregatedFirmware)(nil)).Elem())
+	beam.RegisterType(reflect.TypeOf((*aggregatedFirmwareHashFn)(nil)).Elem())
+}
+
+// Aggregate will output an entry for each firmware entry in the input log, which includes the
+// firmware metadata, along with an aggregated representation of the annotations for it. The
+// rules are:
+// * AnnotationMalware: `Good` is true providing there are no malware annotations that claim the
+//                      firmware is bad.
+func Aggregate(s beam.Scope, treeID int64, fws, annotationMalwares beam.PCollection) (beam.PCollection, beam.PCollection) {
+	keyedFws := beam.ParDo(s, func(l *firmwareLogEntry) (uint64, *firmwareLogEntry) { return uint64(l.Index), l }, fws)
+	keyedAnns := beam.ParDo(s, func(a *annotationMalwareLogEntry) (uint64, *annotationMalwareLogEntry) {
+		return a.Annotation.FirmwareID.LogIndex, a
+	}, annotationMalwares)
+	annotations := beam.ParDo(s, aggregationFn, beam.CoGroupByKey(s, keyedFws, keyedAnns))
+	return beam.ParDo(s, &aggregatedFirmwareHashFn{treeID}, annotations), annotations
+}
+
+func aggregationFn(fwIndex uint64, fwit func(**firmwareLogEntry) bool, amit func(**annotationMalwareLogEntry) bool) (*api.AggregatedFirmware, error) {
+	// There will be exactly one firmware entry for the log index.
+	var fwle *firmwareLogEntry
+	if !fwit(&fwle) {
+		return nil, fmt.Errorf("aggregationFn for %d found no firmware", fwIndex)
+	}
+
+	// And 0-many annotations. The FW is good as long as no annotations say that it is not.
+	good := true
+	var amle *annotationMalwareLogEntry
+	for amit(&amle) {
+		good = good && amle.Annotation.Good
+	}
+
+	return &api.AggregatedFirmware{
+		Index:    fwIndex,
+		Firmware: &fwle.Firmware,
+		Good:     good,
+	}, nil
+}
+
+type aggregatedFirmwareHashFn struct {
+	TreeID int64
+}
+
+func (fn *aggregatedFirmwareHashFn) ProcessElement(afw *api.AggregatedFirmware) (*batchmap.Entry, error) {
+	// We use the Index of the FW Log Entry as the key because that's unique and what we matched on.
+	// The client already has this information from the inclusion proof so it's known information.
+	// Using `afw.Firmware.FirmwareImageSHA512` is another logical choice, but there's nothing to
+	// prevent multiple entries in the log with the same FW hash, and thus we'd have key conflicts.
+	// If we did want to use image hash as the key then we'd need to restructure FW annotations to
+	// remove the `LogIndex` from `FirmwareId`.
+	key := []byte(fmt.Sprintf("summary:%d", afw.Index))
+	value, err := json.Marshal(afw)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AggregatedFirmware failed: %v", err)
+	}
+
+	kbs := sha512.Sum512_256(key)
+	leafID := tree.NewNodeID2(string(kbs[:]), 256)
+	return &batchmap.Entry{
+		HashKey:   kbs[:],
+		HashValue: coniks.Default.HashLeaf(fn.TreeID, leafID, value),
+	}, nil
+}

--- a/binary_transparency/firmware/internal/ftmap/aggregate_test.go
+++ b/binary_transparency/firmware/internal/ftmap/aggregate_test.go
@@ -1,0 +1,116 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ftmap
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/testing/passert"
+	"github.com/apache/beam/sdks/go/pkg/beam/testing/ptest"
+	"github.com/google/trillian-examples/binary_transparency/firmware/api"
+)
+
+func TestAggregate(t *testing.T) {
+	fwEntries := []*firmwareLogEntry{
+		{Index: 0, Firmware: createFW("dummy", 400)},
+		{Index: 1, Firmware: createFW("dummy", 401)},
+	}
+	logHead := int64(len(fwEntries) - 1)
+	createAnnotationMalware := func(fwIndex int, good bool) *annotationMalwareLogEntry {
+		logHead++
+		return &annotationMalwareLogEntry{
+			Index: logHead,
+			Annotation: api.MalwareStatement{
+				FirmwareID: api.FirmwareID{
+					LogIndex:            uint64(fwIndex),
+					FirmwareImageSHA512: fwEntries[fwIndex].Firmware.FirmwareImageSHA512,
+				},
+				Good: good,
+			},
+		}
+	}
+	tests := []struct {
+		name               string
+		treeID             int64
+		annotationMalwares []*annotationMalwareLogEntry
+
+		wantGood []string
+	}{
+		{
+			name:   "No annotations",
+			treeID: 12345,
+
+			wantGood: []string{"0: true", "1: true"},
+		},
+		{
+			name:   "One bad annotation",
+			treeID: 12345,
+
+			annotationMalwares: []*annotationMalwareLogEntry{
+				createAnnotationMalware(1, false),
+			},
+
+			wantGood: []string{"0: true", "1: false"},
+		},
+		{
+			name:   "Many annotations all good",
+			treeID: 12345,
+
+			annotationMalwares: []*annotationMalwareLogEntry{
+				createAnnotationMalware(0, true),
+				createAnnotationMalware(0, true),
+			},
+
+			wantGood: []string{"0: true", "1: true"},
+		},
+		{
+			name:   "Many annotations one bad",
+			treeID: 12345,
+
+			annotationMalwares: []*annotationMalwareLogEntry{
+				createAnnotationMalware(0, true),
+				createAnnotationMalware(0, false),
+				createAnnotationMalware(0, true),
+			},
+
+			wantGood: []string{"0: false", "1: true"},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			p, s := beam.NewPipelineWithRoot()
+
+			fws := beam.CreateList(s, fwEntries)
+			annotationMalwares := beam.CreateList(s, test.annotationMalwares)
+
+			entries, aggs := Aggregate(s, test.treeID, fws, annotationMalwares)
+
+			passert.Count(s, entries, "entries", len(fwEntries))
+			passert.Count(s, aggs, "aggs", len(fwEntries))
+
+			aggregationToString := func(a *api.AggregatedFirmware) string { return fmt.Sprintf("%d: %t", a.Index, a.Good) }
+			passert.Equals(s, beam.ParDo(s, aggregationToString, aggs), beam.CreateList(s, test.wantGood))
+
+			err := ptest.Run(p)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/binary_transparency/firmware/internal/ftmap/log.go
+++ b/binary_transparency/firmware/internal/ftmap/log.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/apache/beam/sdks/go/pkg/beam"
 
+	"github.com/google/trillian-examples/binary_transparency/firmware/api"
 	"github.com/google/trillian/experimental/batchmap"
 	"github.com/google/trillian/merkle/compact"
 	"github.com/google/trillian/merkle/coniks"
@@ -33,14 +34,7 @@ import (
 func init() {
 	beam.RegisterFunction(makeDeviceReleaseLogFn)
 	beam.RegisterType(reflect.TypeOf((*moduleLogHashFn)(nil)).Elem())
-	beam.RegisterType(reflect.TypeOf((*DeviceReleaseLog)(nil)).Elem())
-}
-
-// DeviceReleaseLog represents firmware releases found for a single device ID.
-// Entries are ordered by their sequence in the original log.
-type DeviceReleaseLog struct {
-	DeviceID  string
-	Revisions []uint64
+	beam.RegisterType(reflect.TypeOf((*api.DeviceReleaseLog)(nil)).Elem())
 }
 
 // MakeReleaseLogs takes all firmwareLogEntrys and processes these by
@@ -67,7 +61,7 @@ func (fn *moduleLogHashFn) Setup() {
 	}
 }
 
-func (fn *moduleLogHashFn) ProcessElement(log *DeviceReleaseLog) (*batchmap.Entry, error) {
+func (fn *moduleLogHashFn) ProcessElement(log *api.DeviceReleaseLog) (*batchmap.Entry, error) {
 	logRange := fn.rf.NewEmptyRange(0)
 	for _, v := range log.Revisions {
 		bs := make([]byte, 8)
@@ -90,7 +84,7 @@ func (fn *moduleLogHashFn) ProcessElement(log *DeviceReleaseLog) (*batchmap.Entr
 	}, nil
 }
 
-func makeDeviceReleaseLogFn(deviceID string, lit func(**firmwareLogEntry) bool) (*DeviceReleaseLog, error) {
+func makeDeviceReleaseLogFn(deviceID string, lit func(**firmwareLogEntry) bool) (*api.DeviceReleaseLog, error) {
 	// We need to ensure ordering by sequence ID in the original log for stability.
 
 	// First consume the iterator into an in-memory list.
@@ -108,7 +102,7 @@ func makeDeviceReleaseLogFn(deviceID string, lit func(**firmwareLogEntry) bool) 
 		revisions[i] = entries[i].Firmware.FirmwareRevision
 	}
 
-	return &DeviceReleaseLog{
+	return &api.DeviceReleaseLog{
 		DeviceID:  deviceID,
 		Revisions: revisions,
 	}, nil

--- a/binary_transparency/firmware/internal/ftmap/mapdb.go
+++ b/binary_transparency/firmware/internal/ftmap/mapdb.go
@@ -55,6 +55,10 @@ func (d *MapDB) Init() error {
 	if _, err := d.db.Exec("CREATE TABLE IF NOT EXISTS logs (deviceID BLOB, revision INTEGER, leaves BLOB, PRIMARY KEY (deviceID, revision))"); err != nil {
 		return err
 	}
+	// We use an INTEGER for a boolean to make life easy across multiple DB implementations.
+	if _, err := d.db.Exec("CREATE TABLE IF NOT EXISTS aggregations (fwLogIndex INTEGER, revision INTEGER, good INTEGER, PRIMARY KEY (fwLogIndex, revision))"); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
The pipeline now creates an entry for each piece of firmware in the log with an aggregated version of the malware annotation. The aggregation rule is that it is good, and will switch to bad if there exists any malware annotation saying it is bad. We may wish to revise this to be the result of the most recent annotation, but this approach has the benefit of simplicity. And it seems like an edge-case that a release would be classified as malware, and then the scanner would change its mind.

The key in the map is derived from the Log Index of the original FW metadata, and the value is a commitment to a JSON-encoded `AggregatedFirmware`.
The map tiles and aggregated firmware are stored in a DB, but there is not currently any server for returning this data to clients.