### PR TITLE
Client sketch for map checks

### DIFF
--- a/binary_transparency/firmware/api/map.go
+++ b/binary_transparency/firmware/api/map.go
@@ -44,7 +44,7 @@ type MapCheckpoint struct {
 }
 
 // MapInclusionProof contains the value at the requested key and the proof to the
-// requested tree size.
+// requested Checkpoint.
 type MapInclusionProof struct {
 	Key   []byte
 	Value []byte

--- a/binary_transparency/firmware/api/map.go
+++ b/binary_transparency/firmware/api/map.go
@@ -14,6 +14,8 @@
 
 package api
 
+import "fmt"
+
 // AggregatedFirmware represents the results of aggregating a single piece of firmware
 // according to the rules described in #Aggregate().
 type AggregatedFirmware struct {
@@ -27,4 +29,29 @@ type AggregatedFirmware struct {
 type DeviceReleaseLog struct {
 	DeviceID  string
 	Revisions []uint64
+}
+
+// MapCheckpoint is a commitment to a map built from the FW Log at a given size.
+// The map checkpoint contains the checkpoint of the log this was built from, with
+// the number of entries consumed from that input log. This allows clients to check
+// they are seeing the same version of the log as the map was built from. This also
+// provides information to allow verifiers of the map to confirm correct construction.
+type MapCheckpoint struct {
+	LogCheckpoint LogCheckpoint
+	LogSize       uint64
+	RootHash      []byte
+	Revision      uint64
+}
+
+// MapInclusionProof contains the value at the requested key and the proof to the
+// requested tree size.
+type MapInclusionProof struct {
+	Key   []byte
+	Value []byte
+	Proof [][]byte
+}
+
+// String returns a compact printable representation of an InclusionProof.
+func (l MapInclusionProof) String() string {
+	return fmt.Sprintf("{key: 0x%x, value: 0x%x, proof: %x}", l.Key, l.Value, l.Proof)
 }

--- a/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
+++ b/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
@@ -207,7 +207,7 @@ func verifyAnnotations(c *client.ReadonlyClient, pb api.ProofBundle, fwMeta api.
 	mc := client.MapClient{}
 	mcp, err := mc.MapCheckpoint()
 	if err != nil {
-		return fmt.Errorf("failed to get map root: %w", err)
+		return fmt.Errorf("failed to get map checkpoint: %w", err)
 	}
 
 	// TODO(mhutchinson): check consistency with the largest checkpoint found thus far

--- a/binary_transparency/firmware/internal/client/mapclient.go
+++ b/binary_transparency/firmware/internal/client/mapclient.go
@@ -25,8 +25,8 @@ type MapClient struct {
 	URL *url.URL
 }
 
-func NewMapClient(mapUrl string) (*MapClient, error) {
-	u, err := url.Parse(mapUrl)
+func NewMapClient(mapURL string) (*MapClient, error) {
+	u, err := url.Parse(mapURL)
 	if err != nil {
 		return nil, err
 	}

--- a/binary_transparency/firmware/internal/client/mapclient.go
+++ b/binary_transparency/firmware/internal/client/mapclient.go
@@ -1,0 +1,63 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"errors"
+	"net/url"
+
+	"github.com/google/trillian-examples/binary_transparency/firmware/api"
+)
+
+type MapClient struct {
+	URL *url.URL
+}
+
+func NewMapClient(mapUrl string) (*MapClient, error) {
+	u, err := url.Parse(mapUrl)
+	if err != nil {
+		return nil, err
+	}
+	return &MapClient{
+		URL: u,
+	}, nil
+}
+
+// MapCheckpoint returns the Checkpoint for the latest map revision.
+// This map root needs to be taken on trust that it isn't forked etc.
+// To remove this trust, the map roots should be stored in a log, and
+// this would further return:
+// * A Log Checkpoint for the MapCheckpointLog
+// * An inclusion proof for this checkpoint within it
+func (c *MapClient) MapCheckpoint() (api.MapCheckpoint, error) {
+	// TODO(mhutchinson): http://mapserver/latest
+	return api.MapCheckpoint{}, errors.New("unimplemented")
+}
+
+// Aggregation returns the value committed to by the map under the given key,
+// with an inclusion proof.
+func (c *MapClient) Aggregation(mcp api.MapCheckpoint, fwIndex uint64) (api.AggregatedFirmware, api.MapInclusionProof, error) {
+	// TODO(mhutchinson): Fill out according to psuedocode below
+
+	// key := fmt.Sprintf("summary:%d", fwIndex)
+	// kbs := sha512.Sum512_256([]byte(key))
+	// tiles := fetch(http://mapserver/tiles/$kbs)
+	// leafhash := get the value hash at key from `tiles`
+	// Simultaneously:
+	//   * compute inclusion proof locally from tiles
+	//   * value := fetch(http://mapserver/value/$leafhash)
+	// Confirm the value returned matches the leafhash, return it all
+	return api.AggregatedFirmware{}, api.MapInclusionProof{}, errors.New("unimplemented")
+}

--- a/binary_transparency/firmware/internal/verify/bundle.go
+++ b/binary_transparency/firmware/internal/verify/bundle.go
@@ -59,8 +59,8 @@ func BundleForUpdate(bundleRaw, fwHash []byte, dc api.LogCheckpoint, cpFunc Cons
 	return proofBundle, fwMeta, nil
 }
 
-// BundleValidateRemote verifies the received bundle against a remotely retrieved checkpoint (e.g. witness).
-func BundleValidateRemote(pb api.ProofBundle, rc api.LogCheckpoint, cpFunc ConsistencyProofFunc) error {
+// BundleConsistency verifies the log checkpoint in the bundle is consistent against a given checkpoint (e.g. one fetched from a witness).
+func BundleConsistency(pb api.ProofBundle, rc api.LogCheckpoint, cpFunc ConsistencyProofFunc) error {
 	lv := NewLogVerifier()
 
 	glog.V(1).Infof("Remote TreeSize=%d, Inclusion Index=%d \n", rc.TreeSize, pb.InclusionProof.LeafIndex)

--- a/binary_transparency/firmware/internal/verify/bundle_test.go
+++ b/binary_transparency/firmware/internal/verify/bundle_test.go
@@ -57,7 +57,7 @@ func TestBundleForUpdate(t *testing.T) {
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			imgHash := sha512.Sum512(test.img)
-			_, err := verify.BundleForUpdate([]byte(goldenProofBundle), imgHash[:], dc, proof)
+			_, _, err := verify.BundleForUpdate([]byte(goldenProofBundle), imgHash[:], dc, proof)
 			if (err != nil) != test.wantErr {
 				var lve logverifier.RootMismatchError
 				if errors.As(err, &lve) {


### PR DESCRIPTION
The plan is to serve the map API primarily via a REST API. The server will use the sqlite DB for the first iteration, but the idea is that this could be swapped for static content similar to the serverless log.

This required a little rerouting to get the FWMeta back to where it could be checked.