### PR TITLE
[serverless] Add simple client tool

### DIFF
--- a/serverless/internal/client/client.go
+++ b/serverless/internal/client/client.go
@@ -34,6 +34,7 @@ import (
 // The path parameter is relative to the root of the log storage.
 type FetcherFunc func(path string) ([]byte, error)
 
+// GetLogState fetches and parses the latest LogState from the log.
 func GetLogState(f FetcherFunc) (*api.LogState, error) {
 	sRaw, err := f(layout.StatePath)
 	if err != nil {


### PR DESCRIPTION
Adds the outline of a simple client which knows how to fetch log data via `file://` or `http[s]://` URLs, and use it to compute and verify inclusion proofs.