### PR TITLE
[serverless] Use leafhash files as hash->seq index

### DIFF
--- a/serverless/internal/storage/fs/fs.go
+++ b/serverless/internal/storage/fs/fs.go
@@ -155,8 +155,8 @@ func (fs *Storage) Sequence(leafhash []byte, leaf []byte) (uint64, error) {
 		return 0, fmt.Errorf("failed to make leaf directory structure: %w", err)
 	}
 	// Check for dupe leaf already present.
-	// If there is one, it's a symlink to the sequence file, so read that back
-	// and return that sequence number.
+	// If there is one, it should contain the existing leaf's sequence number,
+	// so read that back and return it.
 	leafFQ := filepath.Join(leafDir, leafFile)
 	if seqString, err := ioutil.ReadFile(leafFQ); !os.IsNotExist(err) {
 		origSeq, err := strconv.ParseUint(string(seqString), 16, 64)


### PR DESCRIPTION
This change allows clients who only hold the leaf primage to figure out the sequence number for that leaf and build the corresponding inclusion proof.