### PR TITLE
[serverless] Extend integration test

### DIFF
--- a/serverless/integration/integration_test.go
+++ b/serverless/integration/integration_test.go
@@ -141,7 +141,6 @@ func TestServerlessViaHTTP(t *testing.T) {
 
 	// Run test
 	RunIntegration(t, fs, f)
-
 }
 
 func sequenceNLeaves(t *testing.T, s log.Storage, lh hashers.LogHasher, start, n int) [][]byte {


### PR DESCRIPTION
Adds coverage for inclusion proofs, and accessing the log via both `file://` and `http://` schemes.