### PR TITLE
Ensure MapDB is initialized when returned.

### DIFF
--- a/binary_transparency/firmware/cmd/ftmap/map.go
+++ b/binary_transparency/firmware/cmd/ftmap/map.go
@@ -104,9 +104,6 @@ func sinkFromFlags() (*ftmap.MapDB, int, error) {
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to open map DB at %q: %v", *mapDBString, err)
 	}
-	if err := mapDB.Init(); err != nil {
-		return nil, 0, fmt.Errorf("failed to Init map DB at %q: %v", *mapDBString, err)
-	}
 
 	var rev int
 	if rev, err = mapDB.NextWriteRevision(); err != nil {

--- a/binary_transparency/firmware/internal/ftmap/mapdb.go
+++ b/binary_transparency/firmware/internal/ftmap/mapdb.go
@@ -39,9 +39,10 @@ func NewMapDB(location string) (*MapDB, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &MapDB{
+	mapDB := &MapDB{
 		db: db,
-	}, nil
+	}
+	return mapDB, mapDB.Init()
 }
 
 // Init creates the database tables if needed.


### PR DESCRIPTION
All client code wants to ensure it has a valid connection to the map, so it makes sense to roll these together.