### PR TITLE
Make map checkpoint contain valid log checkpoint

### DIFF
--- a/binary_transparency/firmware/cmd/ftmapserver/impl/ftmapserver_test.go
+++ b/binary_transparency/firmware/cmd/ftmapserver/impl/ftmapserver_test.go
@@ -22,24 +22,30 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	"github.com/google/trillian/experimental/batchmap"
+	"github.com/google/trillian/types"
 )
 
 func TestRoot(t *testing.T) {
 	for _, test := range []struct {
 		desc     string
 		rev      int
-		logroot  []byte
+		logroot  types.LogRootV1
 		count    int64
 		rootHash []byte
 		wantBody string
 	}{
 		{
-			desc:     "valid 1",
-			rev:      42,
-			logroot:  []byte{0x12, 0x34},
+			desc: "valid 1",
+			rev:  42,
+			logroot: types.LogRootV1{
+				TreeSize:       42,
+				RootHash:       []byte{0x12, 0x34},
+				Revision:       2,
+				TimestampNanos: 12345,
+			},
 			count:    111,
 			rootHash: []byte{0x34, 0x12},
-			wantBody: `{"LogCheckpoint":"EjQ=","LogSize":111,"RootHash":"NBI=","Revision":42}`,
+			wantBody: `{"LogCheckpoint":"eyJUcmVlU2l6ZSI6NDIsIlJvb3RIYXNoIjoiRWpRPSIsIlRpbWVzdGFtcE5hbm9zIjoxMjM0NX0=","LogSize":111,"RootHash":"NBI=","Revision":42}`,
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {

--- a/binary_transparency/firmware/cmd/ftmapserver/impl/mock_mapreader.go
+++ b/binary_transparency/firmware/cmd/ftmapserver/impl/mock_mapreader.go
@@ -8,6 +8,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	batchmap "github.com/google/trillian/experimental/batchmap"
+	types "github.com/google/trillian/types"
 )
 
 // MockMapReader is a mock of MapReader interface.
@@ -34,11 +35,11 @@ func (m *MockMapReader) EXPECT() *MockMapReaderMockRecorder {
 }
 
 // LatestRevision mocks base method.
-func (m *MockMapReader) LatestRevision() (int, []byte, int64, error) {
+func (m *MockMapReader) LatestRevision() (int, types.LogRootV1, int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LatestRevision")
 	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].([]byte)
+	ret1, _ := ret[1].(types.LogRootV1)
 	ret2, _ := ret[2].(int64)
 	ret3, _ := ret[3].(error)
 	return ret0, ret1, ret2, ret3

--- a/binary_transparency/firmware/internal/ftmap/pipeline.go
+++ b/binary_transparency/firmware/internal/ftmap/pipeline.go
@@ -44,6 +44,7 @@ func init() {
 // InputLog allows access to entries from the FT Log.
 type InputLog interface {
 	// Head returns the metadata of available entries.
+	// The log checkpoint is a serialized LogRootV1.
 	Head() (checkpoint []byte, count int64, err error)
 	// Entries returns a PCollection of InputLogLeaf, containing entries in range [start, end).
 	Entries(s beam.Scope, start, end int64) beam.PCollection


### PR DESCRIPTION
The log checkpoint was actually just a hash. We now persist it as a LogRootV1, and then convert that into an api.LogCheckpoint in the server.