### PR TITLE
Allow flash tool to actually call the map server

### DIFF
--- a/binary_transparency/firmware/cmd/flash_tool/flash_tool.go
+++ b/binary_transparency/firmware/cmd/flash_tool/flash_tool.go
@@ -35,6 +35,7 @@ import (
 var (
 	deviceID      = flag.String("device", "", "One of [dummy, armory]")
 	logURL        = flag.String("log_url", "http://localhost:8000", "Base URL of the log HTTP API")
+	mapURL        = flag.String("map_url", "", "Base URL of the map HTTP API. Map checks are not performed if this is absent.")
 	witnessURL    = flag.String("witness_url", "", "Base URL of the Witness, or empty if no witness checks needed")
 	updateFile    = flag.String("update_file", "", "File path to read the update package from")
 	force         = flag.Bool("force", false, "Ignore errors and force update")
@@ -47,6 +48,7 @@ func main() {
 	if err := impl.Main(impl.FlashOpts{
 		DeviceID:      *deviceID,
 		LogURL:        *logURL,
+		MapURL:        *mapURL,
 		WitnessURL:    *witnessURL,
 		UpdateFile:    *updateFile,
 		Force:         *force,

--- a/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
+++ b/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
@@ -84,7 +84,7 @@ func Main(opts FlashOpts) error {
 	if len(opts.MapURL) > 0 {
 		err := verifyAnnotations(c, pb, fwMeta, opts.MapURL)
 		if !opts.Force {
-			return err
+			return fmt.Errorf("verifyAnnotations: %w", err)
 		}
 		glog.Warning(err)
 	}
@@ -204,11 +204,15 @@ func verifyWitness(c *client.ReadonlyClient, pb api.ProofBundle, witnessURL stri
 }
 
 func verifyAnnotations(c *client.ReadonlyClient, pb api.ProofBundle, fwMeta api.FirmwareMetadata, mapURL string) error {
-	mc := client.MapClient{}
+	mc, err := client.NewMapClient(mapURL)
+	if err != nil {
+		return fmt.Errorf("failed to create map client: %w", err)
+	}
 	mcp, err := mc.MapCheckpoint()
 	if err != nil {
 		return fmt.Errorf("failed to get map checkpoint: %w", err)
 	}
+	glog.V(1).Infof("%s", mcp.LogCheckpoint)
 	var lcp api.LogCheckpoint
 	if err := json.Unmarshal(mcp.LogCheckpoint, &lcp); err != nil {
 		return fmt.Errorf("failed to unmarshal log checkpoint: %w", err)


### PR DESCRIPTION
This checks the log checkpoint in the map checkpoint is good and consistent with the log checkpoint otherwise relied on. It currently then fails because the inclusion proof is not yet implemented. Fortunately, the map checks are skipped entirely if the map_url flag is not provided.