### PR TITLE
Remove unused nested field

### DIFF
--- a/binary_transparency/firmware/api/map.go
+++ b/binary_transparency/firmware/api/map.go
@@ -24,9 +24,8 @@ const (
 // AggregatedFirmware represents the results of aggregating a single piece of firmware
 // according to the rules described in #Aggregate().
 type AggregatedFirmware struct {
-	Index    uint64
-	Firmware *FirmwareMetadata
-	Good     bool
+	Index uint64
+	Good  bool
 }
 
 // DeviceReleaseLog represents firmware releases found for a single device ID.

--- a/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
+++ b/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"reflect"
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/binary_transparency/firmware/api"
@@ -229,9 +228,6 @@ func verifyAnnotations(c *client.ReadonlyClient, pb api.ProofBundle, fwMeta api.
 	afw, _, err := mc.Aggregation(mcp, pb.InclusionProof.LeafIndex)
 	if err != nil {
 		return fmt.Errorf("failed to get map value for %q: %w", pb.InclusionProof.LeafIndex, err)
-	}
-	if !reflect.DeepEqual(fwMeta, *afw.Firmware) {
-		return fmt.Errorf("got aggregated response for %q, but expected %q", afw.Firmware, fwMeta)
 	}
 	if !afw.Good {
 		return errors.New("firmware is marked as bad")

--- a/binary_transparency/firmware/internal/ftmap/aggregate.go
+++ b/binary_transparency/firmware/internal/ftmap/aggregate.go
@@ -63,9 +63,8 @@ func aggregationFn(fwIndex uint64, fwit func(**firmwareLogEntry) bool, amit func
 	}
 
 	return &api.AggregatedFirmware{
-		Index:    fwIndex,
-		Firmware: &fwle.Firmware,
-		Good:     good,
+		Index: fwIndex,
+		Good:  good,
 	}, nil
 }
 

--- a/binary_transparency/firmware/internal/ftmap/mapdb.go
+++ b/binary_transparency/firmware/internal/ftmap/mapdb.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/trillian-examples/binary_transparency/firmware/api"
 	"github.com/google/trillian/experimental/batchmap"
 	"github.com/google/trillian/types"
 )
@@ -104,6 +105,18 @@ func (d *MapDB) Tile(revision int, path []byte) (*batchmap.Tile, error) {
 		return nil, fmt.Errorf("failed to parse tile at revision=%d, path=%x: %v", revision, path, err)
 	}
 	return tile, nil
+}
+
+// Aggregation gets the aggregation for the firmware at the given log index.
+func (d *MapDB) Aggregation(revision int, fwLogIndex uint64) (api.AggregatedFirmware, error) {
+	var good int
+	if err := d.db.QueryRow("SELECT good FROM aggregations WHERE fwLogIndex=? AND revision=?", fwLogIndex, revision).Scan(&good); err != nil {
+		return api.AggregatedFirmware{}, err
+	}
+	return api.AggregatedFirmware{
+		Index: fwLogIndex,
+		Good:  good > 0,
+	}, nil
 }
 
 // WriteRevision writes the metadata for a completed run into the database.

--- a/binary_transparency/firmware/internal/ftmap/pipeline_test.go
+++ b/binary_transparency/firmware/internal/ftmap/pipeline_test.go
@@ -41,7 +41,7 @@ func TestCreate(t *testing.T) {
 			treeID: 12345,
 			count:  1,
 
-			wantRoot: "825bf65fd8fe537c6e39836405fbe86b457d08890c21e8abd3b39190fff643fe",
+			wantRoot: "865bbd0034750dd6abe512470722fad51c85ba95d96316818e8ec8a2a55679c0",
 			wantLogs: []string{"dummy: [1]"},
 		},
 		{
@@ -49,7 +49,7 @@ func TestCreate(t *testing.T) {
 			treeID: 12345,
 			count:  -1,
 
-			wantRoot: "496c3192b94184786e899d8199bd92106cb6e669fbe5b113e29378d56d295f6d",
+			wantRoot: "daa0e0c66d69162abbe27ba9aa54a8bdb8850f1100e0626e45ea477cea4765e6",
 			wantLogs: []string{"dummy: [1 5 3]", "fish: [42]"},
 		},
 	}


### PR DESCRIPTION
Keeping this forces the map server to be able to return the raw log entries. This could be done, but requires either a connection to another DB, or duplicating data. Furthermore, the client already has this data and was just asserting equality. Given that we've already checked log consistency, we're already convinced we have the same view of the log data.