### PR TITLE
Implemented map server methods

### DIFF
--- a/binary_transparency/firmware/api/map.go
+++ b/binary_transparency/firmware/api/map.go
@@ -19,6 +19,10 @@ import "fmt"
 const (
 	// MapHTTPGetCheckpoint is the path of the URL to get a recent map checkpoint.
 	MapHTTPGetCheckpoint = "ftmap/v0/get-checkpoint"
+	// MapHTTPGetTile is the path of the URL to get a map tile at a revision.
+	MapHTTPGetTile = "ftmap/v0/tile"
+	// MapHTTPGetAggregation is the path of the URL to get aggregated FW info.
+	MapHTTPGetAggregation = "ftmap/v0/aggregation"
 )
 
 // AggregatedFirmware represents the results of aggregating a single piece of firmware
@@ -46,6 +50,25 @@ type MapCheckpoint struct {
 	LogSize       uint64
 	RootHash      []byte
 	Revision      uint64
+}
+
+// MapTile is a subtree of the whole map.
+type MapTile struct {
+	// The path from the root of the map to the root of this tile.
+	Path []byte
+	// All non-empty leaves in this tile, sorted left-to-right.
+	Leaves []MapTileLeaf
+}
+
+// MapTileLeaf is a leaf value of a MapTile.
+// If it belongs to a leaf tile then this represents one of the values that the
+// map commits to. Otherwise, this leaf represents the root of the subtree in
+// the stratum below.
+type MapTileLeaf struct {
+	// The path from the root of the container MapTile to this leaf.
+	Path []byte
+	// The hash value being committed to.
+	Hash []byte
 }
 
 // MapInclusionProof contains the value at the requested key and the proof to the

--- a/binary_transparency/firmware/cmd/ftmapserver/impl/ftmapserver.go
+++ b/binary_transparency/firmware/cmd/ftmapserver/impl/ftmapserver.go
@@ -17,10 +17,12 @@ package impl
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/binary_transparency/firmware/api"
@@ -39,6 +41,9 @@ type MapReader interface {
 
 	// Tile gets the tile at the given path in the given revision of the map.
 	Tile(revision int, path []byte) (*batchmap.Tile, error)
+
+	// Aggregation gets the aggregation for the firmware at the given log index.
+	Aggregation(revision int, fwLogIndex uint64) (api.AggregatedFirmware, error)
 }
 
 // MapServerOpts encapsulates options for running an FT map server.
@@ -119,7 +124,93 @@ func (s *Server) getCheckpoint(w http.ResponseWriter, r *http.Request) {
 	w.Write(js)
 }
 
+// getTile returns the tile at the given revision & path.
+func (s *Server) getTile(w http.ResponseWriter, r *http.Request) {
+	rev, err := parseIntParam(r, "revision")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	path, err := parseBase64Param(r, "path")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	bmt, err := s.db.Tile(int(rev), path)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	leaves := make([]api.MapTileLeaf, len(bmt.Leaves))
+	for i, l := range bmt.Leaves {
+		leaves[i] = api.MapTileLeaf{
+			Path: l.Path,
+			Hash: l.Hash,
+		}
+	}
+	tile := api.MapTile{
+		Path:   bmt.Path,
+		Leaves: leaves,
+	}
+	js, err := json.Marshal(tile)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(js)
+}
+
+// getAggregation returns the aggregation for the firware at the given log index.
+func (s *Server) getAggregation(w http.ResponseWriter, r *http.Request) {
+	rev, err := parseIntParam(r, "revision")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	fwIndex, err := parseIntParam(r, "fwIndex")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	agg, err := s.db.Aggregation(int(rev), fwIndex)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	js, err := json.Marshal(agg)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(js)
+}
+
 // RegisterHandlers registers HTTP handlers for the endpoints.
 func (s *Server) RegisterHandlers(r *mux.Router) {
 	r.HandleFunc(fmt.Sprintf("/%s", api.MapHTTPGetCheckpoint), s.getCheckpoint).Methods("GET")
+	// Empty tile path is normal for requesting the root tile
+	r.HandleFunc(fmt.Sprintf("/%s/in-revision/{revision:[0-9]+}/at-path/", api.MapHTTPGetTile), s.getTile).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/in-revision/{revision:[0-9]+}/at-path/{path}", api.MapHTTPGetTile), s.getTile).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/in-revision/{revision:[0-9]+}/for-firmware-at-index/{fwIndex:[0-9]+}", api.MapHTTPGetAggregation), s.getAggregation).Methods("GET")
+}
+
+func parseBase64Param(r *http.Request, name string) ([]byte, error) {
+	v := mux.Vars(r)
+	b, err := base64.URLEncoding.DecodeString(v[name])
+	if err != nil {
+		return nil, fmt.Errorf("%s should be URL-safe base64 (%q)", name, err)
+	}
+	return b, nil
+}
+
+func parseIntParam(r *http.Request, name string) (uint64, error) {
+	v := mux.Vars(r)
+	i, err := strconv.ParseUint(v[name], 0, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%s should be an integer (%q)", name, err)
+	}
+	return i, nil
 }

--- a/binary_transparency/firmware/cmd/ftmapserver/impl/ftmapserver.go
+++ b/binary_transparency/firmware/cmd/ftmapserver/impl/ftmapserver.go
@@ -126,7 +126,7 @@ func (s *Server) getCheckpoint(w http.ResponseWriter, r *http.Request) {
 
 // getTile returns the tile at the given revision & path.
 func (s *Server) getTile(w http.ResponseWriter, r *http.Request) {
-	rev, err := parseIntParam(r, "revision")
+	rev, err := parseUintParam(r, "revision")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -163,12 +163,12 @@ func (s *Server) getTile(w http.ResponseWriter, r *http.Request) {
 
 // getAggregation returns the aggregation for the firware at the given log index.
 func (s *Server) getAggregation(w http.ResponseWriter, r *http.Request) {
-	rev, err := parseIntParam(r, "revision")
+	rev, err := parseUintParam(r, "revision")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	fwIndex, err := parseIntParam(r, "fwIndex")
+	fwIndex, err := parseUintParam(r, "fwIndex")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -206,7 +206,7 @@ func parseBase64Param(r *http.Request, name string) ([]byte, error) {
 	return b, nil
 }
 
-func parseIntParam(r *http.Request, name string) (uint64, error) {
+func parseUintParam(r *http.Request, name string) (uint64, error) {
 	v := mux.Vars(r)
 	i, err := strconv.ParseUint(v[name], 0, 64)
 	if err != nil {

--- a/binary_transparency/firmware/cmd/ftmapserver/impl/mock_mapreader.go
+++ b/binary_transparency/firmware/cmd/ftmapserver/impl/mock_mapreader.go
@@ -7,6 +7,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	api "github.com/google/trillian-examples/binary_transparency/firmware/api"
 	batchmap "github.com/google/trillian/experimental/batchmap"
 	types "github.com/google/trillian/types"
 )
@@ -32,6 +33,21 @@ func NewMockMapReader(ctrl *gomock.Controller) *MockMapReader {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMapReader) EXPECT() *MockMapReaderMockRecorder {
 	return m.recorder
+}
+
+// Aggregation mocks base method.
+func (m *MockMapReader) Aggregation(arg0 int, arg1 uint64) (api.AggregatedFirmware, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Aggregation", arg0, arg1)
+	ret0, _ := ret[0].(api.AggregatedFirmware)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Aggregation indicates an expected call of Aggregation.
+func (mr *MockMapReaderMockRecorder) Aggregation(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Aggregation", reflect.TypeOf((*MockMapReader)(nil).Aggregation), arg0, arg1)
 }
 
 // LatestRevision mocks base method.

--- a/binary_transparency/firmware/internal/client/mapclient.go
+++ b/binary_transparency/firmware/internal/client/mapclient.go
@@ -69,13 +69,16 @@ func (c *MapClient) MapCheckpoint() (api.MapCheckpoint, error) {
 func (c *MapClient) Aggregation(mcp api.MapCheckpoint, fwIndex uint64) (api.AggregatedFirmware, api.MapInclusionProof, error) {
 	// TODO(mhutchinson): Fill out according to psuedocode below
 
+	// Simultaneously fetch all tiles:
 	// key := fmt.Sprintf("summary:%d", fwIndex)
 	// kbs := sha512.Sum512_256([]byte(key))
-	// tiles := fetch(http://mapserver/tiles/$kbs)
-	// leafhash := get the value hash at key from `tiles`
-	// Simultaneously:
-	//   * compute inclusion proof locally from tiles
-	//   * value := fetch(http://mapserver/value/$leafhash)
+	// for _, path := range tilePathsForKey(kbs) {
+	//   tiles += fetch(http://mapserver/ftmap/v0/tile/in-revision/$mcp.Revision/at-path/$path)
+	// }
+
+	// In parallel to the above:
+	// agg := fetch(http://mapserver/ftmap/v0/aggregation/in-revision/$mcp.Revision/for-firmware-at-index/$fwIndex)
+
 	// Confirm the value returned matches the leafhash, return it all
 	return api.AggregatedFirmware{}, api.MapInclusionProof{}, errors.New("unimplemented")
 }


### PR DESCRIPTION
The map server now supports:
 * lookup of tiles by the path to the root of the tile
 * getting an aggregation for FW logged at a given index

Updated the client pseudocode to better match the shape of the server API.

This is based on top of #302.