### PR TITLE
Flash tool uses aggregations from map to check for malware

### DIFF
--- a/binary_transparency/firmware/api/map.go
+++ b/binary_transparency/firmware/api/map.go
@@ -23,6 +23,11 @@ const (
 	MapHTTPGetTile = "ftmap/v0/tile"
 	// MapHTTPGetAggregation is the path of the URL to get aggregated FW info.
 	MapHTTPGetAggregation = "ftmap/v0/aggregation"
+
+	// MapPrefixStrata is the number of prefix strata in the FT map.
+	MapPrefixStrata = 1
+	// MapTreeID is the unique tree ID salted into the map's hash functions.
+	MapTreeID = 12345
 )
 
 // AggregatedFirmware represents the results of aggregating a single piece of firmware
@@ -76,6 +81,9 @@ type MapTileLeaf struct {
 type MapInclusionProof struct {
 	Key   []byte
 	Value []byte
+	// Proof is all of the sibling hashes down the path, keyed by the bit length of the parent node ID.
+	// A nil entry means that this branch is empty.
+	// The parent node ID is used because the root does not have a sibling.
 	Proof [][]byte
 }
 

--- a/binary_transparency/firmware/cmd/flash_tool/flash_tool.go
+++ b/binary_transparency/firmware/cmd/flash_tool/flash_tool.go
@@ -26,6 +26,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 
 	"github.com/golang/glog"
@@ -45,7 +46,7 @@ var (
 func main() {
 	flag.Parse()
 
-	if err := impl.Main(impl.FlashOpts{
+	if err := impl.Main(context.Background(), impl.FlashOpts{
 		DeviceID:      *deviceID,
 		LogURL:        *logURL,
 		MapURL:        *mapURL,

--- a/binary_transparency/firmware/cmd/ftmap/map.go
+++ b/binary_transparency/firmware/cmd/ftmap/map.go
@@ -44,8 +44,6 @@ var (
 	trillianMySQL = flag.String("trillian_mysql", "", "The connection string to the Trillian MySQL database.")
 	mapDBString   = flag.String("map_db", "", "Connection path for output database where the map tiles will be written.")
 	count         = flag.Int64("count", -1, "The total number of entries starting from the beginning of the log to use, or -1 to use all. This can be used to independently create maps of the same size.")
-	treeID        = flag.Int64("tree_id", 12345, "The ID of the tree. Used as a salt in hashing.")
-	prefixStrata  = flag.Int("prefix_strata", 2, "The number of strata of 8-bit strata before the final strata.")
 	batchSize     = flag.Int("write_batch_size", 250, "Number of tiles to write per batch")
 )
 
@@ -68,7 +66,9 @@ func main() {
 		glog.Exitf("Failed to initialize Map DB: %v", err)
 	}
 
-	pb := ftmap.NewMapBuilder(trillianDB, *treeID, *prefixStrata)
+	// The tree & strata config is part of the API for clients. If we make this configurable then
+	// there needs to be some dynamic way to get this to clients (e.g. in a MapCheckpoint).
+	pb := ftmap.NewMapBuilder(trillianDB, api.MapTreeID, api.MapPrefixStrata)
 
 	beam.Init()
 	beamlog.SetLogger(&BeamGLogger{InfoLogAtVerbosity: 2})

--- a/binary_transparency/firmware/integration/ft_integration_test.go
+++ b/binary_transparency/firmware/integration/ft_integration_test.go
@@ -99,7 +99,7 @@ func TestFTIntegration(t *testing.T) {
 		}, {
 			desc: "Force flashing device (init)",
 			step: func() error {
-				return i_flash.Main(i_flash.FlashOpts{
+				return i_flash.Main(ctx, i_flash.FlashOpts{
 					LogURL:        pAddr,
 					WitnessURL:    "",
 					DeviceID:      "dummy",
@@ -130,7 +130,7 @@ func TestFTIntegration(t *testing.T) {
 		}, {
 			desc: "Flashing device (update)",
 			step: func() error {
-				return i_flash.Main(i_flash.FlashOpts{
+				return i_flash.Main(ctx, i_flash.FlashOpts{
 					LogURL:        pAddr,
 					WitnessURL:    "",
 					DeviceID:      "dummy",
@@ -236,7 +236,7 @@ func TestFTIntegration(t *testing.T) {
 				<-time.After(5 * time.Second)
 				// Now flash the bundle normally, it will install because it's been logged
 				// and so is now discoverable.
-				if err := i_flash.Main(i_flash.FlashOpts{
+				if err := i_flash.Main(ctx, i_flash.FlashOpts{
 					LogURL:        pAddr,
 					WitnessURL:    "",
 					DeviceID:      "dummy",
@@ -292,7 +292,7 @@ func TestFTIntegration(t *testing.T) {
 				// Wait witness to view the device checkpoint
 				<-time.After(5 * time.Second)
 
-				if err := i_flash.Main(i_flash.FlashOpts{
+				if err := i_flash.Main(ctx, i_flash.FlashOpts{
 					LogURL:        pAddr,
 					WitnessURL:    wAddr,
 					DeviceID:      "dummy",

--- a/binary_transparency/firmware/internal/client/mapclient_test.go
+++ b/binary_transparency/firmware/internal/client/mapclient_test.go
@@ -1,0 +1,160 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/trillian-examples/binary_transparency/firmware/api"
+	"github.com/google/trillian-examples/binary_transparency/firmware/internal/client"
+)
+
+func TestMapCheckpoint(t *testing.T) {
+	for _, test := range []struct {
+		desc    string
+		body    string
+		want    api.MapCheckpoint
+		wantErr bool
+	}{
+		{
+			desc: "valid 1",
+			body: `{ "Revision": 42, "LogSize": 1, "LogCheckpoint": "QyE=", "RootHash": "EjQ="}`,
+			want: api.MapCheckpoint{Revision: 42, LogSize: 1, LogCheckpoint: []byte{0x43, 0x21}, RootHash: []byte{0x12, 0x34}},
+		}, {
+			desc: "valid 2",
+			body: `{ "Revision": 42, "LogSize": 10, "LogCheckpoint": "/u1C", "RootHash": "NBI="}`,
+			want: api.MapCheckpoint{Revision: 42, LogSize: 10, LogCheckpoint: []byte{0xfe, 0xed, 0x42}, RootHash: []byte{0x34, 0x12}},
+		}, {
+			desc:    "garbage",
+			body:    `garbage`,
+			wantErr: true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasSuffix(r.URL.Path, api.MapHTTPGetCheckpoint) {
+					t.Fatalf("Got unexpected HTTP request on %q", r.URL.Path)
+				}
+				fmt.Fprintln(w, test.body)
+			}))
+			defer ts.Close()
+
+			c, err := client.NewMapClient(ts.URL)
+			if err != nil {
+				t.Fatalf("Failed to create client: %q", err)
+			}
+			cp, err := c.MapCheckpoint()
+			switch {
+			case err != nil && !test.wantErr:
+				t.Fatalf("Got unexpected error %q", err)
+			case err == nil && test.wantErr:
+				t.Fatal("Got no error, but wanted error")
+			case err != nil && test.wantErr:
+				// expected error
+			default:
+				if d := cmp.Diff(cp, test.want); len(d) != 0 {
+					t.Fatalf("Got checkpoint with diff: %s", d)
+				}
+			}
+		})
+	}
+}
+
+func TestAggregation(t *testing.T) {
+	for _, test := range []struct {
+		desc       string
+		rev, index uint64
+		bodies     map[string]string
+		wantAgg    api.AggregatedFirmware
+		wantErr    bool
+	}{
+		{
+			desc:  "valid 1",
+			rev:   1,
+			index: 0,
+			bodies: map[string]string{
+				"/ftmap/v0/tile/in-revision/1/at-path/":                       `{"Path":"","Leaves":[{"Path":"Rg==","Hash":"M7DmUN5R2auo88WMjg+EcijUzfX085QdHuTzx7Rrwgs="},{"Path":"7A==","Hash":"fK4jTvvbd90D29jYrsBrmWNG83416K1WhgS5T5qYpEI="}]}`,
+				"/ftmap/v0/tile/in-revision/1/at-path/Rg==":                   `{"Path":"Rg==","Leaves":[{"Path":"IRCmyCYwSorPfJ/NXqlkZdVYvs4KKtRYuV27zLJjCg==","Hash":"sE0GFv87tf0j7YciRBVFk4pFKExwVRhwykxdPz70Dxw="}]}`,
+				"/ftmap/v0/aggregation/in-revision/1/for-firmware-at-index/0": `{"Index":0,"Good":true}`,
+			},
+			wantAgg: api.AggregatedFirmware{
+				Index: 0,
+				Good:  true,
+			},
+		}, {
+			desc:  "valid 2",
+			rev:   2,
+			index: 1,
+			bodies: map[string]string{
+				"/ftmap/v0/tile/in-revision/2/at-path/":                       `{"Path":"","Leaves":[{"Path":"Rg==","Hash":"M7DmUN5R2auo88WMjg+EcijUzfX085QdHuTzx7Rrwgs="},{"Path":"7A==","Hash":"fK4jTvvbd90D29jYrsBrmWNG83416K1WhgS5T5qYpEI="}]}`,
+				"/ftmap/v0/tile/in-revision/2/at-path/7A==":                   `{"Path":"7A==","Leaves":[{"Path":"Kk19hKuMqnXxlJGG0LQ5y8LbzyPhmCCDMxRmPAowFw==","Hash":"+d6n+Cubqrkvx6vwQg0f2M3ZPub3a8jf/HICam0T3sM="},{"Path":"z+HuPYEme3qpfllqffSoL8jKc8VLtf3njh/nVoksCA==","Hash":"rxQDwfN/PhVD+lF2FtVkzUb9ha1G+4OHE7ZaIvSow9Y="}]}`,
+				"/ftmap/v0/aggregation/in-revision/2/for-firmware-at-index/1": `{"Index":1,"Good":false}`,
+			},
+			wantAgg: api.AggregatedFirmware{
+				Index: 1,
+				Good:  false,
+			},
+		}, {
+			desc:  "garbage",
+			rev:   42,
+			index: 22,
+			bodies: map[string]string{
+				"/ftmap/v0/tile/in-revision/42/at-path/":                        `moose`,
+				"/ftmap/v0/tile/in-revision/42/at-path/RA==":                    `loose`,
+				"/ftmap/v0/aggregation/in-revision/42/for-firmware-at-index/22": `house`,
+			},
+			wantErr: true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if body, ok := test.bodies[r.URL.Path]; ok {
+					fmt.Fprintln(w, body)
+				} else {
+					t.Fatalf("Got unexpected HTTP request on %q", r.URL.Path)
+				}
+			}))
+			defer ts.Close()
+
+			c, err := client.NewMapClient(ts.URL)
+			if err != nil {
+				t.Fatalf("Failed to create client: %q", err)
+			}
+			agg, proof, err := c.Aggregation(context.Background(), test.rev, test.index)
+			switch {
+			case err != nil && !test.wantErr:
+				t.Fatalf("Got unexpected error %q", err)
+			case err == nil && test.wantErr:
+				t.Fatal("Got no error, but wanted error")
+			case err != nil && test.wantErr:
+				// expected error
+			default:
+				if d := cmp.Diff(agg, test.wantAgg); len(d) != 0 {
+					t.Errorf("Got aggregation with diff: %s", d)
+				}
+				// TODO(mhutchinson): more fully test the generated inclusion proof.
+				if proof.Key == nil || proof.Value == nil || len(proof.Proof) != 256 {
+					t.Errorf("Generated proof is malformed: %+v", proof)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
The map checkpoint and tiles are now fetched from the server. `mapclient` generates a compact inclusion proof from this data, which is then verified by `flash_tool`.

This architecture is belt and braces, but my thinking evolved during this PR. Initially the plan was to have a very simple server which could work like the "serverless" log and just serve static content. However, as I started to write the map client, I realized that this pushed a lot of work onto the clients, which might have limited compute power. I've thus written the logic in the `mapclient` as effectively untrusted, which means that this work could be done on a server, meaning much less hashing and space requirements for the verifying client.

Raising this as a draft PR to get an early review on this approach, before I write the tests that are missing.