### PR TITLE
[serverless] Remove compact range hashes from log state file

### DIFF
--- a/serverless/api/state.go
+++ b/serverless/api/state.go
@@ -22,9 +22,6 @@ type LogState struct {
 
 	// SHA256 log root, RFC6962 flavour.
 	RootHash []byte
-
-	// Hashes are the roots of the minimal set of perfect subtrees contained by this log.
-	Hashes [][]byte
 }
 
 // Tile represents a subtree tile, containing inner nodes of a log tree.

--- a/serverless/internal/storage/fs/fs.go
+++ b/serverless/internal/storage/fs/fs.go
@@ -107,7 +107,6 @@ func Create(rootDir string, emptyHash []byte) (*Storage, error) {
 	logState := api.LogState{
 		Size:     0,
 		RootHash: emptyHash,
-		Hashes:   [][]byte{},
 	}
 
 	if err := fs.UpdateState(logState); err != nil {

--- a/serverless/internal/storage/fs/fs_test.go
+++ b/serverless/internal/storage/fs/fs_test.go
@@ -44,9 +44,6 @@ func TestCreate(t *testing.T) {
 	if got, want := ls.RootHash, empty; !bytes.Equal(got, want) {
 		t.Errorf("New logstate roothash %x, want %x", got, want)
 	}
-	if got, want := len(ls.Hashes), 0; got != want {
-		t.Errorf("New logstate hashes is size %d, want %d", got, want)
-	}
 }
 
 func TestCreateForExistingDirectory(t *testing.T) {


### PR DESCRIPTION
Storing the compact range hashes in the log state file could be seen as an optimisation, but it's not _strictly_ necessary as we can calculate and fetch the tiles/nodes based on the state's `Size` alone.

So for now at least, and to bring the log state file closer to the common minimal set of fields, remove these hashes from the on-disk state.