### PR TITLE
[serverless] Store tiles in a slightly leaner format than JSON

### DIFF
--- a/serverless/api/state_test.go
+++ b/serverless/api/state_test.go
@@ -16,9 +16,11 @@
 package api_test
 
 import (
+	"crypto/rand"
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian-examples/serverless/api"
 )
 
@@ -47,5 +49,42 @@ func TestNodeKey(t *testing.T) {
 				t.Fatalf("got %d want %d", got, want)
 			}
 		})
+	}
+}
+
+func emptyHashes(n uint) [][]byte {
+	r := make([][]byte, n)
+	for i := range r {
+		r[i] = make([]byte, 32)
+	}
+	return r
+}
+
+func TestMarshalTileRoundtrip(t *testing.T) {
+	tile := api.Tile{
+		Nodes: make([][]byte, 0, 256),
+	}
+	for i := 1; i < 256; i++ {
+		tile.NumLeaves = uint(i)
+		idx := api.TileNodeKey(0, uint64(i-1))
+		if l := uint(len(tile.Nodes)); idx >= l {
+			tile.Nodes = append(tile.Nodes, emptyHashes(idx-l+1)...)
+		}
+		// Fill in the leaf index
+		rand.Read(tile.Nodes[idx])
+
+		raw, err := tile.MarshalText()
+		if err != nil {
+			t.Fatalf("MarshalText() = %v", err)
+		}
+
+		tile2 := api.Tile{}
+		if err := tile2.UnmarshalText(raw); err != nil {
+			t.Fatalf("UnmarshalText() = %v", err)
+		}
+
+		if diff := cmp.Diff(tile, tile2); len(diff) != 0 {
+			t.Fatalf("Got tile with diff: %s", diff)
+		}
 	}
 }

--- a/serverless/internal/client/client.go
+++ b/serverless/internal/client/client.go
@@ -232,7 +232,7 @@ func newTileFetcher(f FetcherFunc) GetTileFunc {
 		}
 
 		var tile api.Tile
-		if err := json.Unmarshal(t, &tile); err != nil {
+		if err := tile.UnmarshalText(t); err != nil {
 			return nil, fmt.Errorf("failed to parse tile: %w", err)
 		}
 		return &tile, nil

--- a/serverless/internal/log/integrate.go
+++ b/serverless/internal/log/integrate.go
@@ -183,14 +183,18 @@ func (tc tileCache) Visit(id compact.NodeID, hash []byte) {
 			// This is a brand new tile.
 			created = true
 			tile = &api.Tile{
-				Nodes: make([][]byte, 256*2),
+				Nodes: make([][]byte, 0, 256*2),
 			}
 		}
 		glog.V(1).Infof("GetTile: %v new: %v", tileKey, created)
 		tc.m[tileKey] = tile
 	}
 	// Update the tile with the new node hash.
-	tile.Nodes[api.TileNodeKey(nodeLevel, nodeIndex)] = hash
+	idx := api.TileNodeKey(nodeLevel, nodeIndex)
+	if l := uint(len(tile.Nodes)); idx >= l {
+		tile.Nodes = append(tile.Nodes, make([][]byte, idx-l+1)...)
+	}
+	tile.Nodes[idx] = hash
 	// Update the number of 'tile leaves', if necessary.
 	if nodeLevel == 0 && nodeIndex >= uint64(tile.NumLeaves) {
 		tile.NumLeaves = uint(nodeIndex + 1)

--- a/serverless/internal/storage/fs/fs.go
+++ b/serverless/internal/storage/fs/fs.go
@@ -276,7 +276,7 @@ func (fs *Storage) GetTile(level, index, logSize uint64) (*api.Tile, error) {
 	}
 
 	var tile api.Tile
-	if err := json.Unmarshal(t, &tile); err != nil {
+	if err := tile.UnmarshalText(t); err != nil {
 		return nil, fmt.Errorf("failed to parse tile: %w", err)
 	}
 	return &tile, nil
@@ -292,7 +292,7 @@ func (fs *Storage) StoreTile(level, index uint64, tile *api.Tile) error {
 	if tileSize == 0 || tileSize > 256 {
 		return fmt.Errorf("tileSize %d must be > 0 and <= 256", tileSize)
 	}
-	t, err := json.Marshal(tile)
+	t, err := tile.MarshalText()
 	if err != nil {
 		return fmt.Errorf("failed to marshal tile: %w", err)
 	}


### PR DESCRIPTION
This PR implements a simple custom text format for serialising the log tiles, rather than directly using JSON.
The format is trying to find a sweet spot between a full binary representation and something which is easy to read/debug but without too much extra clutter.

An example tile in this format looks like this:
```
32
4
qsZs16ec5AEtgHYv6O7Dp38i0cpBRcP0zuAi5+/NWZ0=
z9+lOZmJFyF/Mpcpq483zbJbCGFye9Qq0qH5xQ+3UyM=
ycWD0Xb0jgtbC1nQ6Of7QWpFxlASqs3nQC0vmQ8mxcw=
qiSZ0B/Hha39/LXy6yETE+CZxGE0SDtDM2IjhxLOGAo=
hd9aDSQrndkekVXXrt2weXcStDte0WrHMwKwHZCQLo4=
XnuygG2bXSR9CnvgLx9AlExUsMD1pm9ouR2l1KwsQE4=
Xa/RR4kVQaZZiL5oa3epz0H4dgtdELmfCd3bpTyZVnA=
```

