### PR TITLE
[serverless] Fix concurrency

### DIFF
--- a/serverless/deploy/github/sequence_and_integrate/action.yaml
+++ b/serverless/deploy/github/sequence_and_integrate/action.yaml
@@ -1,7 +1,7 @@
 # action.yml
 name: 'Sequence and integrate'
 description: 'Serverless log: sequence pending entries and integrate into log'
-concurrency: ${{ github.repository }}
+concurrency: master
 inputs:
   log_dir: # Root of the log state files
     description: 'Location of the log files in the repo'


### PR DESCRIPTION
`github` isn't recognised as an expression for some reason, so just use a static string.