### PR TITLE
[serverless] Expose log state serialisation/storage to tools

### DIFF
--- a/serverless/cmd/sequence/main.go
+++ b/serverless/cmd/sequence/main.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
+	"github.com/google/trillian-examples/serverless/api"
 	"github.com/google/trillian-examples/serverless/internal/storage"
 	"github.com/google/trillian-examples/serverless/internal/storage/fs"
 
@@ -46,7 +47,16 @@ func main() {
 	if *create {
 		st, err = fs.Create(*storageDir, h.EmptyRoot())
 	} else {
-		st, err = fs.Load(*storageDir)
+		var stateRaw []byte
+		stateRaw, err = fs.ReadLogState(*storageDir)
+		if err != nil {
+			glog.Exitf("Failed to read log state: %q", err)
+		}
+		var state api.LogState
+		if err := state.UnmarshalText(stateRaw); err != nil {
+			glog.Exitf("Failed to unmarshal state: %q", err)
+		}
+		st, err = fs.Load(*storageDir, &state)
 	}
 	if err != nil {
 		glog.Exitf("Failed to initialise storage: %q", err)


### PR DESCRIPTION
Decouple the log state storage a bit - we really want to be able to store an envelope which _contains_ the log state, rather than just the log state itself (e.g. if the tooling wants to sign the log state), so let the caller decide what/how to do that before they ask the storage to write the bytes.