### PR TITLE
Persist the monitor state to avoid repeated work

### DIFF
--- a/binary_transparency/firmware/README.md
+++ b/binary_transparency/firmware/README.md
@@ -127,7 +127,7 @@ and consider that any binary containing that string is a bad one.
   the command below to start a monitor:
 
 ```bash
-go run ./cmd/ft_monitor/ --logtostderr --keyword="H4x0r3d"
+go run ./cmd/ft_monitor/ --logtostderr --keyword="H4x0r3d" --state_file=/tmp/ftmon.state
 ```
 
 #### Terminal 3 - Firmware Vendor

--- a/binary_transparency/firmware/cmd/ft_monitor/ft_monitor.go
+++ b/binary_transparency/firmware/cmd/ft_monitor/ft_monitor.go
@@ -20,7 +20,7 @@
 // TODO(al): Extend monitor to verify claims.
 //
 // Start the monitor using:
-// go run ./cmd/ft_monitor/main.go --logtostderr -v=2 --ftlog=http://localhost:8000/
+// go run ./cmd/ft_monitor/main.go --logtostderr -v=2 --ftlog=http://localhost:8000/  --state_file=/tmp/ftmon.state
 package main
 
 import (
@@ -38,6 +38,7 @@ var (
 	pollInterval = flag.Duration("poll_interval", 5*time.Second, "Duration to wait between polling for new entries")
 	keyWord      = flag.String("keyword", "trojan", "Example keyword for malware")
 	annotate     = flag.Bool("annotate", false, "If true then this will add annotations to the log in addition to local logging")
+	stateFile    = flag.String("state_file", "", "Filepath to persist monitor state to")
 )
 
 func main() {
@@ -50,7 +51,8 @@ func main() {
 		Matched: func(idx uint64, fw api.FirmwareMetadata) {
 			glog.Warningf("Malware detected at log index %d, in firmware: %v", idx, fw)
 		},
-		Annotate: *annotate,
+		Annotate:  *annotate,
+		StateFile: *stateFile,
 	}); err != nil {
 		glog.Exitf(err.Error())
 	}

--- a/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
+++ b/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"regexp"
 	"time"
 
@@ -48,11 +49,15 @@ type MonitorOpts struct {
 	Keyword      string
 	Matched      MatchFunc
 	Annotate     bool
+	StateFile    string
 }
 
 func Main(ctx context.Context, opts MonitorOpts) error {
 	if len(opts.LogURL) == 0 {
 		return errors.New("log URL is required")
+	}
+	if len(opts.StateFile) == 0 {
+		return errors.New("state file is required")
 	}
 
 	ftURL, err := url.Parse(opts.LogURL)
@@ -65,15 +70,23 @@ func Main(ctx context.Context, opts MonitorOpts) error {
 
 	c := client.ReadonlyClient{LogURL: ftURL}
 
-	// TODO(mhutchinson): This checkpoint and tracker for number of processed entries
-	// should be serialized so the monitor persists its golden state between runs.
-	// In particular this will prevent the annotator from adding multiple annotations
-	// for the same firmware each time the monitor is started.
+	// Initialize the checkpoint from persisted state.
 	var latestCP api.LogCheckpoint
-	var head uint64
+	if state, err := os.ReadFile(opts.StateFile); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("failed to read state: %w", err)
+		}
+		// Silently continue if the file doesn't exist.
+		// This could fail here unless a force flag is provided, for better security.
+	} else {
+		if err := json.Unmarshal(state, &latestCP); err != nil {
+			return fmt.Errorf("failed to read state: %w", err)
+		}
+	}
+	head := latestCP.TreeSize
 	follow := client.NewLogFollower(c)
 
-	glog.Infof("Monitoring FT log %q...", opts.LogURL)
+	glog.Infof("Monitoring FT log (%q) starting from index %d", opts.LogURL, head)
 	cpc, cperrc := follow.Checkpoints(ctx, opts.PollInterval, latestCP)
 	ec, eerrc := follow.Entries(ctx, cpc, head)
 
@@ -89,60 +102,77 @@ func Main(ctx context.Context, opts MonitorOpts) error {
 		case entry = <-ec:
 		}
 
-		stmt := entry.Value
-		if stmt.Type != api.FirmwareMetadataType {
-			// Only analyze firmware statements in the monitor.
-			continue
-		}
+		processEntry(entry, c, opts, matcher)
 
-		// Parse the firmware metadata:
-		var meta api.FirmwareMetadata
-		if err := json.Unmarshal(stmt.Statement, &meta); err != nil {
-			glog.Warningf("Unable to decode FW Metadata from Statement %q", err)
-			continue
-		}
-
-		glog.Infof("Found firmware (@%d): %s", entry.Index, meta)
-
-		// Fetch the Image from FT Personality
-		image, err := c.GetFirmwareImage(meta.FirmwareImageSHA512)
-		if err != nil {
-			glog.Warningf("Unable to GetFirmwareImage for Firmware with Hash 0x%x , reason %q", meta.FirmwareImageSHA512, err)
-			continue
-		}
-		// Verify Image Hash from log Manifest matches the actual image hash
-		h := sha512.Sum512(image)
-		if !bytes.Equal(h[:], meta.FirmwareImageSHA512) {
-			glog.Warningf("downloaded image does not match SHA512 in metadata (%x != %x)", h[:], meta.FirmwareImageSHA512)
-			continue
-		}
-		glog.V(1).Infof("Image Hash Verified for image at leaf index %d", entry.Index)
-
-		// Search for specific keywords inside firmware image
-		malwareDetected := matcher.Match(image)
-
-		if malwareDetected {
-			opts.Matched(entry.Index, meta)
-		}
-		if opts.Annotate {
-			ms := api.MalwareStatement{
-				FirmwareID: api.FirmwareID{
-					LogIndex:            entry.Index,
-					FirmwareImageSHA512: h[:],
-				},
-				Good: !malwareDetected,
-			}
-			glog.V(1).Infof("Annotating %s", ms)
-			js, err := createStatementJSON(ms)
+		if entry.Index == entry.Root.TreeSize-1 {
+			// If we have processed all leaves in the current checkpoint, then persist this checkpoint
+			// so that we don't repeat work on startup.
+			bs, err := json.Marshal(entry.Root)
 			if err != nil {
-				return fmt.Errorf("failed to create annotation: %w", err)
+				return fmt.Errorf("failed to marshal checkpoint: %w", err)
 			}
-			sc := client.SubmitClient{
-				ReadonlyClient: &c,
-			}
-			if err := sc.PublishAnnotationMalware(js); err != nil {
-				return fmt.Errorf("failed to publish annotation: %w", err)
-			}
+			os.WriteFile(opts.StateFile, bs, 0o755)
+			glog.Infof("Persisted state: %v", entry.Root)
+		}
+	}
+}
+
+func processEntry(entry client.LogEntry, c client.ReadonlyClient, opts MonitorOpts, matcher *regexp.Regexp) {
+	stmt := entry.Value
+	if stmt.Type != api.FirmwareMetadataType {
+		// Only analyze firmware statements in the monitor.
+		return
+	}
+
+	// Parse the firmware metadata:
+	var meta api.FirmwareMetadata
+	if err := json.Unmarshal(stmt.Statement, &meta); err != nil {
+		glog.Warningf("Unable to decode FW Metadata from Statement %q", err)
+		return
+	}
+
+	glog.Infof("Found firmware (@%d): %s", entry.Index, meta)
+
+	// Fetch the Image from FT Personality
+	image, err := c.GetFirmwareImage(meta.FirmwareImageSHA512)
+	if err != nil {
+		glog.Warningf("Unable to GetFirmwareImage for Firmware with Hash 0x%x , reason %q", meta.FirmwareImageSHA512, err)
+		return
+	}
+	// Verify Image Hash from log Manifest matches the actual image hash
+	h := sha512.Sum512(image)
+	if !bytes.Equal(h[:], meta.FirmwareImageSHA512) {
+		glog.Warningf("downloaded image does not match SHA512 in metadata (%x != %x)", h[:], meta.FirmwareImageSHA512)
+		return
+	}
+	glog.V(1).Infof("Image Hash Verified for image at leaf index %d", entry.Index)
+
+	// Search for specific keywords inside firmware image
+	malwareDetected := matcher.Match(image)
+
+	if malwareDetected {
+		opts.Matched(entry.Index, meta)
+	}
+	if opts.Annotate {
+		ms := api.MalwareStatement{
+			FirmwareID: api.FirmwareID{
+				LogIndex:            entry.Index,
+				FirmwareImageSHA512: h[:],
+			},
+			Good: !malwareDetected,
+		}
+		glog.V(1).Infof("Annotating %s", ms)
+		js, err := createStatementJSON(ms)
+		if err != nil {
+			glog.Warningf("failed to create annotation: %w", err)
+			return
+		}
+		sc := client.SubmitClient{
+			ReadonlyClient: &c,
+		}
+		if err := sc.PublishAnnotationMalware(js); err != nil {
+			glog.Warningf("failed to publish annotation: %w", err)
+			return
 		}
 	}
 }

--- a/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
+++ b/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
@@ -77,8 +77,8 @@ func Main(ctx context.Context, opts MonitorOpts) error {
 		if !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("failed to read state: %w", err)
 		}
-		// Silently continue if the file doesn't exist.
 		// This could fail here unless a force flag is provided, for better security.
+		glog.Warningf("State file %q did not exist; first log checkpoint will be trusted implicitly", opts.StateFile)
 	} else {
 		if err := json.Unmarshal(state, &latestCP); err != nil {
 			return fmt.Errorf("failed to read state: %w", err)

--- a/binary_transparency/firmware/cmd/ftmap/README.md
+++ b/binary_transparency/firmware/cmd/ftmap/README.md
@@ -25,7 +25,7 @@ go run ./cmd/publisher/publish.go --logtostderr --v=2 --timestamp="2021-10-10T15
 go run ./cmd/publisher/publish.go --logtostderr --v=2 --timestamp="2020-10-10T23:00:00.00Z" --binary_path=./testdata/firmware/dummy_device/hacked.wasm --output_path=/tmp/bad_update.ota --device=dummy
 
 # Run the monitor to annotate
-go run ./cmd/ft_monitor/ --logtostderr --v=1 --keyword="H4x0r3d" --annotate
+go run ./cmd/ft_monitor/ --logtostderr --v=1 --keyword="H4x0r3d" --state_file=/tmp/ftmon.state --annotate
 ```
 
 Now to generate the map:


### PR DESCRIPTION
Without this, the monitor starts from the beginning of the log on each run. This is wasted effort in the best-case, but can actually cause a lot of spam annotations to the log in the worst case.

The state file can always be removed locally if the monitor code is updated and needs to process the whole log again.