### PR TITLE
[firmware transparency] Use `formats/log` checkpoint format

### DIFF
--- a/binary_transparency/firmware/api/http_test.go
+++ b/binary_transparency/firmware/api/http_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/google/trillian-examples/binary_transparency/firmware/api"
+	"github.com/google/trillian-examples/formats/log"
 )
 
 func TestLogCheckpointString(t *testing.T) {
@@ -29,7 +30,13 @@ func TestLogCheckpointString(t *testing.T) {
 			cp:   api.LogCheckpoint{},
 			want: "{size 0 @ 0 root: 0x}",
 		}, {
-			cp:   api.LogCheckpoint{TreeSize: 10, TimestampNanos: 234, RootHash: []byte{0x12, 0x34, 0x56}},
+			cp: api.LogCheckpoint{
+				Checkpoint: log.Checkpoint{
+					Size: 10,
+					Hash: []byte{0x12, 0x34, 0x56},
+				},
+				TimestampNanos: 234,
+			},
 			want: "{size 10 @ 234 root: 0x123456}",
 		},
 	} {

--- a/binary_transparency/firmware/api/update_package.go
+++ b/binary_transparency/firmware/api/update_package.go
@@ -28,7 +28,7 @@ type ProofBundle struct {
 	// ManifestStatement is the json representation of an `api.SignedStatement` struct.
 	ManifestStatement []byte
 	// Checkpoint must represent a tree which includes the ManifestStatement.
-	Checkpoint LogCheckpoint
+	Checkpoint []byte
 	// InclusionProof is a proof to Checkpoint for ManifestStatement.
 	InclusionProof InclusionProof
 }

--- a/binary_transparency/firmware/cmd/flash_tool/devices/device.go
+++ b/binary_transparency/firmware/cmd/flash_tool/devices/device.go
@@ -27,8 +27,8 @@ type ErrNeedsInit = error
 // Drivers for individual devices would be bound to this interface, which
 // allows a generic flash tool to control the secure update process.
 type Device interface {
-	// DeviceCheckpoint returns the log checkpoint used during the last firmware update.
-	DeviceCheckpoint() (api.LogCheckpoint, error)
+	// DeviceCheckpoint returns the log checkpoint note used during the last firmware update.
+	DeviceCheckpoint() ([]byte, error)
 	// ApplyUpdate applies the provided update to the device.
 	ApplyUpdate(api.UpdatePackage) error
 }

--- a/binary_transparency/firmware/cmd/flash_tool/flash_tool.go
+++ b/binary_transparency/firmware/cmd/flash_tool/flash_tool.go
@@ -31,6 +31,8 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/binary_transparency/firmware/cmd/flash_tool/impl"
+	"github.com/google/trillian-examples/binary_transparency/firmware/internal/crypto"
+	"golang.org/x/mod/sumdb/note"
 )
 
 var (
@@ -46,14 +48,20 @@ var (
 func main() {
 	flag.Parse()
 
+	v, err := note.NewVerifier(crypto.TestFTPersonalityPub)
+	if err != nil {
+		glog.Exitf("Failed to create CP verifier: %q", err)
+	}
+
 	if err := impl.Main(context.Background(), impl.FlashOpts{
-		DeviceID:      *deviceID,
-		LogURL:        *logURL,
-		MapURL:        *mapURL,
-		WitnessURL:    *witnessURL,
-		UpdateFile:    *updateFile,
-		Force:         *force,
-		DeviceStorage: *deviceStorage,
+		DeviceID:       *deviceID,
+		LogURL:         *logURL,
+		LogSigVerifier: v,
+		MapURL:         *mapURL,
+		WitnessURL:     *witnessURL,
+		UpdateFile:     *updateFile,
+		Force:          *force,
+		DeviceStorage:  *deviceStorage,
 	}); err != nil {
 		glog.Exit(err.Error())
 	}

--- a/binary_transparency/firmware/cmd/ft_personality/ft_personality.go
+++ b/binary_transparency/firmware/cmd/ft_personality/ft_personality.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/binary_transparency/firmware/cmd/ft_personality/impl"
+	"github.com/google/trillian-examples/binary_transparency/firmware/internal/crypto"
+	"golang.org/x/mod/sumdb/note"
 )
 
 var (
@@ -40,6 +42,11 @@ var (
 func main() {
 	flag.Parse()
 
+	signer, err := note.NewSigner(crypto.TestFTPersonalityPriv)
+	if err != nil {
+		panic(err)
+	}
+
 	ctx := context.Background()
 	if err := impl.Main(ctx, impl.PersonalityOpts{
 		ListenAddr:     *listenAddr,
@@ -47,6 +54,7 @@ func main() {
 		TrillianAddr:   *trillianAddr,
 		CASFile:        *casDBFile,
 		STHRefresh:     *sthRefresh,
+		Signer:         signer,
 	}); err != nil {
 		glog.Exit(err.Error())
 	}

--- a/binary_transparency/firmware/cmd/ft_personality/ft_personality.go
+++ b/binary_transparency/firmware/cmd/ft_personality/ft_personality.go
@@ -56,6 +56,6 @@ func main() {
 		STHRefresh:     *sthRefresh,
 		Signer:         signer,
 	}); err != nil {
-		glog.Exit(err.Error())
+		glog.Exitf("Error running personality: %q", err)
 	}
 }

--- a/binary_transparency/firmware/cmd/ft_personality/impl/ft_personality.go
+++ b/binary_transparency/firmware/cmd/ft_personality/impl/ft_personality.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/trillian-examples/binary_transparency/firmware/cmd/ft_personality/internal/trees"
 	"github.com/google/trillian-examples/binary_transparency/firmware/cmd/ft_personality/internal/trillian"
 	"github.com/gorilla/mux"
+	"golang.org/x/mod/sumdb/note"
 
 	_ "github.com/google/trillian/merkle/rfc6962/hasher" // Load hashers
 	_ "github.com/mattn/go-sqlite3"                      // Load drivers for sqlite3
@@ -43,6 +44,7 @@ type PersonalityOpts struct {
 	TrillianAddr   string
 	ConnectTimeout time.Duration
 	STHRefresh     time.Duration
+	Signer         note.Signer
 }
 
 func Main(ctx context.Context, opts PersonalityOpts) error {
@@ -86,7 +88,7 @@ func Main(ctx context.Context, opts PersonalityOpts) error {
 	}()
 
 	glog.Infof("Starting FT personality server...")
-	srv := ih.NewServer(tclient, cas)
+	srv := ih.NewServer(tclient, cas, opts.Signer)
 	r := mux.NewRouter()
 	srv.RegisterHandlers(r)
 	hServer := &http.Server{

--- a/binary_transparency/firmware/cmd/ft_witness/ft_witness.go
+++ b/binary_transparency/firmware/cmd/ft_witness/ft_witness.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/binary_transparency/firmware/cmd/ft_witness/impl"
+	"github.com/google/trillian-examples/binary_transparency/firmware/internal/crypto"
+	"golang.org/x/mod/sumdb/note"
 )
 
 var (
@@ -34,12 +36,15 @@ var (
 func main() {
 	flag.Parse()
 
+	testVerifier, _ := note.NewVerifier(crypto.TestFTPersonalityPub)
+
 	ctx := context.Background()
 	if err := impl.Main(ctx, impl.WitnessOpts{
-		ListenAddr:   *listenAddr,
-		WSFile:       *wsFile,
-		FtLogURL:     *ftLogURL,
-		PollInterval: *pollInterval,
+		ListenAddr:       *listenAddr,
+		WSFile:           *wsFile,
+		FtLogURL:         *ftLogURL,
+		FtLogSigVerifier: testVerifier,
+		PollInterval:     *pollInterval,
 	}); err != nil {
 		glog.Exit(err.Error())
 	}

--- a/binary_transparency/firmware/cmd/ft_witness/impl/ft_witness.go
+++ b/binary_transparency/firmware/cmd/ft_witness/impl/ft_witness.go
@@ -27,16 +27,18 @@ import (
 	ih "github.com/google/trillian-examples/binary_transparency/firmware/cmd/ft_witness/internal/http"
 	"github.com/google/trillian-examples/binary_transparency/firmware/cmd/ft_witness/internal/ws"
 	"github.com/gorilla/mux"
+	"golang.org/x/mod/sumdb/note"
 
 	_ "github.com/google/trillian/merkle/rfc6962/hasher" // Load hashers
 )
 
 // WitnessOpts encapsulates options for running an FT witness.
 type WitnessOpts struct {
-	ListenAddr   string
-	WSFile       string
-	FtLogURL     string
-	PollInterval time.Duration
+	ListenAddr       string
+	WSFile           string
+	FtLogURL         string
+	FtLogSigVerifier note.Verifier
+	PollInterval     time.Duration
 }
 
 // Main kickstarts the witness
@@ -51,7 +53,7 @@ func Main(ctx context.Context, opts WitnessOpts) error {
 	}
 
 	glog.Infof("Starting FT witness server...")
-	witness, err := ih.NewWitness(ws, opts.FtLogURL, opts.PollInterval)
+	witness, err := ih.NewWitness(ws, opts.FtLogURL, opts.FtLogSigVerifier, opts.PollInterval)
 	if err != nil {
 		return fmt.Errorf("failed to create new witness: %w", err)
 	}

--- a/binary_transparency/firmware/cmd/ft_witness/internal/ws/store_test.go
+++ b/binary_transparency/firmware/cmd/ft_witness/internal/ws/store_test.go
@@ -15,10 +15,9 @@
 package ws
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
-
-	"github.com/google/trillian-examples/binary_transparency/firmware/api"
 )
 
 const (
@@ -29,14 +28,14 @@ const (
 func TestRoundTrip(t *testing.T) {
 	for _, test := range []struct {
 		desc string
-		cp   api.LogCheckpoint
+		data []byte
 	}{
 		{
 			desc: "initial checkpoint test",
-			cp:   api.LogCheckpoint{TreeSize: 1, RootHash: []byte("Standard Root Hash"), TimestampNanos: 41672},
+			data: []byte("some checkpoint"),
 		}, {
 			desc: "check over-write of checkpoint",
-			cp:   api.LogCheckpoint{TreeSize: 2, RootHash: []byte("New  Root Hash"), TimestampNanos: 91982},
+			data: []byte("some more checkpoint"),
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
@@ -45,15 +44,15 @@ func TestRoundTrip(t *testing.T) {
 			if err != nil {
 				t.Error("failed to create storage", err)
 			}
-			want := test.cp
-			if err := store.StoreCP(test.cp); err != nil {
+			want := test.data
+			if err := store.StoreCP(test.data); err != nil {
 				t.Error("failed to store into Witness Store", err)
 			}
 			got, err := store.RetrieveCP()
 			if err != nil {
 				t.Error("failed to retrieve from Witness Store", err)
 			}
-			if got.TimestampNanos != want.TimestampNanos {
+			if !bytes.Equal(got, want) {
 				t.Errorf("got '%s' want '%s'", got, want)
 			}
 

--- a/binary_transparency/firmware/cmd/ftmapserver/impl/ftmapserver.go
+++ b/binary_transparency/firmware/cmd/ftmapserver/impl/ftmapserver.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/binary_transparency/firmware/api"
 	"github.com/google/trillian-examples/binary_transparency/firmware/internal/ftmap"
+	"github.com/google/trillian-examples/formats/log"
 	"github.com/google/trillian/experimental/batchmap"
 	"github.com/google/trillian/types"
 
@@ -100,17 +101,15 @@ func (s *Server) getCheckpoint(w http.ResponseWriter, r *http.Request) {
 	}
 
 	lcp := api.LogCheckpoint{
-		TreeSize:       logRootV1.TreeSize,
-		RootHash:       logRootV1.RootHash,
+		Checkpoint: log.Checkpoint{
+			Ecosystem: api.FTLogCheckpointEcosystemv0,
+			Size:      logRootV1.TreeSize,
+			Hash:      logRootV1.RootHash,
+		},
 		TimestampNanos: logRootV1.TimestampNanos,
 	}
-	lcpEncoded, err := json.Marshal(lcp)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
 	checkpoint := api.MapCheckpoint{
-		LogCheckpoint: lcpEncoded,
+		LogCheckpoint: lcp.Marshal(),
 		LogSize:       uint64(count),
 		Revision:      uint64(rev),
 		RootHash:      tile.RootHash,

--- a/binary_transparency/firmware/cmd/ftmapserver/impl/ftmapserver_test.go
+++ b/binary_transparency/firmware/cmd/ftmapserver/impl/ftmapserver_test.go
@@ -49,7 +49,12 @@ func TestRoot(t *testing.T) {
 			},
 			count:    111,
 			rootHash: []byte{0x34, 0x12},
-			wantBody: `{"LogCheckpoint":"eyJUcmVlU2l6ZSI6NDIsIlJvb3RIYXNoIjoiRWpRPSIsIlRpbWVzdGFtcE5hbm9zIjoxMjM0NX0=","LogSize":111,"RootHash":"NBI=","Revision":42}`,
+			// LogCheckpoint below is base64 of:
+			// Firmware Transparency Log v0
+			// 42
+			// EjQ=
+			// 12345
+			wantBody: `{"LogCheckpoint":"RmlybXdhcmUgVHJhbnNwYXJlbmN5IExvZyB2MAo0MgpFalE9CjEyMzQ1Cg==","LogSize":111,"RootHash":"NBI=","Revision":42}`,
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {

--- a/binary_transparency/firmware/cmd/publisher/impl/publish.go
+++ b/binary_transparency/firmware/cmd/publisher/impl/publish.go
@@ -32,16 +32,18 @@ import (
 	"github.com/google/trillian-examples/binary_transparency/firmware/devices/usbarmory"
 	"github.com/google/trillian-examples/binary_transparency/firmware/internal/client"
 	"github.com/google/trillian-examples/binary_transparency/firmware/internal/crypto"
+	"golang.org/x/mod/sumdb/note"
 )
 
 // PublishOpts encapsulates parameters for the publish Main below.
 type PublishOpts struct {
-	LogURL     string
-	DeviceID   string
-	Revision   uint64
-	BinaryPath string
-	Timestamp  string
-	OutputPath string
+	LogURL         string
+	LogSigVerifier note.Verifier
+	DeviceID       string
+	Revision       uint64
+	BinaryPath     string
+	Timestamp      string
+	OutputPath     string
 }
 
 // Main is the entrypoint for the implementation of the publisher.
@@ -65,7 +67,8 @@ func Main(ctx context.Context, opts PublishOpts) error {
 
 	c := &client.SubmitClient{
 		ReadonlyClient: &client.ReadonlyClient{
-			LogURL: logURL,
+			LogURL:         logURL,
+			LogSigVerifier: opts.LogSigVerifier,
 		},
 	}
 
@@ -96,7 +99,7 @@ func Main(ctx context.Context, opts PublishOpts) error {
 		pb, err := json.Marshal(
 			api.ProofBundle{
 				ManifestStatement: js,
-				Checkpoint:        cp,
+				Checkpoint:        cp.Envelope,
 				InclusionProof:    ip,
 			})
 		if err != nil {

--- a/binary_transparency/firmware/devices/dummy/flash.go
+++ b/binary_transparency/firmware/devices/dummy/flash.go
@@ -70,7 +70,7 @@ func New(storage string) (*Device, error) {
 }
 
 // DeviceCheckpoint returns the latest log checkpoint stored on the device.
-func (d Device) DeviceCheckpoint() (api.LogCheckpoint, error) {
+func (d Device) DeviceCheckpoint() ([]byte, error) {
 	return d.bundle.Checkpoint, nil
 }
 

--- a/binary_transparency/firmware/devices/dummy/rom/rom.go
+++ b/binary_transparency/firmware/devices/dummy/rom/rom.go
@@ -21,7 +21,10 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/binary_transparency/firmware/devices/dummy/common"
+	"github.com/google/trillian-examples/binary_transparency/firmware/internal/crypto"
 	"github.com/google/trillian-examples/binary_transparency/firmware/internal/verify"
+
+	"golang.org/x/mod/sumdb/note"
 )
 
 const (
@@ -68,7 +71,11 @@ func Reset(storagePath string) (Chain, error) {
 	}
 
 	// validate bundle
-	if err := verify.BundleForBoot(bundleRaw, fwMeasurement[:]); err != nil {
+	v, err := note.NewVerifier(crypto.TestFTPersonalityPub)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create sig verifier: %w", err)
+	}
+	if err := verify.BundleForBoot(bundleRaw, fwMeasurement[:], note.VerifierList(v)); err != nil {
 		return nil, fmt.Errorf("failed to verify bundle: %w", err)
 	}
 

--- a/binary_transparency/firmware/devices/usbarmory/bootloader/ft.go
+++ b/binary_transparency/firmware/devices/usbarmory/bootloader/ft.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"github.com/f-secure-foundry/tamago/soc/imx6/dcp"
+	"github.com/google/trillian-examples/binary_transparency/firmware/internal/crypto"
 	"github.com/google/trillian-examples/binary_transparency/firmware/internal/verify"
+	"golang.org/x/mod/sumdb/note"
 )
 
 const (
@@ -41,8 +43,9 @@ func verifyIntegrity(proof, firmware *Partition) error {
 		return fmt.Errorf("failed to hash firmware partition: %w\n", err)
 	}
 	fmt.Printf("firmware partition hash: 0x%x\n", h)
+	cpSigVerifier, err := note.NewVerifier(crypto.TestFTPersonalityPub)
 
-	if err := verify.BundleForBoot(rawBundle, h); err != nil {
+	if err := verify.BundleForBoot(rawBundle, h, note.VerifierList(cpSigVerifier)); err != nil {
 		return fmt.Errorf("failed to verify bundle: %w", err)
 	}
 	return nil

--- a/binary_transparency/firmware/devices/usbarmory/bootloader/ft.go
+++ b/binary_transparency/firmware/devices/usbarmory/bootloader/ft.go
@@ -43,9 +43,9 @@ func verifyIntegrity(proof, firmware *Partition) error {
 		return fmt.Errorf("failed to hash firmware partition: %w\n", err)
 	}
 	fmt.Printf("firmware partition hash: 0x%x\n", h)
-	cpSigVerifier, err := note.NewVerifier(crypto.TestFTPersonalityPub)
+	logSigVerifier, err := note.NewVerifier(crypto.TestFTPersonalityPub)
 
-	if err := verify.BundleForBoot(rawBundle, h, note.VerifierList(cpSigVerifier)); err != nil {
+	if err := verify.BundleForBoot(rawBundle, h, note.VerifierList(logSigVerifier)); err != nil {
 		return fmt.Errorf("failed to verify bundle: %w", err)
 	}
 	return nil

--- a/binary_transparency/firmware/devices/usbarmory/flash/flash.go
+++ b/binary_transparency/firmware/devices/usbarmory/flash/flash.go
@@ -83,7 +83,7 @@ func New(storage string) (*Device, error) {
 }
 
 // DeviceCheckpoint returns the latest log checkpoint stored on the device.
-func (d Device) DeviceCheckpoint() (api.LogCheckpoint, error) {
+func (d Device) DeviceCheckpoint() ([]byte, error) {
 	return d.bundle.Checkpoint, nil
 }
 

--- a/binary_transparency/firmware/integration/ft_integration_test.go
+++ b/binary_transparency/firmware/integration/ft_integration_test.go
@@ -34,6 +34,8 @@ import (
 	i_witness "github.com/google/trillian-examples/binary_transparency/firmware/cmd/ft_witness/impl"
 	i_modify "github.com/google/trillian-examples/binary_transparency/firmware/cmd/hacker/modify_bundle/impl"
 	i_publish "github.com/google/trillian-examples/binary_transparency/firmware/cmd/publisher/impl"
+	"github.com/google/trillian-examples/binary_transparency/firmware/internal/crypto"
+	"golang.org/x/mod/sumdb/note"
 )
 
 const (
@@ -49,6 +51,15 @@ const (
 var (
 	trillianAddr = flag.String("trillian", "", "Host:port of Trillian Log RPC server")
 )
+
+func mustGetCPVerifier(t *testing.T) note.Verifier {
+	t.Helper()
+	v, err := note.NewVerifier(crypto.TestFTPersonalityPub)
+	if err != nil {
+		t.Fatalf("Failed to create CP verifier: %q", err)
+	}
+	return v
+}
 
 func TestFTIntegration(t *testing.T) {
 	if len(*trillianAddr) == 0 {
@@ -68,6 +79,7 @@ func TestFTIntegration(t *testing.T) {
 	pAddr := fmt.Sprintf("http://%s", pListen)
 
 	pErrChan := make(chan error)
+	cpVerifier := mustGetCPVerifier(t)
 
 	go func() {
 		if err := runPersonality(ctx, t, pListen); err != nil {
@@ -88,24 +100,26 @@ func TestFTIntegration(t *testing.T) {
 			desc: "Log initial firmware",
 			step: func() error {
 				return i_publish.Main(ctx, i_publish.PublishOpts{
-					LogURL:     pAddr,
-					DeviceID:   "dummy",
-					BinaryPath: GoodFirmware,
-					Timestamp:  PublishTimestamp1,
-					Revision:   1,
-					OutputPath: updatePath,
+					LogURL:         pAddr,
+					LogSigVerifier: cpVerifier,
+					DeviceID:       "dummy",
+					BinaryPath:     GoodFirmware,
+					Timestamp:      PublishTimestamp1,
+					Revision:       1,
+					OutputPath:     updatePath,
 				})
 			},
 		}, {
 			desc: "Force flashing device (init)",
 			step: func() error {
 				return i_flash.Main(ctx, i_flash.FlashOpts{
-					LogURL:        pAddr,
-					WitnessURL:    "",
-					DeviceID:      "dummy",
-					UpdateFile:    updatePath,
-					DeviceStorage: devStoragePath,
-					Force:         true,
+					LogURL:         pAddr,
+					LogSigVerifier: cpVerifier,
+					WitnessURL:     "",
+					DeviceID:       "dummy",
+					UpdateFile:     updatePath,
+					DeviceStorage:  devStoragePath,
+					Force:          true,
 				})
 			},
 		}, {
@@ -119,23 +133,25 @@ func TestFTIntegration(t *testing.T) {
 			desc: "Log updated firmware",
 			step: func() error {
 				return i_publish.Main(ctx, i_publish.PublishOpts{
-					LogURL:     pAddr,
-					DeviceID:   "dummy",
-					BinaryPath: GoodFirmware,
-					Timestamp:  PublishTimestamp2,
-					Revision:   2,
-					OutputPath: updatePath,
+					LogURL:         pAddr,
+					LogSigVerifier: cpVerifier,
+					DeviceID:       "dummy",
+					BinaryPath:     GoodFirmware,
+					Timestamp:      PublishTimestamp2,
+					Revision:       2,
+					OutputPath:     updatePath,
 				})
 			},
 		}, {
 			desc: "Flashing device (update)",
 			step: func() error {
 				return i_flash.Main(ctx, i_flash.FlashOpts{
-					LogURL:        pAddr,
-					WitnessURL:    "",
-					DeviceID:      "dummy",
-					UpdateFile:    updatePath,
-					DeviceStorage: devStoragePath,
+					LogURL:         pAddr,
+					LogSigVerifier: cpVerifier,
+					WitnessURL:     "",
+					DeviceID:       "dummy",
+					UpdateFile:     updatePath,
+					DeviceStorage:  devStoragePath,
 				})
 			},
 		}, {
@@ -212,7 +228,7 @@ func TestFTIntegration(t *testing.T) {
 				mCtx, mCancel := context.WithCancel(context.Background())
 				defer mCancel()
 				go func() {
-					if err := runMonitor(mCtx, t, pAddr, "H4x0r3d", func(idx uint64, fw api.FirmwareMetadata) {
+					if err := runMonitor(mCtx, t, pAddr, "H4x0r3d", cpVerifier, func(idx uint64, fw api.FirmwareMetadata) {
 						t.Logf("Found malware firmware @%d", idx)
 						matchedChan <- true
 					}); err != nil && err != context.Canceled {
@@ -223,12 +239,13 @@ func TestFTIntegration(t *testing.T) {
 
 				// Log malware fw:
 				if err := i_publish.Main(ctx, i_publish.PublishOpts{
-					LogURL:     pAddr,
-					DeviceID:   "dummy",
-					BinaryPath: HackedFirmware,
-					Timestamp:  PublishMalwareTimestamp,
-					Revision:   1,
-					OutputPath: updatePath,
+					LogURL:         pAddr,
+					LogSigVerifier: cpVerifier,
+					DeviceID:       "dummy",
+					BinaryPath:     HackedFirmware,
+					Timestamp:      PublishMalwareTimestamp,
+					Revision:       1,
+					OutputPath:     updatePath,
 				}); err != nil {
 					t.Fatalf("Failed to log malware: %q", err)
 				}
@@ -237,11 +254,12 @@ func TestFTIntegration(t *testing.T) {
 				// Now flash the bundle normally, it will install because it's been logged
 				// and so is now discoverable.
 				if err := i_flash.Main(ctx, i_flash.FlashOpts{
-					LogURL:        pAddr,
-					WitnessURL:    "",
-					DeviceID:      "dummy",
-					UpdateFile:    updatePath,
-					DeviceStorage: devStoragePath,
+					LogURL:         pAddr,
+					LogSigVerifier: cpVerifier,
+					WitnessURL:     "",
+					DeviceID:       "dummy",
+					UpdateFile:     updatePath,
+					DeviceStorage:  devStoragePath,
 				}); err != nil {
 					t.Fatalf("Failed to flash malware update onto device: %q", err)
 				}
@@ -272,24 +290,23 @@ func TestFTIntegration(t *testing.T) {
 				wHost := "localhost:43565"
 				wAddr := fmt.Sprintf("http://%s", wHost)
 				wCtx, wCancel := context.WithCancel(context.Background())
-				wErrChan := make(chan error)
 				defer wCancel()
 				go func() {
-					if err := runWitness(wCtx, t, pAddr, wHost); err != nil {
-						pErrChan <- err
+					if err := runWitness(wCtx, t, pAddr, wHost, cpVerifier); err != nil {
+						t.Errorf("Witness error: %q", err)
 					}
-					close(wErrChan)
 				}()
 
 				// Wait for few seconds before starting the test
 				<-time.After(2 * time.Second)
 				if err := i_publish.Main(ctx, i_publish.PublishOpts{
-					LogURL:     pAddr,
-					DeviceID:   "dummy",
-					BinaryPath: GoodFirmware,
-					Timestamp:  PublishTimestamp3,
-					Revision:   3,
-					OutputPath: updatePath,
+					LogURL:         pAddr,
+					LogSigVerifier: cpVerifier,
+					DeviceID:       "dummy",
+					BinaryPath:     GoodFirmware,
+					Timestamp:      PublishTimestamp3,
+					Revision:       3,
+					OutputPath:     updatePath,
 				}); err != nil {
 					t.Fatalf("Failed to publish new bundle: %q", err)
 				}
@@ -298,14 +315,16 @@ func TestFTIntegration(t *testing.T) {
 				<-time.After(5 * time.Second)
 
 				if err := i_flash.Main(ctx, i_flash.FlashOpts{
-					LogURL:        pAddr,
-					WitnessURL:    wAddr,
-					DeviceID:      "dummy",
-					UpdateFile:    updatePath,
-					DeviceStorage: devStoragePath,
+					LogURL:         pAddr,
+					LogSigVerifier: cpVerifier,
+					WitnessURL:     wAddr,
+					DeviceID:       "dummy",
+					UpdateFile:     updatePath,
+					DeviceStorage:  devStoragePath,
 				}); err != nil {
 					t.Fatalf("witness verification failed: %q", err)
 				}
+
 				return nil
 			},
 		},
@@ -343,32 +362,37 @@ func setupDeviceStorage(t *testing.T, devStoragePath string) {
 }
 
 func runPersonality(ctx context.Context, t *testing.T, serverAddr string) error {
-
 	t.Helper()
 	r := t.TempDir()
 
-	err := i_personality.Main(ctx, i_personality.PersonalityOpts{
+	signer, err := note.NewSigner(crypto.TestFTPersonalityPriv)
+	if err != nil {
+		return fmt.Errorf("failed to create CP signer: %w", err)
+	}
+
+	if err := i_personality.Main(ctx, i_personality.PersonalityOpts{
 		ListenAddr:     serverAddr,
 		CASFile:        filepath.Join(r, "ft-cas.db"),
 		TrillianAddr:   *trillianAddr,
 		ConnectTimeout: 10 * time.Second,
 		STHRefresh:     time.Second,
-	})
-	if err != http.ErrServerClosed {
+		Signer:         signer,
+	}); err != http.ErrServerClosed {
 		return err
 	}
 	return nil
 }
 
-func runWitness(ctx context.Context, t *testing.T, persAddr, serverAddr string) error {
+func runWitness(ctx context.Context, t *testing.T, persAddr, serverAddr string, cpVerifier note.Verifier) error {
 	t.Helper()
 	r := t.TempDir()
 
 	err := i_witness.Main(ctx, i_witness.WitnessOpts{
-		ListenAddr:   serverAddr,
-		WSFile:       filepath.Join(r, "ft-witness.db"),
-		FtLogURL:     persAddr,
-		PollInterval: 5 * time.Second,
+		ListenAddr:       serverAddr,
+		WSFile:           filepath.Join(r, "ft-witness.db"),
+		FtLogURL:         persAddr,
+		FtLogSigVerifier: cpVerifier,
+		PollInterval:     5 * time.Second,
 	})
 	if err != http.ErrServerClosed {
 		return err
@@ -376,17 +400,18 @@ func runWitness(ctx context.Context, t *testing.T, persAddr, serverAddr string) 
 	return nil
 }
 
-func runMonitor(ctx context.Context, t *testing.T, serverAddr string, pattern string, matched i_monitor.MatchFunc) error {
+func runMonitor(ctx context.Context, t *testing.T, serverAddr string, pattern string, cpVerifier note.Verifier, matched i_monitor.MatchFunc) error {
 	t.Helper()
 
 	r := t.TempDir()
 
 	err := i_monitor.Main(ctx, i_monitor.MonitorOpts{
-		LogURL:       serverAddr,
-		PollInterval: 1 * time.Second,
-		Keyword:      "H4x0r3d",
-		Matched:      matched,
-		StateFile:    filepath.Join(r, "ft-monitor.state"),
+		LogURL:         serverAddr,
+		LogSigVerifier: cpVerifier,
+		PollInterval:   1 * time.Second,
+		Keyword:        "H4x0r3d",
+		Matched:        matched,
+		StateFile:      filepath.Join(r, "ft-monitor.state"),
 	})
 	if err != http.ErrServerClosed {
 		return err

--- a/binary_transparency/firmware/internal/client/client.go
+++ b/binary_transparency/firmware/internal/client/client.go
@@ -130,6 +130,7 @@ func (c ReadonlyClient) GetCheckpoint() (*api.LogCheckpoint, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer r.Body.Close()
 	if r.StatusCode != 200 {
 		return &api.LogCheckpoint{}, errFromResponse("failed to fetch checkpoint", r)
 	}
@@ -138,7 +139,6 @@ func (c ReadonlyClient) GetCheckpoint() (*api.LogCheckpoint, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read body: %w", err)
 	}
-	defer r.Body.Close()
 
 	n, err := note.Open(b, note.VerifierList(c.LogSigVerifier))
 	if err != nil {

--- a/binary_transparency/firmware/internal/client/client_test.go
+++ b/binary_transparency/firmware/internal/client/client_test.go
@@ -47,7 +47,7 @@ func mustSignCPNote(t *testing.T, b string) []byte {
 	return n
 }
 
-func mustGetCPVerifier(t *testing.T) note.Verifier {
+func mustGetLogSigVerifier(t *testing.T) note.Verifier {
 	t.Helper()
 	v, err := note.NewVerifier(crypto.TestFTPersonalityPub)
 	if err != nil {
@@ -208,7 +208,7 @@ func TestGetCheckpoint(t *testing.T) {
 			}
 			c := client.ReadonlyClient{
 				LogURL:         tsURL,
-				LogSigVerifier: mustGetCPVerifier(t),
+				LogSigVerifier: mustGetLogSigVerifier(t),
 			}
 			cp, err := c.GetCheckpoint()
 			switch {

--- a/binary_transparency/firmware/internal/client/wclient_test.go
+++ b/binary_transparency/firmware/internal/client/wclient_test.go
@@ -78,7 +78,7 @@ func TestGetWitnessCheckpoint(t *testing.T) {
 			}
 			wc := client.WitnessClient{
 				URL:            tsURL,
-				LogSigVerifier: mustGetCPVerifier(t),
+				LogSigVerifier: mustGetLogSigVerifier(t),
 			}
 			cp, err := wc.GetWitnessCheckpoint()
 			switch {

--- a/binary_transparency/firmware/internal/client/wclient_test.go
+++ b/binary_transparency/firmware/internal/client/wclient_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package client
+package client_test
 
 import (
 	"fmt"
@@ -24,26 +24,42 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian-examples/binary_transparency/firmware/api"
+	"github.com/google/trillian-examples/binary_transparency/firmware/internal/client"
+	"github.com/google/trillian-examples/formats/log"
 )
 
 func TestGetWitnessCheckpoint(t *testing.T) {
 	for _, test := range []struct {
 		desc    string
-		body    string
+		body    []byte
 		want    api.LogCheckpoint
 		wantErr bool
 	}{
 		{
 			desc: "valid 1",
-			body: `{ "TreeSize": 1, "TimestampNanos": 123, "RootHash": "EjQ="}`,
-			want: api.LogCheckpoint{TreeSize: 1, TimestampNanos: 123, RootHash: []byte{0x12, 0x34}},
+			body: mustSignCPNote(t, "Firmware Transparency Log v0\n1\nEjQ=\n123\n"),
+			want: api.LogCheckpoint{
+				Checkpoint: log.Checkpoint{
+					Ecosystem: "Firmware Transparency Log v0",
+					Size:      1,
+					Hash:      []byte{0x12, 0x34},
+				},
+				TimestampNanos: 123,
+			},
 		}, {
 			desc: "valid 2",
-			body: `{ "TreeSize": 10, "TimestampNanos": 1230, "RootHash": "NBI="}`,
-			want: api.LogCheckpoint{TreeSize: 10, TimestampNanos: 1230, RootHash: []byte{0x34, 0x12}},
+			body: mustSignCPNote(t, "Firmware Transparency Log v0\n10\nNBI=\n1230\n"),
+			want: api.LogCheckpoint{
+				Checkpoint: log.Checkpoint{
+					Ecosystem: "Firmware Transparency Log v0",
+					Size:      10,
+					Hash:      []byte{0x34, 0x12},
+				},
+				TimestampNanos: 1230,
+			},
 		}, {
 			desc:    "garbage",
-			body:    `garbage`,
+			body:    []byte("garbage"),
 			wantErr: true,
 		},
 	} {
@@ -52,7 +68,7 @@ func TestGetWitnessCheckpoint(t *testing.T) {
 				if !strings.HasSuffix(r.URL.Path, api.WitnessGetCheckpoint) {
 					t.Fatalf("Got unexpected HTTP request on %q", r.URL.Path)
 				}
-				fmt.Fprintln(w, test.body)
+				fmt.Fprint(w, string(test.body))
 			}))
 			defer ts.Close()
 
@@ -60,7 +76,10 @@ func TestGetWitnessCheckpoint(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to parse test server URL: %v", err)
 			}
-			wc := WitnessClient{URL: tsURL}
+			wc := client.WitnessClient{
+				URL:            tsURL,
+				LogSigVerifier: mustGetCPVerifier(t),
+			}
 			cp, err := wc.GetWitnessCheckpoint()
 			switch {
 			case err != nil && !test.wantErr:
@@ -70,6 +89,9 @@ func TestGetWitnessCheckpoint(t *testing.T) {
 			case err != nil && test.wantErr:
 				// expected error
 			default:
+				// TODO(al): fix sigs here
+				cp.Envelope = nil
+
 				if d := cmp.Diff(*cp, test.want); len(d) != 0 {
 					t.Fatalf("Got checkpoint with diff: %s", d)
 				}

--- a/binary_transparency/firmware/internal/verify/bundle.go
+++ b/binary_transparency/firmware/internal/verify/bundle.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/binary_transparency/firmware/api"
 	"github.com/google/trillian-examples/binary_transparency/firmware/internal/crypto"
+	"golang.org/x/mod/sumdb/note"
 )
 
 // ConsistencyProofFunc is a function which returns a consistency proof between two tree sizes.
@@ -34,8 +35,8 @@ type ConsistencyProofFunc func(from, to uint64) ([][]byte, error)
 // the one in the bundle. It also checks consistency proof between update log point
 // and device log point (for non zero device tree size). Upon successful verification
 // returns a proof bundle
-func BundleForUpdate(bundleRaw, fwHash []byte, dc api.LogCheckpoint, cpFunc ConsistencyProofFunc) (api.ProofBundle, api.FirmwareMetadata, error) {
-	proofBundle, fwMeta, err := verifyBundle(bundleRaw)
+func BundleForUpdate(bundleRaw, fwHash []byte, dc api.LogCheckpoint, cpFunc ConsistencyProofFunc, cpSigVerifier note.Verifier) (api.ProofBundle, api.FirmwareMetadata, error) {
+	proofBundle, fwMeta, err := verifyBundle(bundleRaw, note.VerifierList(cpSigVerifier))
 	if err != nil {
 		return proofBundle, fwMeta, err
 	}
@@ -44,15 +45,24 @@ func BundleForUpdate(bundleRaw, fwHash []byte, dc api.LogCheckpoint, cpFunc Cons
 		return proofBundle, fwMeta, fmt.Errorf("firmware update image hash does not match metadata (0x%x != 0x%x)", got, want)
 	}
 
-	cProof, err := cpFunc(dc.TreeSize, proofBundle.Checkpoint.TreeSize)
+	pcNote, err := note.Open(proofBundle.Checkpoint, note.VerifierList(cpSigVerifier))
+	if err != nil {
+		return proofBundle, fwMeta, fmt.Errorf("failed to open the device checkpoint: %w", err)
+	}
+	pc := &api.LogCheckpoint{Envelope: proofBundle.Checkpoint}
+	if err := pc.Unmarshal([]byte(pcNote.Text)); err != nil {
+		return proofBundle, fwMeta, fmt.Errorf("failed to unmarshal the device checkpoint: %w", err)
+	}
+
+	cProof, err := cpFunc(dc.Size, pc.Size)
 	if err != nil {
 		return proofBundle, fwMeta, fmt.Errorf("cpFunc failed: %q", err)
 	}
 
 	// Verify the consistency proof between device and bundle checkpoint
-	if dc.TreeSize > 0 {
+	if dc.Size > 0 {
 		lv := NewLogVerifier()
-		if err := lv.VerifyConsistencyProof(int64(dc.TreeSize), int64(proofBundle.Checkpoint.TreeSize), dc.RootHash, proofBundle.Checkpoint.RootHash, cProof); err != nil {
+		if err := lv.VerifyConsistencyProof(int64(dc.Size), int64(pc.Size), dc.Hash, pc.Hash, cProof); err != nil {
 			return proofBundle, fwMeta, fmt.Errorf("failed verification of consistency proof %w", err)
 		}
 	}
@@ -60,26 +70,32 @@ func BundleForUpdate(bundleRaw, fwHash []byte, dc api.LogCheckpoint, cpFunc Cons
 }
 
 // BundleConsistency verifies the log checkpoint in the bundle is consistent against a given checkpoint (e.g. one fetched from a witness).
-func BundleConsistency(pb api.ProofBundle, rc api.LogCheckpoint, cpFunc ConsistencyProofFunc) error {
+func BundleConsistency(pb api.ProofBundle, rc api.LogCheckpoint, cpFunc ConsistencyProofFunc, cpSigVerifier note.Verifier) error {
 	lv := NewLogVerifier()
 
-	glog.V(1).Infof("Remote TreeSize=%d, Inclusion Index=%d \n", rc.TreeSize, pb.InclusionProof.LeafIndex)
-	if rc.TreeSize < pb.InclusionProof.LeafIndex {
-		return fmt.Errorf("remote verification failed wcp treesize(%d)<device cp index(%d)", rc.TreeSize, pb.InclusionProof.LeafIndex)
+	glog.V(1).Infof("Remote TreeSize=%d, Inclusion Index=%d \n", rc.Size, pb.InclusionProof.LeafIndex)
+	if rc.Size < pb.InclusionProof.LeafIndex {
+		return fmt.Errorf("remote verification failed wcp treesize(%d)<device cp index(%d)", rc.Size, pb.InclusionProof.LeafIndex)
 	}
 
-	fromcp := rc
-	tocp := pb.Checkpoint
-	// swap the remote checkpoint(fromcp) with published checkpoint (tocp) if it is ahead of published checkpoint
-	if fromcp.TreeSize > tocp.TreeSize {
-		fromcp = pb.Checkpoint
-		tocp = rc
+	bundleCPNote, err := note.Open(pb.Checkpoint, note.VerifierList(cpSigVerifier))
+	if err != nil {
+		return fmt.Errorf("failed to open the proof bundle checkpoint: %w", err)
 	}
-	cProof, err := cpFunc(fromcp.TreeSize, tocp.TreeSize)
+	bundleCP := api.LogCheckpoint{Envelope: pb.Checkpoint}
+	if err := bundleCP.Unmarshal([]byte(bundleCPNote.Text)); err != nil {
+		return fmt.Errorf("failed to unmarshal the proof bundle checkpoint: %w", err)
+	}
+	fromCP, toCP := rc, bundleCP
+	// swap the remote checkpoint(fromCP) with published checkpoint (toCP) if it is ahead of published checkpoint
+	if rc.Size > bundleCP.Size {
+		fromCP, toCP = toCP, fromCP
+	}
+	cProof, err := cpFunc(fromCP.Size, toCP.Size)
 	if err != nil {
 		return fmt.Errorf("cpFunc failed: %q", err)
 	}
-	if err := lv.VerifyConsistencyProof(int64(fromcp.TreeSize), int64(tocp.TreeSize), fromcp.RootHash, tocp.RootHash, cProof); err != nil {
+	if err := lv.VerifyConsistencyProof(int64(fromCP.Size), int64(toCP.Size), fromCP.Hash, toCP.Hash, cProof); err != nil {
 		return fmt.Errorf("failed consistency proof between remote and client checkpoint %w", err)
 	}
 	return nil
@@ -88,8 +104,8 @@ func BundleConsistency(pb api.ProofBundle, rc api.LogCheckpoint, cpFunc Consiste
 // BundleForBoot checks that the manifest, checkpoint, and proofs in a bundle
 // are all self-consistent, and that the provided firmware measurement matches
 // the one expected by the bundle.
-func BundleForBoot(bundleRaw, measurement []byte) error {
-	_, fwMeta, err := verifyBundle(bundleRaw)
+func BundleForBoot(bundleRaw, measurement []byte, cpSigVerifiers note.Verifiers) error {
+	_, fwMeta, err := verifyBundle(bundleRaw, cpSigVerifiers)
 	if err != nil {
 		return err
 	}
@@ -101,13 +117,20 @@ func BundleForBoot(bundleRaw, measurement []byte) error {
 }
 
 // verifyBundle parses a proof bundle and verifies its self-consistency.
-func verifyBundle(bundleRaw []byte) (api.ProofBundle, api.FirmwareMetadata, error) {
+func verifyBundle(bundleRaw []byte, cpSigVerifiers note.Verifiers) (api.ProofBundle, api.FirmwareMetadata, error) {
 	var pb api.ProofBundle
 	if err := json.Unmarshal(bundleRaw, &pb); err != nil {
 		return api.ProofBundle{}, api.FirmwareMetadata{}, fmt.Errorf("failed to parse proof bundle: %w", err)
 	}
 
-	// TODO(al): check Checkpoint signature
+	bundleCPNote, err := note.Open(pb.Checkpoint, cpSigVerifiers)
+	if err != nil {
+		return api.ProofBundle{}, api.FirmwareMetadata{}, fmt.Errorf("failed to open the proof bundle checkpoint: %w", err)
+	}
+	bundleCP := &api.LogCheckpoint{Envelope: pb.Checkpoint}
+	if err := bundleCP.Unmarshal([]byte(bundleCPNote.Text)); err != nil {
+		return api.ProofBundle{}, api.FirmwareMetadata{}, fmt.Errorf("failed to unmarshal the proof bundle checkpoint: %w", err)
+	}
 
 	var fwStatement api.SignedStatement
 	if err := json.Unmarshal(pb.ManifestStatement, &fwStatement); err != nil {
@@ -123,7 +146,7 @@ func verifyBundle(bundleRaw []byte) (api.ProofBundle, api.FirmwareMetadata, erro
 
 	lh := HashLeaf(pb.ManifestStatement)
 	lv := NewLogVerifier()
-	if err := lv.VerifyInclusionProof(int64(pb.InclusionProof.LeafIndex), int64(pb.Checkpoint.TreeSize), pb.InclusionProof.Proof, pb.Checkpoint.RootHash, lh); err != nil {
+	if err := lv.VerifyInclusionProof(int64(pb.InclusionProof.LeafIndex), int64(bundleCP.Size), pb.InclusionProof.Proof, bundleCP.Hash, lh); err != nil {
 		return api.ProofBundle{}, api.FirmwareMetadata{}, fmt.Errorf("invalid inclusion proof in bundle: %w", err)
 	}
 

--- a/binary_transparency/firmware/internal/verify/bundle_test.go
+++ b/binary_transparency/firmware/internal/verify/bundle_test.go
@@ -26,16 +26,43 @@ import (
 	"github.com/google/trillian-examples/binary_transparency/firmware/internal/crypto"
 	"github.com/google/trillian-examples/binary_transparency/firmware/internal/verify"
 	"github.com/google/trillian/merkle/logverifier"
+	"golang.org/x/mod/sumdb/note"
 )
 
 const (
-	goldenProofBundle   = `{"ManifestStatement":"eyJUeXBlIjoxMDIsIlN0YXRlbWVudCI6ImV5SkVaWFpwWTJWSlJDSTZJbVIxYlcxNUlpd2lSbWx5YlhkaGNtVlNaWFpwYzJsdmJpSTZNU3dpUm1seWJYZGhjbVZKYldGblpWTklRVFV4TWlJNkltZ3ZTblpLTURVeE1GZE5Ua05hZG1wWFQwTXdVMUZxTDFKUFJHVXpLMGh6Uld0dE5HMUhUbnBWVEhSd1lXVlVhblkyU2xrcmQzSTBlVk51Vm5aNVJqVXdZa055TVhSd2NYZERiMEZvWm5CeFFscHNNbUpSUFQwaUxDSkZlSEJsWTNSbFpFWnBjbTEzWVhKbFRXVmhjM1Z5WlcxbGJuUWlPaUkyZEZWWGVYbHJlbmRtYjI5dVIzVm5ibVl4WkV3clkyZGtObUpGVjFWb2IyeEJUbUZFVERoS1dVdFhkR1J0VUdORlpWbDJaMDgyYmsxeUwwbE1aMWRRWTFWWloyZDJRVUZ5Y25SaFUwSnRZVzQxU0RSTFp6MDlJaXdpUW5WcGJHUlVhVzFsYzNSaGJYQWlPaUl5TURJd0xURXdMVEV3VkRFMU9qTXdPakl3TGpFd1dpSjkiLCJTaWduYXR1cmUiOiJUeUxVdFpCdHJHbyt3anRoSjI2Rk8wVE5QUHpTTDZhU0c1V0ZTanRCcjZLZ2x4a0RjR3dmZUxTTEpjbklmUnhZMnVJZHZLL09tMStXMndLNEkxSFRUYTdIUFZlSHo2MmF0V09hZm9TL1ZGc01OdEx1RkplaU5WNE5uY2Y0bllYMFBDdnN0MHRpYm5TVFRzNnEwMUZ1cEhaMnFwc2lyY2hFVXgwLzFjOFFOM2hGZVArSXcwVWxPNTVvZUhlWGtlRGRwL2w5SCsvZjYxYndFMmpHZVl1cFcvbld2bmN2NFgrS00weXgrYW1oVi9od0lCMDQ2aitNQzVndkd4LzJ2TkkySk5JeTBOQk13YWRIK1VONnp1MzRIZzM5NkY4MkxJU2NTOXU2MENBY3hzRlozR3d5NGpoR1JXR1lwSnhXdEJ6Zk5hZ1IvaVdmUzRJY2tJVmZ5Z2ZQUXc9PSJ9","Checkpoint":{"TreeSize":5,"RootHash":"X6TF8AcdIHv9ZtQl+SSaeVNc/Z5Rc42px1iFRKTcCtw=","TimestampNanos":1607450738111506088},"InclusionProof":{"Value":null,"LeafIndex":4,"Proof":["KFh4IVeIwbsvbWyz2QHVCXXyjWTRDqusRa0ZEjS2fls="]}}`
+	goldenProofBundle   = `{"ManifestStatement":"eyJUeXBlIjoxMDIsIlN0YXRlbWVudCI6ImV5SkVaWFpwWTJWSlJDSTZJbVIxYlcxNUlpd2lSbWx5YlhkaGNtVlNaWFpwYzJsdmJpSTZNU3dpUm1seWJYZGhjbVZKYldGblpWTklRVFV4TWlJNkltZ3ZTblpLTURVeE1GZE5Ua05hZG1wWFQwTXdVMUZxTDFKUFJHVXpLMGh6Uld0dE5HMUhUbnBWVEhSd1lXVlVhblkyU2xrcmQzSTBlVk51Vm5aNVJqVXdZa055TVhSd2NYZERiMEZvWm5CeFFscHNNbUpSUFQwaUxDSkZlSEJsWTNSbFpFWnBjbTEzWVhKbFRXVmhjM1Z5WlcxbGJuUWlPaUkyZEZWWGVYbHJlbmRtYjI5dVIzVm5ibVl4WkV3clkyZGtObUpGVjFWb2IyeEJUbUZFVERoS1dVdFhkR1J0VUdORlpWbDJaMDgyYmsxeUwwbE1aMWRRWTFWWloyZDJRVUZ5Y25SaFUwSnRZVzQxU0RSTFp6MDlJaXdpUW5WcGJHUlVhVzFsYzNSaGJYQWlPaUl5TURJd0xURXdMVEV3VkRFMU9qTXdPakl3TGpFd1dpSjkiLCJTaWduYXR1cmUiOiJUeUxVdFpCdHJHbyt3anRoSjI2Rk8wVE5QUHpTTDZhU0c1V0ZTanRCcjZLZ2x4a0RjR3dmZUxTTEpjbklmUnhZMnVJZHZLL09tMStXMndLNEkxSFRUYTdIUFZlSHo2MmF0V09hZm9TL1ZGc01OdEx1RkplaU5WNE5uY2Y0bllYMFBDdnN0MHRpYm5TVFRzNnEwMUZ1cEhaMnFwc2lyY2hFVXgwLzFjOFFOM2hGZVArSXcwVWxPNTVvZUhlWGtlRGRwL2w5SCsvZjYxYndFMmpHZVl1cFcvbld2bmN2NFgrS00weXgrYW1oVi9od0lCMDQ2aitNQzVndkd4LzJ2TkkySk5JeTBOQk13YWRIK1VONnp1MzRIZzM5NkY4MkxJU2NTOXU2MENBY3hzRlozR3d5NGpoR1JXR1lwSnhXdEJ6Zk5hZ1IvaVdmUzRJY2tJVmZ5Z2ZQUXc9PSJ9","Checkpoint":"RmlybXdhcmUgVHJhbnNwYXJlbmN5IExvZyB2MAo1Clg2VEY4QWNkSUh2OVp0UWwrU1NhZVZOYy9aNVJjNDJweDFpRlJLVGNDdHc9CjE2MDc0NTA3MzgxMTE1MDYwODgKCuKAlCBmdF9wZXJzb25hbGl0eSA2S0pDdlVyOWRqRGJ5Wm44dlRmYU9UN0hqRzZtMzkyaUkzMStHc2Naak9hclFnRHRVVlZEY2YreG5QTU90ZG5pMEV5bmNQdmNENjA1VDVPeXhQNXM5a2ZnOUFjPQo=","InclusionProof":{"Value":null,"LeafIndex":4,"Proof":["KFh4IVeIwbsvbWyz2QHVCXXyjWTRDqusRa0ZEjS2fls="]}}`
 	goldenFirmwareImage = `Firmware image`
 	// goldenFirmwareHashB64 is a base64 encoded string for ExpectedMeasurement field inside ManifestStatement.
 	// For the dummy device, this is SHA512("dummy"||img), where img is the base64 decoded bytes from
 	// goldenUpdate.FirmwareImage
 	goldenFirmwareHashB64 = "6tUWyykzwfoonGugnf1dL+cgd6bEWUholANaDL8JYKWtdmPcEeYvgO6nMr/ILgWPcUYggvAArrtaSBman5H4Kg=="
 )
+
+func mustGetCPVerifier(t *testing.T) note.Verifier {
+	t.Helper()
+	v, err := note.NewVerifier(crypto.TestFTPersonalityPub)
+	if err != nil {
+		t.Fatalf("failed to create verifier: %q", err)
+	}
+	return v
+}
+
+// This test is useful for creating the Checkpoint field of the goldenProofBundle above.
+func TestGenerateGoldenCheckpoint(t *testing.T) {
+	cp := "RmlybXdhcmUgVHJhbnNwYXJlbmN5IExvZyB2MAo1Clg2VEY4QWNkSUh2OVp0UWwrU1NhZVZOYy9aNVJjNDJweDFpRlJLVGNDdHc9CjE2MDc0NTA3MzgxMTE1MDYwODgK"
+	nb, _ := base64.StdEncoding.DecodeString(cp)
+	s, err := note.NewSigner(crypto.TestFTPersonalityPriv)
+	if err != nil {
+		t.Fatalf("failed to create signer: %q", err)
+	}
+	n, err := note.Sign(&note.Note{Text: string(nb)}, s)
+	if err != nil {
+		t.Fatalf("failed to sign note: %q", err)
+	}
+	t.Log(string(n))
+	t.Log(base64.StdEncoding.EncodeToString(n))
+
+}
 
 func TestBundleForUpdate(t *testing.T) {
 	var dc api.LogCheckpoint
@@ -57,7 +84,7 @@ func TestBundleForUpdate(t *testing.T) {
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			imgHash := sha512.Sum512(test.img)
-			_, _, err := verify.BundleForUpdate([]byte(goldenProofBundle), imgHash[:], dc, proof)
+			_, _, err := verify.BundleForUpdate([]byte(goldenProofBundle), imgHash[:], dc, proof, mustGetCPVerifier(t))
 			if (err != nil) != test.wantErr {
 				var lve logverifier.RootMismatchError
 				if errors.As(err, &lve) {
@@ -95,7 +122,7 @@ func TestBundleForBoot(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			err := verify.BundleForBoot([]byte(goldenProofBundle), test.measurement)
+			err := verify.BundleForBoot([]byte(goldenProofBundle), test.measurement, note.VerifierList(mustGetCPVerifier(t)))
 			if (err != nil) != test.wantErr {
 				t.Fatalf("want err %v, got %q", test.wantErr, err)
 			}

--- a/binary_transparency/firmware/internal/verify/bundle_test.go
+++ b/binary_transparency/firmware/internal/verify/bundle_test.go
@@ -38,7 +38,7 @@ const (
 	goldenFirmwareHashB64 = "6tUWyykzwfoonGugnf1dL+cgd6bEWUholANaDL8JYKWtdmPcEeYvgO6nMr/ILgWPcUYggvAArrtaSBman5H4Kg=="
 )
 
-func mustGetCPVerifier(t *testing.T) note.Verifier {
+func mustGetLogSigVerifier(t *testing.T) note.Verifier {
 	t.Helper()
 	v, err := note.NewVerifier(crypto.TestFTPersonalityPub)
 	if err != nil {
@@ -84,7 +84,7 @@ func TestBundleForUpdate(t *testing.T) {
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			imgHash := sha512.Sum512(test.img)
-			_, _, err := verify.BundleForUpdate([]byte(goldenProofBundle), imgHash[:], dc, proof, mustGetCPVerifier(t))
+			_, _, err := verify.BundleForUpdate([]byte(goldenProofBundle), imgHash[:], dc, proof, mustGetLogSigVerifier(t))
 			if (err != nil) != test.wantErr {
 				var lve logverifier.RootMismatchError
 				if errors.As(err, &lve) {
@@ -122,7 +122,7 @@ func TestBundleForBoot(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			err := verify.BundleForBoot([]byte(goldenProofBundle), test.measurement, note.VerifierList(mustGetCPVerifier(t)))
+			err := verify.BundleForBoot([]byte(goldenProofBundle), test.measurement, note.VerifierList(mustGetLogSigVerifier(t)))
 			if (err != nil) != test.wantErr {
 				t.Fatalf("want err %v, got %q", test.wantErr, err)
 			}


### PR DESCRIPTION
Best reviewed commit-by-commit.

