### PR TITLE
Tool that bulk downloads CT logs, respecting backoffs

### DIFF
--- a/clone/README.md
+++ b/clone/README.md
@@ -1,0 +1,41 @@
+# Log Cloner
+
+A log client that copies a CT log to a local database for processing.
+The tool downloads batches of leaves in parallel, but always writes them to the local database in sequence.
+This ensures there are no missing ranges, which keeps state tracking easier.
+
+One important implementation feature is that the download tools will exponentially back off if there are errors
+communicating with the log, which prevents the client from performing a DoS on any log it is downloading.
+
+## Setup
+
+In MariaDB, create a database and user:
+
+```
+MariaDB [(none)]> CREATE DATABASE google_xenon2022;
+MariaDB [(none)]> CREATE USER 'clonetool'@localhost IDENTIFIED BY 'letmein';
+MariaDB [(none)]> GRANT ALL PRIVILEGES ON google_xenon2022.* TO 'clonetool'@localhost;
+MariaDB [(none)]> FLUSH PRIVILEGES;
+```
+
+Now you can clone the log with:
+
+```
+go run ./clone/cmd/ctclone --alsologtostderr --v=1 --log_url https://ct.googleapis.com/logs/xenon2022/ --mysql_uri 'clonetool:letmein@tcp(localhost)/google_xenon2022'
+```
+
+See the optional flags in the `ctclone` tool to configure tuning parameters.
+
+## Docker
+
+To build a docker image, run the following from the `trillian-examples` root directory:
+
+```
+docker build . -t ctclone -f ./clone/cmd/ctclone/Dockerfile
+```
+
+This can be pointed at a local MySQL instance running outside of docker using:
+
+```
+docker run --name clone_xenon2022 -d ctclone --alsologtostderr --v=1 --log_url https://ct.googleapis.com/logs/xenon2022/ --mysql_uri 'clonetool:letmein@tcp(host.docker.internal)/google_xenon2022'
+```

--- a/clone/README.md
+++ b/clone/README.md
@@ -5,7 +5,7 @@ The tool downloads batches of leaves in parallel, but always writes them to the 
 This ensures there are no missing ranges, which keeps state tracking easier.
 
 One important implementation feature is that the download tools will exponentially back off if there are errors
-communicating with the log, which prevents the client from performing a DoS on any log it is downloading.
+communicating with the log; this prevents the client from performing a DoS on any log it is downloading.
 
 ## Setup
 

--- a/clone/cmd/ctclone/Dockerfile
+++ b/clone/cmd/ctclone/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:buster AS builder
+
+ARG GOFLAGS=""
+ENV GOFLAGS=$GOFLAGS
+ENV GO111MODULE=on
+
+# Move to working directory /build
+WORKDIR /build
+
+# Copy and download dependency using go mod
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+# Copy the code into the container
+COPY . .
+
+# Build the application
+RUN go build ./clone/cmd/ctclone
+
+# Build release image
+FROM golang:buster
+
+COPY --from=builder /build/ctclone /bin/ctclone
+ENTRYPOINT ["/bin/ctclone"]

--- a/clone/cmd/ctclone/ctclone.go
+++ b/clone/cmd/ctclone/ctclone.go
@@ -1,0 +1,178 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ctclone is a one-shot tool for downloading entries from a CT log.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/clone/internal/download"
+	"github.com/google/trillian-examples/clone/internal/logdb"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+const getEntriesFormat = "ct/v1/get-entries?start=%d&end=%d"
+
+var (
+	logURL         = flag.String("log_url", "", "Log storage root URL, https://ct.googleapis.com/rocketeer/")
+	mysqlURI       = flag.String("mysql_uri", "", "URL of a MySQL database to clone the log into. The DB should contain only one log.")
+	fetchBatchSize = flag.Uint("fetch_batch_size", 32, "The number of entries to fetch from the log in each request.")
+	writeBatchSize = flag.Uint("write_batch_size", 32, "The number of leaves to write in each DB transaction.")
+	workers        = flag.Uint("workers", 2, "The number of worker threads to run in parallel to fetch entries.")
+)
+
+func main() {
+	flag.Parse()
+
+	if !strings.HasSuffix(*logURL, "/") {
+		glog.Exit("'log_url' must end with '/'")
+	}
+	if len(*mysqlURI) == 0 {
+		glog.Exit("Missing required parameter 'mysql_uri'")
+	}
+	lu, err := url.Parse(*logURL)
+	if err != nil {
+		glog.Exitf("log_url is invalid: %v", err)
+	}
+
+	ctx := context.Background()
+	db, err := logdb.NewDatabase(*mysqlURI)
+	if err != nil {
+		glog.Exitf("Failed to connect to database: %q", err)
+	}
+	// TODO(mhutchinson): Persist log URI and check here to prevent user-error writing different logs to same DB.
+	head, err := db.Head()
+	if err != nil {
+		if err == logdb.ErrNoDataFound {
+			glog.Infof("failed to find head of database, assuming empty and starting from scratch: %v", err)
+			head = -1
+		} else {
+			glog.Exitf("Failed to query for head of local log: %q", err)
+		}
+	}
+	next := uint64(head + 1)
+
+	fetcher := download.NewHTTPFetcher(lu)
+
+	errChan := make(chan error)
+	lc := make(chan []byte, *writeBatchSize*2)
+	go download.Bulk(next, certLeafFetcher{fetcher}.Batch, *workers, *fetchBatchSize, lc, errChan)
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	r := reporter{
+		lastReported: next,
+		lastReport:   time.Now(),
+	}
+
+	batch := make([][]byte, *writeBatchSize)
+	bi := 0
+	bs := next
+
+	for {
+		select {
+		case err := <-errChan:
+			glog.Exit(err)
+		case <-ticker.C:
+			r.report()
+		case l := <-lc:
+			workDone := r.trackWork(next)
+			next++
+			batch[bi] = l
+			bi = (bi + 1) % int(*writeBatchSize)
+			if bi == 0 {
+				if err := db.WriteLeaves(ctx, bs, batch); err != nil {
+					glog.Exitf("Failed to write to DB for batch starting at %d: %q", bs, err)
+				}
+				bs = next
+			}
+			workDone()
+		}
+	}
+}
+
+type reporter struct {
+	lastReport   time.Time
+	lastReported uint64
+	lastWorked   uint64
+	epochWorked  time.Duration
+}
+
+func (r *reporter) report() {
+	elapsed := time.Since(r.lastReport)
+	workRatio := r.epochWorked.Seconds() / elapsed.Seconds()
+
+	rate := float64(r.lastWorked-r.lastReported) / elapsed.Seconds()
+	glog.Infof("%.1f leaves/s, last leaf=%d, time working=%.1f%%", rate, r.lastReported, 100*workRatio)
+	r.epochWorked = 0
+	r.lastReported = r.lastWorked
+	r.lastReport = time.Now()
+}
+
+func (r *reporter) trackWork(index uint64) func() {
+	start := time.Now()
+	r.lastWorked = index
+
+	return func() {
+		end := time.Now()
+		r.epochWorked += end.Sub(start)
+	}
+}
+
+// fetcher gets data paths. This allows impl to be swapped for tests.
+type fetcher interface {
+	// GetData gets the data at the given path, or returns an error.
+	GetData(path string) ([]byte, error)
+}
+
+type certLeafFetcher struct {
+	f fetcher
+}
+
+func (clf certLeafFetcher) Batch(start uint64, leaves [][]byte) error {
+	// CT API gets [start, end] not [start, end).
+	last := start + uint64(len(leaves)) - 1
+	data, err := clf.f.GetData(fmt.Sprintf(getEntriesFormat, start, last))
+	if err != nil {
+		return fmt.Errorf("fetcher.GetData: %w", err)
+	}
+	var r getEntriesResponse
+	if err := json.Unmarshal(data, &r); err != nil {
+		return fmt.Errorf("json.Unmarshal of %d bytes: %w", len(data), err)
+	}
+	if got, want := len(r.Leaves), len(leaves); got != want {
+		return fmt.Errorf("wanted %d leaves but got %d", want, got)
+	}
+	for i, l := range r.Leaves {
+		leaves[i] = l.Data
+	}
+	return nil
+}
+
+type getEntriesResponse struct {
+	Leaves []leafInput `json:"entries"`
+}
+
+type leafInput struct {
+	Data []byte `json:"leaf_input"`
+}

--- a/clone/cmd/ctclone/ctclone.go
+++ b/clone/cmd/ctclone/ctclone.go
@@ -64,7 +64,7 @@ func main() {
 	head, err := db.Head()
 	if err != nil {
 		if err == logdb.ErrNoDataFound {
-			glog.Infof("failed to find head of database, assuming empty and starting from scratch: %v", err)
+			glog.Infof("Failed to find head of database, assuming empty and starting from scratch: %v", err)
 			head = -1
 		} else {
 			glog.Exitf("Failed to query for head of local log: %q", err)

--- a/clone/cmd/ctclone/ctclone.go
+++ b/clone/cmd/ctclone/ctclone.go
@@ -149,6 +149,9 @@ type certLeafFetcher struct {
 	f fetcher
 }
 
+// Batch provides a mechanism to fetch a range of leaves.
+// Enough leaves are fetched to fully fill `leaves`, or an error is returned.
+// This implements batch.BatchFetch.
 func (clf certLeafFetcher) Batch(start uint64, leaves [][]byte) error {
 	// CT API gets [start, end] not [start, end).
 	last := start + uint64(len(leaves)) - 1

--- a/clone/cmd/ctclone/ctclone_test.go
+++ b/clone/cmd/ctclone/ctclone_test.go
@@ -1,0 +1,96 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCertLeafFetcher(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		start   uint64
+		count   uint
+		urls    map[string]string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:  "first leaf",
+			start: 0,
+			count: 1,
+			urls:  map[string]string{"ct/v1/get-entries?start=0&end=0": `{"entries":[{"leaf_input": "dGhpcyBjb3VsZCBiZSBhIGNlcnQ="}]}`},
+			want:  []string{"this could be a cert"},
+		},
+		{
+			name:  "three leaves",
+			start: 101,
+			count: 3,
+			urls:  map[string]string{"ct/v1/get-entries?start=101&end=103": `{"entries":[{"leaf_input": "b25lIG9oIG9uZQ=="},{"leaf_input": "b25lIG9oIHR3bw=="},{"leaf_input": "b25lIG9oIHRocmVl"}]}`},
+			want:  []string{"one oh one", "one oh two", "one oh three"},
+		},
+		{
+			name:    "too many returned",
+			start:   42,
+			count:   1,
+			urls:    map[string]string{"ct/v1/get-entries?start=42&end=42": `{"entries":[{"leaf_input": "b25l"},{"leaf_input": "dHdv"}]}`},
+			wantErr: true,
+		},
+		{
+			name:    "not enough returned",
+			start:   42,
+			count:   2,
+			urls:    map[string]string{"ct/v1/get-entries?start=42&end=43": `{"entries":[{"leaf_input": "b25l"}]}`},
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			clf := certLeafFetcher{&fakeFetcher{test.urls}}
+			leaves := make([][]byte, test.count)
+			err := clf.Batch(test.start, leaves)
+			switch {
+			case err != nil && !test.wantErr:
+				t.Fatalf("Got unexpected error %q", err)
+			case err == nil && test.wantErr:
+				t.Fatal("Got no error, but wanted error")
+			case err != nil && test.wantErr:
+				// expected error
+			default:
+				gotStrings := make([]string, len(leaves))
+				for i, bs := range leaves {
+					gotStrings[i] = string(bs)
+				}
+				if d := cmp.Diff(gotStrings, test.want); len(d) != 0 {
+					t.Fatalf("Got different result: %s", d)
+				}
+			}
+		})
+	}
+}
+
+type fakeFetcher struct {
+	values map[string]string
+}
+
+func (f *fakeFetcher) GetData(path string) ([]byte, error) {
+	res, ok := f.values[path]
+	if !ok {
+		return nil, fmt.Errorf("could not find '%s'", path)
+	}
+	return []byte(res), nil
+}

--- a/clone/internal/download/batch.go
+++ b/clone/internal/download/batch.go
@@ -1,0 +1,107 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// download contains classes for downloading data from logs.
+package download
+
+import (
+	"fmt"
+	"time"
+
+	backoff "github.com/cenkalti/backoff/v4"
+	"github.com/golang/glog"
+)
+
+// BatchFetch should be implemented to provide a mechanism to fetch a range of leaves.
+// Enough leaves should be fetched to fully fill `leaves`, or an error should be returned.
+type BatchFetch func(start uint64, leaves [][]byte) error
+
+// Bulk keeps downloading leaves starting from `first`, using the given leaf fetcher.
+// The number of workers and the batch size to use for each of the fetch requests are also specified.
+// The resulting leaves are returned in order over `leafChan`, and any terminal errors are returned via `errc`.
+// Internally this uses exponential backoff on the workers to download as fast as possible, but no faster.
+func Bulk(first uint64, batchFetch BatchFetch, workers, batchSize uint, leafChan chan<- []byte, errc chan<- error) {
+	// Each worker gets its own unbuffered channel to make sure it can only be at most one ahead.
+	// This prevents lots of wasted work happening if one shard gets stuck.
+	rangeChans := make([]chan leafRange, workers)
+
+	increment := workers * batchSize
+	for i := uint(0); i < workers; i++ {
+		rangeChans[i] = make(chan leafRange)
+		start := first + uint64(i*batchSize)
+		go fetchWorker{
+			label:      fmt.Sprintf("worker %d", i),
+			start:      start,
+			count:      batchSize,
+			increment:  uint64(increment),
+			out:        rangeChans[i],
+			errc:       errc,
+			batchFetch: batchFetch,
+		}.run()
+	}
+
+	// Perpetually round-robin through the sharded ranges.
+	for i := 0; ; i = (i + 1) % int(workers) {
+		r := <-rangeChans[i]
+		for _, l := range r.leaves {
+			leafChan <- l
+		}
+	}
+}
+
+type leafRange struct {
+	start  uint64
+	leaves [][]byte
+}
+
+type fetchWorker struct {
+	label            string
+	start, increment uint64
+	count            uint
+	out              chan<- leafRange
+	errc             chan<- error
+	batchFetch       BatchFetch
+}
+
+func (w fetchWorker) run() {
+	// TODO(mhutchinson): Consider some way to reset this after intermittent connectivity issue.
+	// If this is pushed in the loop then it fixes this issue, but at the cost that the worker
+	// will never reach a stable rate if it is asked to back off. This is optimized for being
+	// gentle to the logs, which is a reasonable default for a happy ecosystem.
+	bo := backoff.NewExponentialBackOff()
+	for {
+		leaves := make([][]byte, w.count)
+		var c leafRange
+		operation := func() error {
+			err := w.batchFetch(w.start, leaves)
+			if err != nil {
+				return fmt.Errorf("LeafFetcher.Batch(%d, %d): %w", w.start, w.count, err)
+			}
+			c = leafRange{
+				start:  w.start,
+				leaves: leaves,
+			}
+			return nil
+		}
+		err := backoff.RetryNotify(operation, bo, func(e error, _ time.Duration) {
+			glog.V(1).Infof("%s: Retryable error getting data: %q", w.label, e)
+		})
+		if err != nil {
+			w.errc <- err
+		} else {
+			w.out <- c
+		}
+		w.start += w.increment
+	}
+}

--- a/clone/internal/download/batch.go
+++ b/clone/internal/download/batch.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// download contains classes for downloading data from logs.
+// download contains a library for downloading data from logs.
 package download
 
 import (
@@ -31,6 +31,7 @@ type BatchFetch func(start uint64, leaves [][]byte) error
 // The number of workers and the batch size to use for each of the fetch requests are also specified.
 // The resulting leaves are returned in order over `leafChan`, and any terminal errors are returned via `errc`.
 // Internally this uses exponential backoff on the workers to download as fast as possible, but no faster.
+// TODO(mhutchinson): Pass in a context and check for termination so we can gracefully exit.
 func Bulk(first uint64, batchFetch BatchFetch, workers, batchSize uint, leafChan chan<- []byte, errc chan<- error) {
 	// Each worker gets its own unbuffered channel to make sure it can only be at most one ahead.
 	// This prevents lots of wasted work happening if one shard gets stuck.

--- a/clone/internal/download/batch_test.go
+++ b/clone/internal/download/batch_test.go
@@ -1,0 +1,110 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package download
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFetchWorkerRun(t *testing.T) {
+	rangec := make(chan leafRange, 10)
+	errc := make(chan error)
+	var first uint64
+	var batchSize uint = 10
+
+	fakeFetch := func(start uint64, leaves [][]byte) error {
+		return nil
+	}
+	fw := fetchWorker{
+		label:      "solipsism",
+		start:      first,
+		increment:  uint64(batchSize),
+		count:      batchSize,
+		out:        rangec,
+		errc:       errc,
+		batchFetch: fakeFetch,
+	}
+
+	go fw.run()
+
+	for i := 0; i < 10; i++ {
+		select {
+		case err := <-errc:
+			t.Fatal(err)
+		case r := <-rangec:
+			if got, want := r.start, uint64(i*10); got != want {
+				t.Errorf("%d got != want (%d != %d)", i, got, want)
+			}
+		}
+	}
+}
+
+func TestBulk(t *testing.T) {
+	leafc := make(chan []byte, 10)
+	errc := make(chan error)
+	var first uint64
+	var workers uint = 4
+	var batchSize uint = 10
+
+	fakeFetch := func(start uint64, leaves [][]byte) error {
+		for i := range leaves {
+			leaves[i] = []byte(fmt.Sprintf("%d.%d", start, i))
+		}
+		return nil
+	}
+	go Bulk(first, fakeFetch, workers, batchSize, leafc, errc)
+
+	for i := 0; i < 1000; i++ {
+		select {
+		case err := <-errc:
+			t.Fatal(err)
+		case l := <-leafc:
+			tens := (i / 10) * 10
+			units := i % 10
+			if got, want := string(l), fmt.Sprintf("%d.%d", tens, units); got != want {
+				t.Errorf("%d got != want (%q != %q)", i, got, want)
+			}
+		}
+	}
+}
+
+func BenchmarkBulk(b *testing.B) {
+	leafc := make(chan []byte, 10)
+	errc := make(chan error)
+	var first uint64
+	var workers uint = 20
+	var batchSize uint = 10
+
+	fakeFetch := func(start uint64, leaves [][]byte) error {
+		for i := range leaves {
+			// Allocate a non-trivial amount of memory for the leaf.
+			leaf := make([]byte, 1024)
+			leaves[i] = leaf
+		}
+		return nil
+	}
+	go Bulk(first, fakeFetch, workers, batchSize, leafc, errc)
+
+	for n := 0; n < b.N; n++ {
+		for i := 0; i < 1000; i++ {
+			select {
+			case err := <-errc:
+				b.Fatal(err)
+			case <-leafc:
+			}
+		}
+	}
+}

--- a/clone/internal/download/http.go
+++ b/clone/internal/download/http.go
@@ -1,0 +1,58 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package download
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+// NewHTTPFetcher returns an HTTPFetcher that gets paths appended to the given prefix.
+func NewHTTPFetcher(prefix *url.URL) HTTPFetcher {
+	return HTTPFetcher{
+		baseURL: prefix,
+	}
+}
+
+// HTTPFetcher gets the data over HTTP(S).
+// This is thread safe.
+type HTTPFetcher struct {
+	baseURL *url.URL
+}
+
+// GetData gets the data at the given path.
+func (f HTTPFetcher) GetData(path string) ([]byte, error) {
+	u, err := f.baseURL.Parse(path)
+	if err != nil {
+		return nil, fmt.Errorf("url (%s) failed to parse(%s): %w", f.baseURL, path, err)
+	}
+	target := u.String()
+	resp, err := http.Get(target)
+	if err != nil {
+		return nil, fmt.Errorf("http.Get: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		// Could be worth returning a special error when we've been explicitly told to back off.
+		return nil, fmt.Errorf("GET %v: %v", target, resp.Status)
+	}
+	// TODO(mhutchinson): Consider using io.LimitReader and making it configurable.
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("ioutil.ReadAll: %w", err)
+	}
+	return data, nil
+}

--- a/clone/internal/logdb/database.go
+++ b/clone/internal/logdb/database.go
@@ -1,0 +1,82 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// logdb contains read/write access to the locally cloned data.
+package logdb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ErrNoDataFound is returned when the DB appears valid but has no data in it.
+var ErrNoDataFound = errors.New("no data found")
+
+// Database provides read/write access to the mirrored log.
+type Database struct {
+	db *sql.DB
+}
+
+// NewDatabase creates a Database using the given database connection.
+// This has been tested with sqlite and MariaDB.
+func NewDatabase(connString string) (*Database, error) {
+	dbConn, err := sql.Open("mysql", connString)
+	if err != nil {
+		return nil, fmt.Errorf("sql.Open: %w", err)
+	}
+	db := &Database{
+		db: dbConn,
+	}
+	return db, db.Init()
+}
+
+// Init creates the database tables if needed.
+func (d *Database) Init() error {
+	if _, err := d.db.Exec("CREATE TABLE IF NOT EXISTS leaves (id INTEGER PRIMARY KEY, data BLOB)"); err != nil {
+		return err
+	}
+	// TODO(mhutchinson): Create a table for checkpoints too?
+	return nil
+}
+
+// WriteLeaves writes the contiguous chunk of leaves, starting at the stated index.
+// This is an atomic operation, and will fail if any leaf cannot be inserted.
+func (d *Database) WriteLeaves(ctx context.Context, start uint64, leaves [][]byte) error {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("BeginTx: %w", err)
+	}
+	for li, l := range leaves {
+		lidx := uint64(li) + start
+		tx.Exec("INSERT INTO leaves (id, data) VALUES (?, ?)", lidx, l)
+	}
+	return tx.Commit()
+}
+
+// Head returns the largest leaf index written.
+func (d *Database) Head() (int64, error) {
+	var head sql.NullInt64
+	if err := d.db.QueryRow("SELECT MAX(id) AS head FROM leaves").Scan(&head); err != nil {
+		if err == sql.ErrNoRows {
+			return 0, ErrNoDataFound
+		}
+		return 0, fmt.Errorf("failed to get max revision: %w", err)
+	}
+	if head.Valid {
+		return head.Int64, nil
+	}
+	return 0, ErrNoDataFound
+}

--- a/clone/internal/logdb/database_test.go
+++ b/clone/internal/logdb/database_test.go
@@ -1,0 +1,71 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logdb
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3" // Load drivers for sqlite3
+)
+
+func TestHeadIncremented(t *testing.T) {
+	for _, test := range []struct {
+		desc    string
+		leaves  [][]byte
+		want    int64
+		wantErr error
+	}{
+		{
+			desc:    "no data",
+			wantErr: ErrNoDataFound,
+		}, {
+			desc:   "one leaf",
+			leaves: [][]byte{[]byte("first!")},
+			want:   0,
+		}, {
+			desc:   "many leaves",
+			leaves: [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+			want:   2,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			sqlitedb, err := sql.Open("sqlite3", ":memory:")
+			if err != nil {
+				t.Fatal("failed to open temporary in-memory DB", err)
+			}
+			defer sqlitedb.Close()
+
+			db := Database{sqlitedb}
+			if err := db.Init(); err != nil {
+				t.Fatal("failed to init DB", err)
+			}
+			if err := db.WriteLeaves(context.Background(), 0, test.leaves); err != nil {
+				t.Fatal("failed to write leaves", err)
+			}
+
+			head, err := db.Head()
+			if test.wantErr != err {
+				t.Errorf("expected err %q but got %q", test.wantErr, err)
+			}
+			if test.wantErr != nil {
+				if head != test.want {
+					t.Errorf("expected %d but got %d", test.want, head)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
The tool clones leaves from the log as quickly as possible to a MySQL instance provisioned by the user. This is the foundation for doing local processing of all data, such as building a verifiable map.

This is optimized very heavily towards downloading a large amount of data quickly, while respecting the log if it asks the client to back off. Missing features:
 * downloading/persisting checkpoints & verifying the leaf data
 * terminating cleanly when the end of the log is reached

The design ensures that leaves are never written without any gaps in order to simplify the local state required.