### PR TITLE
[serverless] Add update client command

### DIFF
--- a/serverless/internal/client/client.go
+++ b/serverless/internal/client/client.go
@@ -44,12 +44,13 @@ func fetchCheckpointAndParse(f FetcherFunc, v note.Verifier) (*log.Checkpoint, [
 	if err != nil {
 		return nil, nil, err
 	}
-	vCp, err := note.Open(cpRaw, note.VerifierList(v))
+	n, err := note.Open(cpRaw, note.VerifierList(v))
 	if err != nil {
 		glog.Exitf("failed to open Checkpoint: %q", err)
 	}
 	cp := log.Checkpoint{}
-	if _, err := cp.Unmarshal([]byte(vCp.Text)); err != nil {
+	if _, err := cp.Unmarshal([]byte(n.Text)); err != nil {
+		glog.V(1).Infof("Bad checkpoint: %q", cpRaw)
 		return nil, nil, fmt.Errorf("failed to unmarshal checkpoint: %w", err)
 	}
 	return &cp, cpRaw, nil
@@ -332,6 +333,7 @@ func (lst *LogStateTracker) Update() error {
 			if err != nil {
 				return err
 			}
+			glog.V(1).Infof("Built consistency proof %x", p)
 			if err := lst.Verifier.VerifyConsistencyProof(int64(lst.LatestConsistent.Size), int64(c.Size), lst.LatestConsistent.Hash, c.Hash, p); err != nil {
 				return ErrInconsistency{
 					SmallerRaw: lst.LatestConsistentRaw,


### PR DESCRIPTION
This updates the client's local cached state forward to the latest log checkpoint.

Using `-v=1` will print out the checkpoint and proof data:

```
I0527 15:49:43.596880 3352634 client.go:215] Original checkpoint:
Log Checkpoint v0
5
41smjBUiAU70EtKlT6lIOIYtRTYxYXsDB+XHfcvu/BE=

— github.com/AlCutter/serverless-test/log KANRkZyJJHaTBkJwLH6Qa+tBAgZvX8tN2putKEmEe8QqYnou10EoY2uZEY2PKXPnoJgFGk1AdYbUcnDYE8UgbG87owA=
I0527 15:49:43.847665 3352634 client.go:336] Built consistency proof [b9e1d62618f7fee8034e4c5010f727ab24d8e4705cb296c374bf2025a87a10d2 aac66cd7a79ce4012d80762fe8eec3a77f22d1ca4145c3f4cee022e7efcd599d 89d0f753f66a290c483b39cd5e9eafb12021293395fad3d4a2ad053cfbcfdc9e 29e40bb79c966f4c6fe96aff6f30acfce5f3e8d84c02215175d6e018a5dee833]
I0527 15:49:43.847794 3352634 client.go:227] Updated checkpoint:
Log Checkpoint v0
8
V8K9aklZ4EPB+RMOk1/8VsJUdFZR77GDtZUQq84vSbo=

— github.com/AlCutter/serverless-test/log KANRkYPOWHYk4toUUT9hccdvqXnqxJDrhT5D1FG0K02WwU6PD5tRTz2+RcT2BcQMQNaCMTtXqDmoyILGjSx2w3nvCAU=
```