### PR TITLE
Move beam.Init further up

### DIFF
--- a/binary_transparency/firmware/cmd/ftmap/map.go
+++ b/binary_transparency/firmware/cmd/ftmap/map.go
@@ -55,6 +55,7 @@ func init() {
 
 func main() {
 	flag.Parse()
+	beam.Init()
 
 	// Connect to where we will read from and write to.
 	trillianDB, err := newTrillianDBFromFlags()
@@ -70,7 +71,6 @@ func main() {
 	// there needs to be some dynamic way to get this to clients (e.g. in a MapCheckpoint).
 	pb := ftmap.NewMapBuilder(trillianDB, api.MapTreeID, api.MapPrefixStrata)
 
-	beam.Init()
 	beamlog.SetLogger(&BeamGLogger{InfoLogAtVerbosity: 2})
 	p, s := beam.NewPipelineWithRoot()
 	result, err := pb.Create(s, *count)

--- a/experimental/batchmap/sumdb/build/map.go
+++ b/experimental/batchmap/sumdb/build/map.go
@@ -58,6 +58,7 @@ func init() {
 
 func main() {
 	flag.Parse()
+	beam.Init()
 
 	// Connect to where we will read from and write to.
 	sumDB, err := newSumDBMirrorFromFlags()
@@ -71,7 +72,6 @@ func main() {
 
 	pb := pipeline.NewMapBuilder(sumDB, *treeID, *prefixStrata, *buildVersionList)
 
-	beam.Init()
 	beamlog.SetLogger(&BeamGLogger{InfoLogAtVerbosity: 2})
 	p, s := beam.NewPipelineWithRoot()
 


### PR DESCRIPTION
This can cause problems with flag parsing in Dataflow if not above flag checks