### PR TITLE
Support writing & reading checkpoints in DB

### DIFF
--- a/clone/cmd/ctclone/ctclone.go
+++ b/clone/cmd/ctclone/ctclone.go
@@ -34,7 +34,7 @@ import (
 const getEntriesFormat = "ct/v1/get-entries?start=%d&end=%d"
 
 var (
-	logURL         = flag.String("log_url", "", "Log storage root URL, https://ct.googleapis.com/rocketeer/")
+	logURL         = flag.String("log_url", "", "Log storage root URL, e.g. https://ct.googleapis.com/rocketeer/")
 	mysqlURI       = flag.String("mysql_uri", "", "URL of a MySQL database to clone the log into. The DB should contain only one log.")
 	fetchBatchSize = flag.Uint("fetch_batch_size", 32, "The number of entries to fetch from the log in each request.")
 	writeBatchSize = flag.Uint("write_batch_size", 32, "The number of leaves to write in each DB transaction.")

--- a/clone/internal/verify/verify.go
+++ b/clone/internal/verify/verify.go
@@ -14,56 +14,69 @@
 package verify
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/clone/logdb"
 	"github.com/google/trillian/merkle/compact"
 )
-
-// StreamLeaves is a function that returns all the leaves in [start, end), in order, on the `out` channel.
-// Errors are returned via `errc`, and `out` will be closed when all data has been returned.
-type StreamLeaves func(start, end uint64, out chan []byte, errc chan error)
 
 // LeafHashFn returns the leaf hash (commitment) to the given preimage at the given log index.
 type LeafHashFn func(index uint64, data []byte) []byte
 
-// NewLogVerifier returns a LogVerifier which obtains raw leaves from `streamLeaves`, and uses the given
+// NewLogVerifier returns a LogVerifier which obtains raw leaves from `db`, and uses the given
 // hash functions to construct a merkle tree.
-func NewLogVerifier(streamLeaves StreamLeaves, lh LeafHashFn, ih compact.HashFn) LogVerifier {
+func NewLogVerifier(db *logdb.Database, lh LeafHashFn, ih compact.HashFn) LogVerifier {
 	return LogVerifier{
-		streamLeaves: streamLeaves,
-		lh:           lh,
-		rf:           &compact.RangeFactory{Hash: ih},
+		db: db,
+		lh: lh,
+		rf: &compact.RangeFactory{Hash: ih},
 	}
 }
 
 // LogVerifier calculates the Merkle root of a log.
 type LogVerifier struct {
-	streamLeaves StreamLeaves
-	lh           LeafHashFn
-	rf           *compact.RangeFactory
+	db *logdb.Database
+	lh LeafHashFn
+	rf *compact.RangeFactory
 }
 
 // MerkleRoot calculates the Merkle root hash of its log at the given size.
-func (v LogVerifier) MerkleRoot(size uint64) ([]byte, error) {
-	r := v.rf.NewEmptyRange(0)
+func (v LogVerifier) MerkleRoot(ctx context.Context, size uint64) ([]byte, [][]byte, error) {
+	cr := v.rf.NewEmptyRange(0)
+	from := uint64(0)
+
+	if cpSize, _, crBs, err := v.db.GetLatestCheckpoint(ctx); err != nil {
+		if err != logdb.ErrNoDataFound {
+			return nil, nil, err
+		}
+	} else if size >= cpSize {
+		from = cpSize
+		cr, err = v.rf.NewRange(0, cpSize, crBs)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
 
 	leaves := make(chan []byte, 1)
 	errc := make(chan error)
+	glog.V(1).Infof("Streaming leaves [%d, %d)", from, size)
+	go v.db.StreamLeaves(from, size, leaves, errc)
 
-	go v.streamLeaves(0, size, leaves, errc)
-
-	index := uint64(0)
+	index := from
 	for leaf := range leaves {
 		select {
 		case err := <-errc:
-			return nil, fmt.Errorf("failed to get leaves from DB: %w", err)
+			return nil, nil, fmt.Errorf("failed to get leaves from DB: %w", err)
 		default:
 		}
-		r.Append(v.lh(index, leaf), nil)
+		cr.Append(v.lh(index, leaf), nil)
 		index++
 	}
 	if index != size {
-		return nil, fmt.Errorf("expected to receive %d leaves but got %d", size, index)
+		return nil, nil, fmt.Errorf("expected to receive %d leaves but got %d", size, index)
 	}
-	return r.GetRootHash(nil)
+	root, err := cr.GetRootHash(nil)
+	return root, cr.Hashes(), err
 }

--- a/clone/internal/verify/verify_test.go
+++ b/clone/internal/verify/verify_test.go
@@ -15,29 +15,32 @@
 package verify
 
 import (
+	"context"
+	"database/sql"
 	"encoding/base64"
 	"fmt"
 	"testing"
 
+	"github.com/google/trillian-examples/clone/logdb"
 	"github.com/google/trillian/merkle/rfc6962/hasher"
 	_ "github.com/mattn/go-sqlite3" // Load drivers for sqlite3
 )
 
-func TestRoot(t *testing.T) {
+func TestRootFromScratch(t *testing.T) {
+	db, close, err := NewInMemoryDatabase()
+	if err != nil {
+		t.Fatalf("NewDatabase(): %v", err)
+	}
+	defer close()
+
 	leaves := make([][]byte, 64)
 	for i := range leaves {
 		leaves[i] = []byte(fmt.Sprintf("leaf %d", i))
 	}
-	sl := func(start, end uint64, out chan []byte, errc chan error) {
-		defer close(out)
-		stop := int(end)
-		if stop > len(leaves) {
-			stop = len(leaves)
-		}
-		for i := int(start); i < stop; i++ {
-			out <- leaves[i]
-		}
+	if err := db.WriteLeaves(context.Background(), 0, leaves); err != nil {
+		t.Fatalf("Failed to initialize database with leaves")
 	}
+
 	h := hasher.DefaultHasher
 	lh := func(_ uint64, preimage []byte) []byte {
 		return h.HashLeaf(preimage)
@@ -53,6 +56,10 @@ func TestRoot(t *testing.T) {
 		count:    1,
 		wantRoot: "G7l9zCFjXUfiZj79/QoXRobZjdcBNS3SzQbotD/T0wU",
 	}, {
+		desc:     "16 leaves",
+		count:    16,
+		wantRoot: "cUopKYyn2GQ5dRAFaUmcIwnoOm8vlwkC3EbvMuvBsA8",
+	}, {
 		desc:     "17 leaves",
 		count:    17,
 		wantRoot: "Ru8bykxkgM1l5Q4pzBw3XbNnEc1QJF7NPmsxDG4qOD8",
@@ -67,8 +74,8 @@ func TestRoot(t *testing.T) {
 	},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			v := NewLogVerifier(sl, lh, h.HashChildren)
-			got, err := v.MerkleRoot(test.count)
+			v := NewLogVerifier(db, lh, h.HashChildren)
+			got, _, err := v.MerkleRoot(context.Background(), test.count)
 			if gotErr := err != nil; test.wantErr != gotErr {
 				t.Errorf("expected err (%t) but got: %q", test.wantErr, err)
 			}
@@ -80,4 +87,83 @@ func TestRoot(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPartialRoot(t *testing.T) {
+	db, close, err := NewInMemoryDatabase()
+	if err != nil {
+		t.Fatalf("NewDatabase(): %v", err)
+	}
+	defer close()
+
+	leaves := make([][]byte, 64)
+	for i := range leaves {
+		leaves[i] = []byte(fmt.Sprintf("leaf %d", i))
+	}
+	if err := db.WriteLeaves(context.Background(), 0, leaves); err != nil {
+		t.Fatalf("Failed to initialize database with leaves: %v", err)
+	}
+	cr, err := base64.RawStdEncoding.DecodeString("cUopKYyn2GQ5dRAFaUmcIwnoOm8vlwkC3EbvMuvBsA8")
+	if err != nil {
+		t.Fatalf("Failed to decode base64: %v", err)
+	}
+	if err := db.WriteCheckpoint(context.Background(), 16, []byte("root"), [][]byte{cr}); err != nil {
+		t.Fatalf("Failed to init db with checkpoint: %v", err)
+	}
+
+	h := hasher.DefaultHasher
+	lh := func(_ uint64, preimage []byte) []byte {
+		return h.HashLeaf(preimage)
+	}
+
+	for _, test := range []struct {
+		desc     string
+		count    uint64
+		wantRoot string
+		wantErr  bool
+	}{{
+		desc:     "one leaf",
+		count:    1,
+		wantRoot: "G7l9zCFjXUfiZj79/QoXRobZjdcBNS3SzQbotD/T0wU",
+	}, {
+		desc:     "16 leaves",
+		count:    16,
+		wantRoot: "cUopKYyn2GQ5dRAFaUmcIwnoOm8vlwkC3EbvMuvBsA8",
+	}, {
+		desc:     "17 leaves",
+		count:    17,
+		wantRoot: "Ru8bykxkgM1l5Q4pzBw3XbNnEc1QJF7NPmsxDG4qOD8",
+	}, {
+		desc:     "all leaves",
+		count:    64,
+		wantRoot: "8mHiNpLZeP2sP9lJ21SVlApDeuZxuabd6aphGNADZS8",
+	}, {
+		desc:    "too many leaves",
+		count:   65,
+		wantErr: true,
+	},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			v := NewLogVerifier(db, lh, h.HashChildren)
+			got, _, err := v.MerkleRoot(context.Background(), test.count)
+			if gotErr := err != nil; test.wantErr != gotErr {
+				t.Errorf("expected err (%t) but got: %q", test.wantErr, err)
+			}
+			if !test.wantErr {
+				gotb64 := base64.RawStdEncoding.EncodeToString(got)
+				if gotb64 != test.wantRoot {
+					t.Errorf("got %q but wanted root %q", gotb64, test.wantRoot)
+				}
+			}
+		})
+	}
+}
+
+func NewInMemoryDatabase() (*logdb.Database, func() error, error) {
+	sqlitedb, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open temporary in-memory DB: %v", err)
+	}
+	db, err := logdb.NewDatabaseDirect(sqlitedb)
+	return db, sqlitedb.Close, err
 }

--- a/clone/logdb/database.go
+++ b/clone/logdb/database.go
@@ -25,7 +25,7 @@ import (
 const (
 	// This can be changed to a field of Database or metadata in the database if
 	// we need to support other sizes in the future.
-	HASH_SIZE_BYTES = 32
+	hashSizeBytes = 32
 )
 
 // ErrNoDataFound is returned when the DB appears valid but has no data in it.
@@ -89,10 +89,10 @@ func (d *Database) WriteCheckpoint(ctx context.Context, size uint64, checkpoint 
 		return nil
 	}
 
-	srs := make([]byte, HASH_SIZE_BYTES*len(compactRange))
+	srs := make([]byte, hashSizeBytes*len(compactRange))
 	for i, cr := range compactRange {
-		from := i * HASH_SIZE_BYTES
-		to := from + HASH_SIZE_BYTES
+		from := i * hashSizeBytes
+		to := from + hashSizeBytes
 		copy(srs[from:to], cr)
 	}
 	tx.ExecContext(ctx, "INSERT INTO checkpoints (size, data, compactRange) VALUES (?, ?, ?)", size, checkpoint, srs)
@@ -109,10 +109,10 @@ func (d *Database) GetLatestCheckpoint(ctx context.Context) (size uint64, checkp
 		}
 		return 0, nil, nil, fmt.Errorf("Scan(): %v", err)
 	}
-	compactRange = make([][]byte, len(srs)/HASH_SIZE_BYTES)
+	compactRange = make([][]byte, len(srs)/hashSizeBytes)
 	for i := range compactRange {
-		from := i * HASH_SIZE_BYTES
-		to := from + HASH_SIZE_BYTES
+		from := i * hashSizeBytes
+		to := from + hashSizeBytes
 		compactRange[i] = srs[from:to]
 	}
 	return

--- a/clone/logdb/database.go
+++ b/clone/logdb/database.go
@@ -22,6 +22,12 @@ import (
 	"fmt"
 )
 
+const (
+	// This can be changed to a field of Database or metadata in the database if
+	// we need to support other sizes in the future.
+	HASH_SIZE_BYTES = 32
+)
+
 // ErrNoDataFound is returned when the DB appears valid but has no data in it.
 var ErrNoDataFound = errors.New("no data found")
 
@@ -30,7 +36,7 @@ type Database struct {
 	db *sql.DB
 }
 
-// NewDatabase creates a Database using the given database connection.
+// NewDatabase creates a Database using the given database connection string.
 // This has been tested with sqlite and MariaDB.
 func NewDatabase(connString string) (*Database, error) {
 	dbConn, err := sql.Open("mysql", connString)
@@ -40,16 +46,76 @@ func NewDatabase(connString string) (*Database, error) {
 	db := &Database{
 		db: dbConn,
 	}
-	return db, db.Init()
+	return db, db.init()
 }
 
-// Init creates the database tables if needed.
-func (d *Database) Init() error {
+// NewDatabase creates a Database using the given database connection.
+func NewDatabaseDirect(db *sql.DB) (*Database, error) {
+	ret := &Database{
+		db: db,
+	}
+	return ret, ret.init()
+}
+
+func (d *Database) init() error {
 	if _, err := d.db.Exec("CREATE TABLE IF NOT EXISTS leaves (id INTEGER PRIMARY KEY, data BLOB)"); err != nil {
 		return err
 	}
-	// TODO(mhutchinson): Create a table for checkpoints too?
+	if _, err := d.db.Exec("CREATE TABLE IF NOT EXISTS checkpoints (size INTEGER PRIMARY KEY, data BLOB, compactRange BLOB)"); err != nil {
+		return err
+	}
 	return nil
+}
+
+// WriteCheckpoint writes the checkpoint for the given tree size.
+// This should have been verified before writing.
+func (d *Database) WriteCheckpoint(ctx context.Context, size uint64, checkpoint []byte, compactRange [][]byte) error {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("BeginTx(): %v", err)
+	}
+
+	row := tx.QueryRowContext(ctx, "SELECT size FROM checkpoints ORDER BY size DESC LIMIT 1")
+	var max uint64
+	if err := row.Scan(&max); err != nil {
+		if err != sql.ErrNoRows {
+			tx.Rollback()
+			return fmt.Errorf("Scan(): %v", err)
+		}
+	}
+
+	if size <= max {
+		tx.Rollback()
+		return nil
+	}
+
+	srs := make([]byte, HASH_SIZE_BYTES*len(compactRange))
+	for i, cr := range compactRange {
+		from := i * HASH_SIZE_BYTES
+		to := from + HASH_SIZE_BYTES
+		copy(srs[from:to], cr)
+	}
+	tx.ExecContext(ctx, "INSERT INTO checkpoints (size, data, compactRange) VALUES (?, ?, ?)", size, checkpoint, srs)
+	return tx.Commit()
+}
+
+// GetLatestCheckpoint gets the details of the latest checkpoint.
+func (d *Database) GetLatestCheckpoint(ctx context.Context) (size uint64, checkpoint []byte, compactRange [][]byte, err error) {
+	row := d.db.QueryRowContext(ctx, "SELECT size, data, compactRange FROM checkpoints ORDER BY size DESC LIMIT 1")
+	srs := make([]byte, 0)
+	if err := row.Scan(&size, &checkpoint, &srs); err != nil {
+		if err == sql.ErrNoRows {
+			return 0, nil, nil, ErrNoDataFound
+		}
+		return 0, nil, nil, fmt.Errorf("Scan(): %v", err)
+	}
+	compactRange = make([][]byte, len(srs)/HASH_SIZE_BYTES)
+	for i := range compactRange {
+		from := i * HASH_SIZE_BYTES
+		to := from + HASH_SIZE_BYTES
+		compactRange[i] = srs[from:to]
+	}
+	return
 }
 
 // WriteLeaves writes the contiguous chunk of leaves, starting at the stated index.

--- a/clone/logdb/database_test.go
+++ b/clone/logdb/database_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -161,7 +162,7 @@ func TestCheckpointRoundTrip(t *testing.T) {
 		desc:         "single compact range",
 		size:         256,
 		checkpoint:   hashes[0],
-		compactRange: hashes[1:1],
+		compactRange: hashes[1:2],
 	}, {
 		desc:         "longer compact range",
 		size:         277,
@@ -193,8 +194,8 @@ func TestCheckpointRoundTrip(t *testing.T) {
 			if !bytes.Equal(gotCP, test.checkpoint) {
 				t.Errorf("checkpoint: got %x, want %x", gotCP, test.checkpoint)
 			}
-			if diff := cmp.Diff(gotCR, test.compactRange); len(diff) > 0 {
-				t.Errorf("diff in compact range: %q", diff)
+			if !reflect.DeepEqual(gotCR, test.compactRange) {
+				t.Errorf("compact range: got != want: \n%v\n%v", gotCR, test.compactRange)
 			}
 		})
 	}


### PR DESCRIPTION
Checkpoints are stored with the compact range, which allows the log contents to be verified incrementally.

Verified checkpoints are now stored by the `ctverify` tool. Upon verifying a new checkpoint, the latest verified checkpoint will be loaded and only the leaves added since that checkpoint will directly be checked.

This is a performance improvement for verification, and it also provides tooling that reads from the log (e.g. map building code) to find the log checkpoints. This code can either trust the local DB hasn't been modified since verification, or it can re-verify all leaves against the checkpoint if desired. In the case of the map, the log checkpoint used will be embedded within the map checkpoint in order to complete an audit trail.