### PR TITLE
[Serverless] Add docker github feeder

### DIFF
--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -109,10 +109,18 @@ main() {
         ./...
     fi
 
-    echo "building serverless actions"
+    echo "Bbuilding serverless actions =================================="
     for i in $(find serverless/deploy/github -name Dockerfile); do
+      echo "Building ${i} ------------------------------------------------"
       docker build -f "${i}" "$(dirname ${i})"
     done
+
+    echo "Building serverless non-action dockerfiles ===================="
+    for i in $(find serverless -name Dockerfile -not -path 'serverless/deploy/github/*' ); do
+      echo "Building ${i} ------------------------------------------------"
+      docker build -f "${i}" .
+    done
+
   fi
 
   if [[ "${run_lint}" -eq 1 ]]; then

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -109,7 +109,7 @@ main() {
         ./...
     fi
 
-    echo "Bbuilding serverless actions =================================="
+    echo "Building serverless actions =================================="
     for i in $(find serverless/deploy/github -name Dockerfile); do
       echo "Building ${i} ------------------------------------------------"
       docker build -f "${i}" "$(dirname ${i})"

--- a/serverless/cmd/feeder/Dockerfile
+++ b/serverless/cmd/feeder/Dockerfile
@@ -1,0 +1,35 @@
+FROM golang:buster AS builder
+
+ARG GOFLAGS=""
+ENV GOFLAGS=$GOFLAGS
+ENV GO111MODULE=on
+
+# Move to working directory /build
+WORKDIR /build
+
+# Copy and download dependency using go mod
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+# Copy the code into the container
+COPY . .
+
+# Build the application
+RUN go build -o /build/bin/feeder ./serverless/cmd/feeder
+COPY ./serverless/cmd/feeder/feed-to-github /build/bin
+
+# Build release image
+FROM golang:buster
+
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+
+RUN apt-get update && apt-get install -y git gh
+
+COPY --from=builder /build/bin/feeder /bin/feeder
+COPY --from=builder /build/bin/feed-to-github /bin/feed-to-github
+
+ENTRYPOINT ["/bin/feed-to-github"]

--- a/serverless/cmd/feeder/feed-to-github
+++ b/serverless/cmd/feeder/feed-to-github
@@ -70,6 +70,7 @@ function check_git() {
 
 function sleep_or_exit() {
   if [[ "${1}" != "" ]]; then
+    echo "Sleeping ${1}"
     sleep "${1}"
   else
     exit 0
@@ -113,9 +114,9 @@ function main() {
   git remote add upstream "https://github.com/${log_repo}.git"
   git fetch --all
   git branch -u upstream/master
+  echo "[Starting feeding]---------------------------------------------------"
 
   while true; do
-    echo "--------------------------------------------------------------------"
     git pull
 
     # Run the feeder to gather new signatures
@@ -125,31 +126,34 @@ function main() {
     # Create a witness PR if necessary
     cd "${temp}"
 
-    if [ -z "$(git diff --no-patch --stat | grep addition)" ]; then
+    local diff_stats=$(git diff --numstat | grep "checkpoint.witnessed")
+    local added=$(echo "${diff_stats}" | awk -- '{print $1}')
+
+    # If we've added a signature, or updated the checkpoint from the previously witnessed one, we should
+    # see some added lines reported in the stats.
+    if [[ "${added}" -eq "0" ]]; then
       echo "No signatures added"
       sleep_or_exit ${interval}
       continue
     fi
 
+    local cp_size="$(sed -n 2p ${log_path}/checkpoint.witnessed)"
+    local cp_hash="$(sed -n 3p ${log_path}/checkpoint.witnessed)"
+    local branch="witness_${cp_hash}"
 
-    local size="$(sed -n 2p ${log_path}/checkpoint.witnessed)"
-    local hash="$(sed -n 3p ${log_path}/checkpoint.witnessed)"
-    local branch="witness_${hash}"
-
-    git stash
-    git checkout -b "${branch}"
-    git stash pop
-
+    git stash > /dev/null
+    git checkout -b "${branch}" > /dev/null
+    git stash pop > /dev/null
 
     git commit -a -m "Witness checkpoint@${size}"
     git push -f origin "${branch}"
-    gh pr create -R "${log_repo}" --title="Witness @ ${size}" -f --head="${fork_owner}:${branch}"
+    gh pr create -R "${log_repo}" --title="Witness @ ${cp_size}" -f --head="${fork_owner}:${branch}"
 
     git checkout master
     git branch -D ${branch}
 
+    echo "[Feed cycle complete]------------------------------------------------"
     sleep_or_exit ${interval}
-    echo "--------------------------------------------------------------------"
   done
 }
 

--- a/serverless/cmd/feeder/feed-to-github
+++ b/serverless/cmd/feeder/feed-to-github
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# feed-to-github is a wrapper around the serverless feeder command which uploads the result
+# feed-to-github is a wrapper around the serverless `feeder` command which uploads the result
 # of feeding a checkpoint to one or more witnesses back to the source log via a github PR.
 #
-# This script expects the git, gh, and feeder (built from the same directory this script
+# This script expects the `git`, `gh`, and `feeder` (built from the same directory this script
 # is in) to be present in the PATH.
 #
 # GLOBALS:

--- a/serverless/cmd/feeder/feed-to-github
+++ b/serverless/cmd/feeder/feed-to-github
@@ -1,75 +1,156 @@
 #!/bin/bash
 #
-# feed-to-github is a wrapper around the serverless feeder command which does a 
-# one-shot feed to the configured witness(es), and then creates a "Witness PR" on the
-# log repo with the resulting cosigned checkpoint.
+# feed-to-github is a wrapper around the serverless feeder command which uploads the result
+# of feeding a checkpoint to one or more witnesses back to the source log via a github PR.
 #
+# This script expects the git, gh, and feeder (built from the same directory this script
+# is in) to be present in the PATH.
+#
+# GLOBALS:
+#  FEEDER_GITHUB_TOKEN: 
+#     (optional)
+#     Github Personal Access Token to use for creating witness PR.
+#     If unset, uses "ambient" access privilesges already present.
+#  GIT_USERNAME:
+#    (required)
+#     GitHub username to associate with the witness PR commit.
+#  GIT_EMAIL:
+#     (required)
+#     Email address to associate with the witness PR commit.
 
-set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 function usage() {
   cat <<EOF
 Usage:
- feed-to-github <log_github_owner/repo> <witness_fork_owner/repo> <log_path> <feeder_config_file> []
+ feed-to-github <log_github_owner/repo> <log_path> <feeder_config_file> [interval_seconds]
 
 Where:
- <log_github_owner/repo> is the repo owner/fragment from the repo URL 
+ <log_github_owner/repo> is the repo owner/fragment from the repo URL.
      e.g. github.com/AlCutter/serverless-test -> AlCutter/serverless-test
- <witness_fork_owner/repo> is the repo owner/fragment of the fork to use for creating witness pull requests
- <log_repo_path> is the path from the root of the rep where the log files can be found
+ <witness_github_owner/repo> is the repo owner/fragment of the log fork to use for the PR branch.
+ <log_repo_path> is the path from the root of the rep where the log files can be found,
  <feeder_config_fil> is the path to the config file for the serverless/cmd/feeder command.
+ [interval_seconds] if set, the script will continously feed and (if needed) create witness PRs sleeping
+     the specified number of seconds between attempts. If not provided, the tool does a one-shot feed.
 
 EOF
   exit 1
 }
 
-function checkExist() {
+function check_exist() {
   local missing=()
   for i in $*; do
     if ! type ${i} &> /dev/null; then
       missing+=("${i}")
     fi
   done
-  if [ ! -z ${missing} ]; then
+  if [[ ! -z ${missing} ]]; then
     echo "Please install the following tool(s) in a location on the PATH:"
     echo "${missing[@]}"
     exit 1
   fi
 }
 
+function check_git() {
+  local bad=0
+  if [[ -z "$(git config user.name)" && -z "${GIT_USERNAME}" ]]; then
+    echo "Please set GIT_USERNAME environment variable - this is used for the witness PR commit"
+    bad=1
+  fi
+  if [[ -z "$(git config user.email)" && -z "${GIT_EMAIL}" ]]; then
+    echo "Please set GIT_EMAIL environment variable - this is used for the witness PR commit"
+    bad=1
+  fi
+  if [[ "${bad}" -ne 0 ]]; then
+    exit 1
+  fi
+}
+
+function sleep_or_exit() {
+  if [[ "${1}" != "" ]]; then
+    sleep "${1}"
+  else
+    exit 0
+  fi
+}
+
 function main() {
-  if [ $# -ne 4 ]; then
+  if [ $# -lt 4 ]; then
     usage
   fi
-  checkExist git gh
+  check_exist git gh
+  if ! type feeder &> /dev/null; then
+    echo "Please run: "
+    echo " go build ${SCRIPT_DIR}"
+    echo "and ensure the feeder binary is on the PATH"
+    exit 1
+  fi
+  check_git
 
-  local log_repo=${1}
-  local witness_repo=${2}
-  local log_path=${3}
-  local feeder_conf=$(readlink -f -n ${4})
+  if [[ ! -z "${FEEDER_GITHUB_TOKEN}" ]]; then
+    echo ${FEEDER_GITHUB_TOKEN} | gh auth login --with-token
+  fi
+
+  local log_repo="${1}"
+  local fork_repo="${2}"
+  local fork_owner="$(echo ${fork_repo} | cut -f1 -d/)"
+  local log_path="${3}"
+  local feeder_conf="$(readlink -f -n ${4})"
+  local interval="${5}"
   local repo_url="github.com/${repo}"
-  local temp=$(mktemp -d)
-  local branch="witness_${RANDOM}"
+  local temp="$(mktemp -d)"
 
   trap "rm -fr ${temp}" EXIT
 
   # Clone the fork of the log so we can make a PR branch on it with the updated checkpoint.witness file
-  gh repo clone ${witness_repo} ${temp} -- --depth 1
-  cd ${temp}
-  git checkout -b ${branch}
+  git clone -o origin "https://${GIT_USERNAME}:${FEEDER_GITHUB_TOKEN}@github.com/${fork_repo}.git" "${temp}"
+  cd "${temp}"
 
-  # Run the feeder to gather new signatures
-  cd ${SCRIPT_DIR}
-  go run . --config_file=${feeder_conf} --logtostderr --input=https://raw.githubusercontent.com/${log_repo}/master/${log_path}/checkpoint --output=${temp}/${log_path}/checkpoint.witnessed -v 2
+  git config user.name "${GIT_USERNAME}"
+  git config user.email "${GIT_EMAIL}"
+  git remote add upstream "https://github.com/${log_repo}.git"
+  git fetch --all
+  git branch -u upstream/master
 
-  # Create a witness PR
-  cd ${temp}
-  local size=$(sed -n 2p ${log_path}/checkpoint.witnessed)
-  git commit -a -m "Witness checkpoint@${size}"
-  git push origin ${branch}
-  gh pr create -R ${log_repo} --title="Witness @ ${size}" --head=${branch} -f
+  while true; do
+    echo "--------------------------------------------------------------------"
+    git pull
+
+    # Run the feeder to gather new signatures
+    cd "${SCRIPT_DIR}"
+    feeder --config_file="${feeder_conf}" --logtostderr --input="https://raw.githubusercontent.com/${log_repo}/master/${log_path}/checkpoint" --output="${temp}/${log_path}/checkpoint.witnessed" -v 2
+
+    # Create a witness PR if necessary
+    cd "${temp}"
+
+    if [ -z "$(git diff --no-patch --stat | grep addition)" ]; then
+      echo "No signatures added"
+      sleep_or_exit ${interval}
+      continue
+    fi
+
+
+    local size="$(sed -n 2p ${log_path}/checkpoint.witnessed)"
+    local hash="$(sed -n 3p ${log_path}/checkpoint.witnessed)"
+    local branch="witness_${hash}"
+
+    git stash
+    git checkout -b "${branch}"
+    git stash pop
+
+
+    git commit -a -m "Witness checkpoint@${size}"
+    git push -f origin "${branch}"
+    gh pr create -R "${log_repo}" --title="Witness @ ${size}" -f --head="${fork_owner}:${branch}"
+
+    git checkout master
+    git branch -D ${branch}
+
+    sleep_or_exit ${interval}
+    echo "--------------------------------------------------------------------"
+  done
 }
 
 main $*

--- a/serverless/cmd/feeder/impl/feeder.go
+++ b/serverless/cmd/feeder/impl/feeder.go
@@ -125,6 +125,12 @@ func Feed(ctx context.Context, cp []byte, opts FeedOpts) ([]byte, error) {
 		}
 	}
 
+	// Bail if we got nothing new
+	if len(allWitnessed) == 0 {
+		glog.Infof("No new signatures")
+		return cp, nil
+	}
+
 	// ...and combine signatures.
 	wvList := note.VerifierList(wSigVs...)
 	r, err := checkpoints.Combine(append([][]byte{cp}, allWitnessed...), opts.LogSigVerifier, wvList)
@@ -153,6 +159,7 @@ func submitToWitness(ctx context.Context, cpRaw []byte, cpSubmit log.Checkpoint,
 	// TODO(al): make this configurable
 	h := hasher.DefaultHasher
 	wSigV := w.SigVerifier()
+
 	// Keep submitting until success or context timeout...
 	t := time.NewTicker(1)
 	for {
@@ -172,14 +179,18 @@ func submitToWitness(ctx context.Context, cpRaw []byte, cpSubmit log.Checkpoint,
 
 		var conP [][]byte
 		if len(latestCPRaw) > 0 {
-			_, err := note.Open(latestCPRaw, note.VerifierList(logSigV))
+			n, err := note.Open(latestCPRaw, note.VerifierList(logSigV, wSigV))
 			if err != nil {
 				glog.Warningf("%s: failed to open CP: %v", wSigV.Name(), err)
 				continue
 			}
+			if numSigs := len(n.Sigs); numSigs != 2 {
+				errs <- errors.New("checkpoint from witness was not signed by at least log + witness")
+				return
+			}
 
 			latestCP := &log.Checkpoint{}
-			_, err = latestCP.Unmarshal(latestCPRaw)
+			_, err = latestCP.Unmarshal([]byte(n.Text))
 			if err != nil {
 				glog.Warningf("%s: failed to unmarshal CP: %v", wSigV.Name(), err)
 				continue

--- a/serverless/cmd/feeder/impl/feeder.go
+++ b/serverless/cmd/feeder/impl/feeder.go
@@ -125,12 +125,6 @@ func Feed(ctx context.Context, cp []byte, opts FeedOpts) ([]byte, error) {
 		}
 	}
 
-	// Bail if we got nothing new
-	if len(allWitnessed) == 0 {
-		glog.Infof("No new signatures")
-		return cp, nil
-	}
-
 	// ...and combine signatures.
 	wvList := note.VerifierList(wSigVs...)
 	r, err := checkpoints.Combine(append([][]byte{cp}, allWitnessed...), opts.LogSigVerifier, wvList)

--- a/serverless/cmd/feeder/main.go
+++ b/serverless/cmd/feeder/main.go
@@ -101,6 +101,8 @@ func main() {
 		glog.Exitf("Failed to read input checkpoint: %v", err)
 	}
 
+	glog.Infof("CP to feed:\n%s", string(cp))
+
 	wCP, err := impl.Feed(ctx, cp, opts)
 	if err != nil {
 		glog.Exitf("Feeding failed: %v", err)

--- a/serverless/deploy/docker/witness/README.md
+++ b/serverless/deploy/docker/witness/README.md
@@ -4,11 +4,21 @@ Witness
 This [docker-compose.yaml](docker-compose.yaml) file can be used to spin up a witness daemon.
 
 You should set the following environmemt variables (either `export` or with a `.env` file):
-name | description
-------------------
-WITNESS_CONFIG_DIR | Absolute path to a directory containing a witness config file (default: `/etc/witness/config`)
+Variable Name       | Description
+------------------------------------------
+WITNESS_CONFIG_DIR  | Absolute path to a directory containing a witness config file (default: `/etc/witness/config`)
 WITNESS_CONFIG_FILE | The name of the witness config file within ${WITNESS_CONFIG_DIR} (default: `witness.config`)
 WITNESS_PRIVATE_KEY | The witness private key in note format (*not* the path to the key)
+SERVERLESS_LOG_REPO | The GitHub "<owner/repo>" fragment of the serverless log
+SERVERLESS_LOG_FORK | The GitHub "<owner/repo>" fragment of the witness' fork of the serverless log
+SERVERLESS_LOG_DIR  | The path to the root of the serverless log in its repo
+FEEDER_CONFIG_DIR   | The path to the directory containing the `serverless/cmd/feeder` command's config file
+FEEDER_CONFIG_FILE  | The name of the `serverless/cmd/feeder` command's config file in `${FEEDER_CONFIG_DIR}`
+FEEDER_INTERVAL_SECONDS | The number of seconds between feed/witness attempts, set to empty string for one-shot
+FEEDER_GITHUB_TOKEN | A GitHub Personal Access Token for the feeder to use to create a PR on the log repo with the witnessed checkpoint
+GIT_USERNAME        | The GitHub username associated with the Personal Access Token
+GIT_EMAIL           | An email address to associate with the feeder commits
+
 
 
 The witness can be started with the following command:

--- a/serverless/deploy/docker/witness/README.md
+++ b/serverless/deploy/docker/witness/README.md
@@ -1,0 +1,22 @@
+Witness
+-------
+
+This [docker-compose.yaml](docker-compose.yaml) file can be used to spin up a witness daemon.
+
+You should set the following environmemt variables (either `export` or with a `.env` file):
+name | description
+------------------
+WITNESS_CONFIG_DIR | Absolute path to a directory containing a witness config file (default: `/etc/witness/config`)
+WITNESS_CONFIG_FILE | The name of the witness config file within ${WITNESS_CONFIG_DIR} (default: `witness.config`)
+WITNESS_PRIVATE_KEY | The witness private key in note format (*not* the path to the key)
+
+
+The witness can be started with the following command:
+
+```bash
+$ docker-compose -f serverless/deploy/docker/witness/docker-compose.yaml up
+Starting witness_witness_1 ... done
+Attaching to witness_witness_1
+witness_1  | I0714 18:20:19.300495       1 witness.go:88] Connecting to local DB at "/data/witness.sqlite"
+witness_1  | I0714 18:20:19.301276       1 witness.go:108] Starting witness server...
+```

--- a/serverless/deploy/docker/witness/README.md
+++ b/serverless/deploy/docker/witness/README.md
@@ -4,21 +4,20 @@ Witness
 This [docker-compose.yaml](docker-compose.yaml) file can be used to spin up a witness daemon.
 
 You should set the following environmemt variables (either `export` or with a `.env` file):
- Variable Name      | Required | Description
-|-------------------|:--------:|-------------------------------------------------|
-SERVERLESS_LOG_REPO | yes      | The GitHub "<owner/repo>" fragment of the serverless log
-SERVERLESS_LOG_FORK | yes      | The GitHub "<owner/repo>" fragment of the witness' fork of the serverless log
-SERVERLESS_LOG_DIR  | yes      | The path to the root of the serverless log in its repo
-FEEDER_CONFIG_DIR   | yes      | The path to the directory containing the `serverless/cmd/feeder` command's config file
-FEEDER_CONFIG_FILE  | yes      | The name of the `serverless/cmd/feeder` command's config file in `${FEEDER_CONFIG_DIR}`
-FEEDER_GITHUB_TOKEN | yes      | A GitHub Personal Access Token for the feeder to use to create a PR on the log repo with the witnessed checkpoint
-GIT_USERNAME        | yes      | The GitHub username associated with the Personal Access Token
-GIT_EMAIL           | yes      | An email address to associate with the feeder commits
-WITNESS_PRIVATE_KEY | yes      | The witness private key in note format (*not* the path to the key)
-WITNESS_CONFIG_DIR  | no       | Absolute path to a directory containing a witness config file (default: `/etc/witness/config`)
-WITNESS_CONFIG_FILE | no       | The name of the witness config file within ${WITNESS_CONFIG_DIR} (default: `witness.config`)
-FEEDER_INTERVAL_SECONDS | no   | The number of seconds between feed/witness attempts, set to empty string for one-shot (default: 300s)
-
+ Variable Name        | Required | Description
+|---------------------|:--------:|-------------------------------------------------|
+`SERVERLESS_LOG_REPO` | yes      | The GitHub "<owner/repo>" fragment of the serverless log
+`SERVERLESS_LOG_FORK` | yes      | The GitHub "<owner/repo>" fragment of the witness' fork of the serverless log
+`SERVERLESS_LOG_DIR`  | yes      | The path to the root of the serverless log in its repo
+`FEEDER_CONFIG_DIR`   | yes      | The path to the directory containing the `serverless/cmd/feeder` command's config file
+`FEEDER_CONFIG_FILE`  | yes      | The name of the `serverless/cmd/feeder` command's config file in `${FEEDER_CONFIG_DIR}`
+`FEEDER_GITHUB_TOKEN` | yes      | A GitHub [Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) for the feeder to use to create a PR on the log repo with the witnessed checkpoint
+`GIT_USERNAME`        | yes      | The GitHub username associated with the Personal Access Token
+`GIT_EMAIL`           | yes      | An email address to associate with the feeder commits
+`WITNESS_PRIVATE_KEY` | yes      | The witness private key in note format (*not* the path to the key)
+`WITNESS_CONFIG_DIR`  | no       | Absolute path to a directory containing a witness config file (default: `/etc/witness/config`)
+`WITNESS_CONFIG_FILE` | no       | The name of the witness config file within `${WITNESS_CONFIG_DIR}` (default: `witness.config`)
+`FEEDER_INTERVAL_SECONDS` | no   | The number of seconds between feed/witness attempts, set to empty string for one-shot (default: 300s)
 
 
 The witness can be started with the following command:

--- a/serverless/deploy/docker/witness/README.md
+++ b/serverless/deploy/docker/witness/README.md
@@ -4,20 +4,20 @@ Witness
 This [docker-compose.yaml](docker-compose.yaml) file can be used to spin up a witness daemon.
 
 You should set the following environmemt variables (either `export` or with a `.env` file):
-Variable Name       | Description
-------------------------------------------
-WITNESS_CONFIG_DIR  | Absolute path to a directory containing a witness config file (default: `/etc/witness/config`)
-WITNESS_CONFIG_FILE | The name of the witness config file within ${WITNESS_CONFIG_DIR} (default: `witness.config`)
-WITNESS_PRIVATE_KEY | The witness private key in note format (*not* the path to the key)
-SERVERLESS_LOG_REPO | The GitHub "<owner/repo>" fragment of the serverless log
-SERVERLESS_LOG_FORK | The GitHub "<owner/repo>" fragment of the witness' fork of the serverless log
-SERVERLESS_LOG_DIR  | The path to the root of the serverless log in its repo
-FEEDER_CONFIG_DIR   | The path to the directory containing the `serverless/cmd/feeder` command's config file
-FEEDER_CONFIG_FILE  | The name of the `serverless/cmd/feeder` command's config file in `${FEEDER_CONFIG_DIR}`
-FEEDER_INTERVAL_SECONDS | The number of seconds between feed/witness attempts, set to empty string for one-shot
-FEEDER_GITHUB_TOKEN | A GitHub Personal Access Token for the feeder to use to create a PR on the log repo with the witnessed checkpoint
-GIT_USERNAME        | The GitHub username associated with the Personal Access Token
-GIT_EMAIL           | An email address to associate with the feeder commits
+ Variable Name      | Required | Description
+|-------------------|:--------:|-------------------------------------------------|
+SERVERLESS_LOG_REPO | yes      | The GitHub "<owner/repo>" fragment of the serverless log
+SERVERLESS_LOG_FORK | yes      | The GitHub "<owner/repo>" fragment of the witness' fork of the serverless log
+SERVERLESS_LOG_DIR  | yes      | The path to the root of the serverless log in its repo
+FEEDER_CONFIG_DIR   | yes      | The path to the directory containing the `serverless/cmd/feeder` command's config file
+FEEDER_CONFIG_FILE  | yes      | The name of the `serverless/cmd/feeder` command's config file in `${FEEDER_CONFIG_DIR}`
+FEEDER_GITHUB_TOKEN | yes      | A GitHub Personal Access Token for the feeder to use to create a PR on the log repo with the witnessed checkpoint
+GIT_USERNAME        | yes      | The GitHub username associated with the Personal Access Token
+GIT_EMAIL           | yes      | An email address to associate with the feeder commits
+WITNESS_PRIVATE_KEY | yes      | The witness private key in note format (*not* the path to the key)
+WITNESS_CONFIG_DIR  | no       | Absolute path to a directory containing a witness config file (default: `/etc/witness/config`)
+WITNESS_CONFIG_FILE | no       | The name of the witness config file within ${WITNESS_CONFIG_DIR} (default: `witness.config`)
+FEEDER_INTERVAL_SECONDS | no   | The number of seconds between feed/witness attempts, set to empty string for one-shot (default: 300s)
 
 
 

--- a/serverless/deploy/docker/witness/docker-compose.yaml
+++ b/serverless/deploy/docker/witness/docker-compose.yaml
@@ -1,0 +1,50 @@
+version: '3.2'
+services:
+  witness:
+    build:
+      context: ../../../../
+      dockerfile: ./witness/golang/cmd/witness/Dockerfile
+    volumes:
+        - type: volume
+          source: data
+          target: /data
+          volume:
+            nocopy: true
+        - type: bind
+          source: ${WITNESS_CONFIG_DIR:-/etc/witness/config}
+          target: /witness-config
+          read_only: true
+    command:
+      - "--listen=:8100"
+      - "--db_file=/data/witness.sqlite"
+      - "--private_key=${WITNESS_PRIVATE_KEY}"
+      - "--config_file=/witness-config/${WITNESS_CONFIG_FILE:-witness.config}"
+      - "--logtostderr"
+    restart: always
+    ports:
+      - "8100:8100"
+  feeder:
+    depends_on:
+      - witness
+    build:
+      context: ../../../../
+      dockerfile: ./serverless/cmd/feeder/Dockerfile
+    command:
+      - "${SERVERLESS_LOG_REPO}"
+      - "${SERVERLESS_LOG_FORK}"
+      - "${SERVERLESS_LOG_DIR:-.}"
+      - "/feeder-config/${FEEDER_CONFIG_FILE:-feeder.config}"
+      - "${FEEDER_INTERVAL_SECONDS:-300}"
+    environment:
+      - FEEDER_GITHUB_TOKEN=${FEEDER_GITHUB_TOKEN}
+      - GIT_USERNAME=${GIT_USERNAME}
+      - GIT_EMAIL=${GIT_EMAIL}
+    volumes:
+      - type: bind
+        source: ${FEEDER_CONFIG_DIR:-/etc/feeder/config}
+        target: /feeder-config
+      - type: tmpfs
+        target: /tmp
+volumes:
+  data:
+

--- a/witness/golang/cmd/witness/Dockerfile
+++ b/witness/golang/cmd/witness/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:buster AS builder
+
+ARG GOFLAGS=""
+ENV GOFLAGS=$GOFLAGS
+ENV GO111MODULE=on
+
+# Move to working directory /build
+WORKDIR /build
+
+# Copy and download dependency using go mod
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+# Copy the code into the container
+COPY . .
+
+# Build the application
+RUN go build -o /build/bin/witness ./witness/golang/cmd/witness
+
+# Build release image
+FROM golang:buster
+
+COPY --from=builder /build/bin/witness /bin/witness
+ENTRYPOINT ["/bin/witness"]


### PR DESCRIPTION
- Add `Dockerfile`s for `witness` and `feeder`
- Add `docker-compose.yaml` for running a combined `witness` and `feeder`
- Update `feed-to-github` to support running inside docker, and add option to run continuously
