### PR TITLE
serverless: Fix consistency checks

### DIFF
--- a/serverless/client/client.go
+++ b/serverless/client/client.go
@@ -405,8 +405,8 @@ func CheckConsistency(ctx context.Context, h hashers.LogHasher, f Fetcher, cp []
 
 	lv := logverifier.New(h)
 
-	// Go through list of checkpoints pairwise, checking consistency
-	var a, b log.Checkpoint
+	// Go through list of checkpoints pairwise, checking consistency.
+	a, b := cp[0], cp[1]
 	for i := 0; i < len(cp)-1; i, a, b = i+1, cp[i], cp[i+1] {
 		if a.Size == b.Size {
 			if bytes.Equal(a.Hash, b.Hash) {

--- a/serverless/client/client_test.go
+++ b/serverless/client/client_test.go
@@ -131,6 +131,16 @@ func TestCheckConsistency(t *testing.T) {
 			},
 			wantErr: true,
 		}, {
+			desc: "two inconsistent CPs",
+			cp: []log.Checkpoint{
+				{
+					Size: 2,
+					Hash: []byte("This is a banana"),
+				},
+				testCheckpoints[4],
+			},
+			wantErr: true,
+		}, {
 			desc: "Inconsistent",
 			cp: []log.Checkpoint{
 				testCheckpoints[5],


### PR DESCRIPTION
The consistency checking function ignores the first pair of checkpoints.
This change adds a test that failed, and fixes it.