### PR TITLE
Combine result and error channels together

### DIFF
--- a/clone/internal/download/batch_test.go
+++ b/clone/internal/download/batch_test.go
@@ -40,14 +40,12 @@ func TestFetchWorkerRun(t *testing.T) {
 	go fw.run(context.Background())
 
 	for i := 0; i < 10; i++ {
-		select {
-		case r := <-wrc:
-			if r.err != nil {
-				t.Fatal(r.err)
-			}
-			if got, want := r.start, uint64(i*10); got != want {
-				t.Errorf("%d got != want (%d != %d)", i, got, want)
-			}
+		r := <-wrc
+		if r.err != nil {
+			t.Fatal(r.err)
+		}
+		if got, want := r.start, uint64(i*10); got != want {
+			t.Errorf("%d got != want (%d != %d)", i, got, want)
 		}
 	}
 }

--- a/clone/internal/download/batch_test.go
+++ b/clone/internal/download/batch_test.go
@@ -21,8 +21,7 @@ import (
 )
 
 func TestFetchWorkerRun(t *testing.T) {
-	rangec := make(chan leafRange, 10)
-	errc := make(chan error)
+	wrc := make(chan workerResult, 10)
 	var first uint64
 	var batchSize uint = 10
 
@@ -34,8 +33,7 @@ func TestFetchWorkerRun(t *testing.T) {
 		start:      first,
 		increment:  uint64(batchSize),
 		count:      batchSize,
-		out:        rangec,
-		errc:       errc,
+		out:        wrc,
 		batchFetch: fakeFetch,
 	}
 
@@ -43,9 +41,10 @@ func TestFetchWorkerRun(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		select {
-		case err := <-errc:
-			t.Fatal(err)
-		case r := <-rangec:
+		case r := <-wrc:
+			if r.err != nil {
+				t.Fatal(r.err)
+			}
 			if got, want := r.start, uint64(i*10); got != want {
 				t.Errorf("%d got != want (%d != %d)", i, got, want)
 			}
@@ -54,8 +53,7 @@ func TestFetchWorkerRun(t *testing.T) {
 }
 
 func TestBulk(t *testing.T) {
-	leafc := make(chan []byte, 10)
-	errc := make(chan error)
+	brc := make(chan BulkResult, 10)
 	var first uint64
 	var workers uint = 4
 	var batchSize uint = 10
@@ -66,25 +64,23 @@ func TestBulk(t *testing.T) {
 		}
 		return nil
 	}
-	go Bulk(context.Background(), first, fakeFetch, workers, batchSize, leafc, errc)
+	go Bulk(context.Background(), first, fakeFetch, workers, batchSize, brc)
 
 	for i := 0; i < 1000; i++ {
-		select {
-		case err := <-errc:
-			t.Fatal(err)
-		case l := <-leafc:
-			tens := (i / 10) * 10
-			units := i % 10
-			if got, want := string(l), fmt.Sprintf("%d.%d", tens, units); got != want {
-				t.Errorf("%d got != want (%q != %q)", i, got, want)
-			}
+		br := <-brc
+		if br.Err != nil {
+			t.Fatal(br.Err)
+		}
+		tens := (i / 10) * 10
+		units := i % 10
+		if got, want := string(br.Leaf), fmt.Sprintf("%d.%d", tens, units); got != want {
+			t.Errorf("%d got != want (%q != %q)", i, got, want)
 		}
 	}
 }
 
 func TestBulkCancelled(t *testing.T) {
-	leafc := make(chan []byte, 10)
-	errc := make(chan error)
+	brc := make(chan BulkResult, 10)
 	var first uint64
 	var workers uint = 4
 	var batchSize uint = 10
@@ -95,20 +91,18 @@ func TestBulkCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go Bulk(ctx, first, fakeFetch, workers, batchSize, leafc, errc)
+	go Bulk(ctx, first, fakeFetch, workers, batchSize, brc)
 
 	seen := 0
 	for i := 0; i < 1000; i++ {
-		select {
-		case <-leafc:
-			seen++
-			if seen == 10 {
-				cancel()
-			}
-			continue
-		case <-errc:
+		br := <-brc
+		if br.Err != nil {
+			break
 		}
-		break
+		seen++
+		if seen == 10 {
+			cancel()
+		}
 	}
 	if seen == 1000 {
 		t.Error("Expected cancellation to prevent all leaves being read")
@@ -116,8 +110,7 @@ func TestBulkCancelled(t *testing.T) {
 }
 
 func BenchmarkBulk(b *testing.B) {
-	leafc := make(chan []byte, 10)
-	errc := make(chan error)
+	brc := make(chan BulkResult, 10)
 	var first uint64
 	var workers uint = 20
 	var batchSize uint = 10
@@ -130,14 +123,13 @@ func BenchmarkBulk(b *testing.B) {
 		}
 		return nil
 	}
-	go Bulk(context.Background(), first, fakeFetch, workers, batchSize, leafc, errc)
+	go Bulk(context.Background(), first, fakeFetch, workers, batchSize, brc)
 
 	for n := 0; n < b.N; n++ {
 		for i := 0; i < 1000; i++ {
-			select {
-			case err := <-errc:
-				b.Fatal(err)
-			case <-leafc:
+			br := <-brc
+			if br.Err != nil {
+				b.Fatal(br.Err)
 			}
 		}
 	}


### PR DESCRIPTION
The Bulk method now takes ownership of the channel too. This simplifies control flow.

This came up as part of another piece of work and has been separated into its own PR.