### PR TITLE
[Serverless] Add checkpoint sigs to the wasm experiment

### DIFF
--- a/serverless/experimental/wasm/index.html
+++ b/serverless/experimental/wasm/index.html
@@ -12,7 +12,7 @@
 	<body>
 		<div id="log" style="border: 2px solid; margin: 5px; background: #ddd;">
 			<div><b>Log</b></div>
-			<div id="latestCP" style="border: 1px solid; height: 5em; background: #eee;"></div>
+			<div id="latestCP" style="border: 1px solid; height: 8em; background: #eee;"></div>
 			<div style="border: 1px solid; background: #eee;">
 				<textarea id="logConsole" readonly rows="10" style="width: 100%;"></textarea>
 			</div>

--- a/serverless/experimental/wasm/main.go
+++ b/serverless/experimental/wasm/main.go
@@ -213,7 +213,6 @@ func monitor(ctx context.Context, f client.Fetcher) {
 		monMsg(fmt.Sprintf("<invert>Saw new CP with size %d</invert>", cp.Size))
 
 		if cpCur.Size > 0 {
-
 			pb, err := client.NewProofBuilder(ctx, *cp, rfc6962.DefaultHasher.HashChildren, f)
 			if err != nil {
 				monMsg(err)
@@ -240,6 +239,7 @@ func initKeys() {
 	var s, v string
 	var err error
 
+	// Don't forget, this is a DEMO - don't do this for your production things:
 	prevV := js.Global().Get("sessionStorage").Call("getItem", "log.pub")
 	prevS := js.Global().Get("sessionStorage").Call("getItem", "log.sec")
 


### PR DESCRIPTION
- This allows us to use the `client` package
- Use the `client` package in the monitor to do consistency checking of CPs
