### PR TITLE
[Serverless] Make WASM monitor inspect log entries

### DIFF
--- a/serverless/experimental/wasm/index.html
+++ b/serverless/experimental/wasm/index.html
@@ -1,5 +1,9 @@
 <html>
 	<head>
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:bold">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=VT323">
+
 		<meta charset="utf-8"/>
 		<script src="wasm_exec.js"></script>
 		<script>
@@ -8,31 +12,86 @@
 				go.run(result.instance);
 			});
 		</script>
+		<style>
+			body {
+				font-family: "Roboto";
+			}
+			.role {
+				padding: 5px;
+				border: black 1px solid;
+				margin: 5px;
+				border-radius: 5px;
+			}
+			.controls {
+				padding-top: 5px;
+			}
+			.console {
+				color: orange;
+				font-family: 'VT323';
+				font-size: 1.3em;
+				background-color: black;
+				background-image: radial-gradient(circle farthest-corner at 70% 70%,
+				rgba(255, 165, 0, 0.15), black 150%);
+				height: 100vh;
+				max-width: 100vw;
+				text-shadow: 0 0 2px #C8C8C8;
+				position: relative;
+				overflow-y: auto;
+				word-wrap: break-word;
+				display: block;
+			}
+			.console::after {
+				position: absolute;
+				top: 0;
+				left: 0;
+				bottom: 0;
+				right: 0;
+				background: repeating-linear-gradient(
+					0deg,
+					rgba(0,0,0, 0.15),
+					rgba(0,0,0, 0.25) 1px,
+					transparent 1px,
+					transparent 2px
+				);
+			}
+			blink {
+				animation: blinker 1s infinite cubic-bezier(0.49, 0.01, 0, 1.03);
+			}
+			@keyframes blinker {
+				0% { opacity: 1; }
+				50% { opacity: 0; }
+				100% { opacity: 1; }
+			}
+			invert {
+				background: orange;
+				color: black;
+			}
+		</style>
 	</head>
 	<body>
-		<div id="log" style="border: 2px solid; margin: 5px; background: #ddd;">
+		<div id="publisher" class="role" style="background: #fdd;">
+			<div><b>Publisher</b></div>
+			<label>Leaf data:</label><input type="text" id="leaf_value" style="width: 80%;"/>
+			<input type="button" value="QueueLeaf" onclick="queueLeaf(document.getElementById('leaf_value').value)"/>
+		</div>
+		<br/>
+		<div id="log" class="role" style="background: #ddd;">
 			<div><b>Log</b></div>
-			<div id="latestCP" style="border: 1px solid; height: 8em; background: #eee;"></div>
+			<div id="latestCP" class="console" style="height: 10em; border-bottom: orange solid 1em;"></div>
 			<div style="border: 1px solid; background: #eee;">
-				<textarea id="logConsole" readonly rows="10" style="width: 100%;"></textarea>
+				<div id="logConsole" style="height: 10em;" class="console"></div>
 			</div>
-			<div>
+			<div class="controls">
 				<input type="button" value="Sequence" onclick="sequence()"/>
 				<input type="button" value="Integrate" onclick="integrate()"/>
 				<input type="button" value="DESTROY LOG" style="color: red; float: right;" onclick="sessionStorage.clear()"/>
 			</div>
 		</div>
 		<br/>
-		<div id="publisher" style="border: 2px solid; margin: 5px; background: #fdd;">
-			<div><b>publisher</b></div>
-			<label>Leaf data:</label><input type="text" id="leaf_value" style="width: 80%;"/>
-			<input type="button" value="QueueLeaf" onclick="queueLeaf(document.getElementById('leaf_value').value)"/>
-		</div>
-		<br/>
-		<div id="monitor" style="border: 2px solid; margin: 5px; background: #dfd;">
-			<div><b>monitor</b></div>
+		<div id="monitor" class="role" style="background: #dfd;">
+			<div><b>Monitor</b></div>
 			<div style="border: 1px solid; background: #eee;">
-				<textarea id="monitorConsole" readonly rows="10" style="width: 100%;"></textarea>
+				<div id="monitorConsole" style="height: 30em;" class="console"></div>
 			</div>
 		</div>
 

--- a/serverless/experimental/wasm/index.html
+++ b/serverless/experimental/wasm/index.html
@@ -22,6 +22,9 @@
 				margin: 5px;
 				border-radius: 5px;
 			}
+			.info::before {
+				content: "🐸 "
+			}
 			.controls {
 				padding-top: 5px;
 			}
@@ -31,7 +34,7 @@
 				font-size: 1.3em;
 				background-color: black;
 				background-image: radial-gradient(circle farthest-corner at 70% 70%,
-				rgba(255, 165, 0, 0.15), black 150%);
+				rgba(255, 165, 0, 0.25), black 150%);
 				height: 100vh;
 				max-width: 100vw;
 				text-shadow: 0 0 2px #C8C8C8;
@@ -69,6 +72,17 @@
 		</style>
 	</head>
 	<body>
+		<div id="clippy" class="info role" style="background: #ffd;">
+			<b>Welcome!</b><br/>
+			To get started, type something into the Publisher's <code>Leaf data</code> field below and click on the <code>Queue Leaf</code> button.<br/>
+			You can do this multiple times if you like, just make sure that the <code>Leaf data</code> field is different each time.<br/>
+			Next, click on the <code>Sequence</code> button and you should see some information in the Log's console about which index each of your leaves have been assigned.<br/>
+			Finally, click on the <code>Integrate</code> button and the log should incorporate your newly sequenced leaves into the tree and produce a new Checkpoint which will appear in the upper part of the Log's console.<br/>
+			<br/>
+			You should notice that the Monitor's console also updates as it notices that the log has produced a new Checkpoint.<br/>
+			If you add more leaves and <code>Sequence</code> and <code>Integrate</code> them, you'll see the Monitor's console adding information about new Checkpoints and consistency proofs.
+		</div>
+		<br/>
 		<div id="publisher" class="role" style="background: #fdd;">
 			<div><b>Publisher</b></div>
 			<label>Leaf data:</label><input type="text" id="leaf_value" style="width: 80%;"/>

--- a/serverless/experimental/wasm/main.go
+++ b/serverless/experimental/wasm/main.go
@@ -236,6 +236,15 @@ func monitor(ctx context.Context, f client.Fetcher) {
 			monMsg(logfmt.Proof(proof).Marshal())
 			monMsg("New CP verified to be consistent")
 		}
+
+		for i := cpCur.Size; i < cp.Size; i++ {
+			l, err := client.GetLeaf(ctx, f, i)
+			if err != nil {
+				monMsg(fmt.Sprintf("Failed to fetch leaf at %d: %v", i, err))
+				continue
+			}
+			monMsg(fmt.Sprintf(" + Leaf %d: <i>%q</i>", i, string(l)))
+		}
 		cpCur = cp
 	}
 }


### PR DESCRIPTION
- Print out log entries in the monitor console
- Use compact range to verify consistency and inclusion

(currently stacked on #417 and #418, will rebase)