### PR TITLE
Download leaves up to the latest checkpoint and verify result

### DIFF
--- a/clone/cmd/ctclone/ctclone.go
+++ b/clone/cmd/ctclone/ctclone.go
@@ -162,11 +162,10 @@ func main() {
 	if err != nil {
 		glog.Exitf("Failed to compute root: %q", err)
 	}
-	if bytes.Equal(targetCp.RootHash, root) {
-		glog.Infof("Got matching roots for tree size %d: %x", targetCp.TreeSize, root)
-	} else {
+	if !bytes.Equal(targetCp.RootHash, root) {
 		glog.Exitf("Computed root %x != provided checkpoint %x for tree size %d", root, targetCp.RootHash, targetCp.TreeSize)
 	}
+	glog.Infof("Got matching roots for tree size %d: %x", targetCp.TreeSize, root)
 	if err := db.WriteCheckpoint(ctx, targetCp.TreeSize, targetCp.raw, crs); err != nil {
 		glog.Exitf("Failed to update database with new checkpoint: %v", err)
 	}

--- a/clone/cmd/ctclone/ctclone.go
+++ b/clone/cmd/ctclone/ctclone.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
@@ -26,12 +27,12 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/clone/internal/download"
+	"github.com/google/trillian-examples/clone/internal/verify"
 	"github.com/google/trillian-examples/clone/logdb"
+	"github.com/google/trillian/merkle/rfc6962"
 
 	_ "github.com/go-sql-driver/mysql"
 )
-
-const getEntriesFormat = "ct/v1/get-entries?start=%d&end=%d"
 
 var (
 	logURL         = flag.String("log_url", "", "Log storage root URL, e.g. https://ct.googleapis.com/rocketeer/")
@@ -60,7 +61,8 @@ func main() {
 	if err != nil {
 		glog.Exitf("Failed to connect to database: %q", err)
 	}
-	// TODO(mhutchinson): Persist log URI and check here to prevent user-error writing different logs to same DB.
+
+	// Determine head: the index of the last leaf stored in the DB (or -1 if none present).
 	head, err := db.Head()
 	if err != nil {
 		if err == logdb.ErrNoDataFound {
@@ -72,42 +74,101 @@ func main() {
 	}
 	next := uint64(head + 1)
 
-	fetcher := download.NewHTTPFetcher(lu)
+	// Load from the local DB the latest verified checkpoint for the leaves, if any.
+	cpSize, _, _, err := db.GetLatestCheckpoint(ctx)
+	if err != nil {
+		if err != logdb.ErrNoDataFound {
+			glog.Exitf("Failed to query for any checkpoints: %q", err)
+		}
+	} else if cpSize > next {
+		glog.Exitf("Illegal state: checkpoint size %d > downloaded leaf count %d", cpSize, next)
+	}
 
+	// Get the latest checkpoint from the log we are cloning: we will download all the leaves this commits to.
+	fetcher := ctFetcher{download.NewHTTPFetcher(lu)}
+	targetCp, err := fetcher.latestCheckpoint()
+	if err != nil {
+		glog.Exitf("Failed to get latest checkpoint from log: %v", err)
+	}
+	if targetCp.TreeSize <= cpSize {
+		glog.Infof("No work to do. Local tree size = %d, latest log tree size = %d", cpSize, targetCp.TreeSize)
+		return
+	}
+	glog.Infof("Fetching all leaves for tree size %d", targetCp.TreeSize)
+
+	// Start downloading leaves in a background thread, with the results put into brc.
 	brc := make(chan download.BulkResult, *writeBatchSize*2)
-	go download.Bulk(ctx, next, certLeafFetcher{fetcher}.Batch, *workers, *fetchBatchSize, brc)
+	go download.Bulk(ctx, next, targetCp.TreeSize, fetcher.Batch, *workers, *fetchBatchSize, brc)
 
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
+	// Set up a background thread to report downloading progress (as it can take a long time).
+	rCtx, rCtxCancel := context.WithCancel(ctx)
 	r := reporter{
 		lastReported: next,
 		lastReport:   time.Now(),
+		treeSize:     targetCp.TreeSize,
 	}
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				r.report()
+			case <-rCtx.Done():
+				return
+			}
+		}
+	}()
 
+	// This main thread will now take the downloaded leaves, batch them, and write to the DB.
 	batch := make([][]byte, *writeBatchSize)
 	bi := 0
 	bs := next
-
-	for {
-		select {
-		case <-ticker.C:
-			r.report()
-		case br := <-brc:
-			if br.Err != nil {
-				glog.Exit(err)
-			}
-			workDone := r.trackWork(next)
-			next++
-			batch[bi] = br.Leaf
-			bi = (bi + 1) % int(*writeBatchSize)
-			if bi == 0 {
-				if err := db.WriteLeaves(ctx, bs, batch); err != nil {
-					glog.Exitf("Failed to write to DB for batch starting at %d: %q", bs, err)
-				}
-				bs = next
-			}
-			workDone()
+	for br := range brc {
+		if br.Err != nil {
+			glog.Exit(err)
 		}
+		workDone := r.trackWork(next)
+		next++
+		batch[bi] = br.Leaf
+		bi = (bi + 1) % int(*writeBatchSize)
+		if bi == 0 {
+			if err := db.WriteLeaves(ctx, bs, batch); err != nil {
+				glog.Exitf("Failed to write to DB for batch starting at %d: %q", bs, err)
+			}
+			bs = next
+		}
+		workDone()
+	}
+	// All leaves are downloaded, but make sure we write the final (maybe partial) batch.
+	if bi > 0 {
+		if err := db.WriteLeaves(ctx, bs, batch[:bi]); err != nil {
+			glog.Exitf("Failed to write to DB for final batch starting at %d: %q", bs, err)
+		}
+	}
+	// Stop the reporting now downloading is finished.
+	rCtxCancel()
+	r.report()
+	glog.Infof("Downloaded %d leaves. Now verifying", bs+uint64(bi))
+
+	// Verify the downloaded leaves with the target checkpoint, and if it verifies, persist the checkpoint.
+	// TODO(mhutchinson): Verify in parallel with downloading.
+	h := rfc6962.DefaultHasher
+	lh := func(_ uint64, preimage []byte) []byte {
+		return h.HashLeaf(preimage)
+	}
+	v := verify.NewLogVerifier(db, lh, h.HashChildren)
+	root, crs, err := v.MerkleRoot(ctx, targetCp.TreeSize)
+	if err != nil {
+		glog.Exitf("Failed to compute root: %q", err)
+	}
+	if bytes.Equal(targetCp.RootHash, root) {
+		glog.Infof("Got matching roots for tree size %d: %x", targetCp.TreeSize, root)
+	} else {
+		glog.Exitf("Computed root %x != provided checkpoint %x for tree size %d", root, targetCp.RootHash, targetCp.TreeSize)
+	}
+	if err := db.WriteCheckpoint(ctx, targetCp.TreeSize, targetCp.raw, crs); err != nil {
+		glog.Exitf("Failed to update database with new checkpoint: %v", err)
 	}
 }
 
@@ -115,6 +176,7 @@ type reporter struct {
 	lastReport   time.Time
 	lastReported uint64
 	lastWorked   uint64
+	treeSize     uint64
 	epochWorked  time.Duration
 }
 
@@ -122,8 +184,10 @@ func (r *reporter) report() {
 	elapsed := time.Since(r.lastReport)
 	workRatio := r.epochWorked.Seconds() / elapsed.Seconds()
 
+	remaining := r.treeSize - r.lastReported - 1
 	rate := float64(r.lastWorked-r.lastReported) / elapsed.Seconds()
-	glog.Infof("%.1f leaves/s, last leaf=%d, time working=%.1f%%", rate, r.lastReported, 100*workRatio)
+	eta := time.Duration(float64(remaining)/rate) * time.Second
+	glog.Infof("%.1f leaves/s, last leaf=%d (remaining: %d, ETA: %s), time working=%.1f%%", rate, r.lastReported, remaining, eta, 100*workRatio)
 	r.epochWorked = 0
 	r.lastReported = r.lastWorked
 	r.lastReport = time.Now()
@@ -145,17 +209,17 @@ type fetcher interface {
 	GetData(path string) ([]byte, error)
 }
 
-type certLeafFetcher struct {
+type ctFetcher struct {
 	f fetcher
 }
 
 // Batch provides a mechanism to fetch a range of leaves.
 // Enough leaves are fetched to fully fill `leaves`, or an error is returned.
 // This implements batch.BatchFetch.
-func (clf certLeafFetcher) Batch(start uint64, leaves [][]byte) error {
+func (cf ctFetcher) Batch(start uint64, leaves [][]byte) error {
 	// CT API gets [start, end] not [start, end).
 	last := start + uint64(len(leaves)) - 1
-	data, err := clf.f.GetData(fmt.Sprintf(getEntriesFormat, start, last))
+	data, err := cf.f.GetData(fmt.Sprintf("ct/v1/get-entries?start=%d&end=%d", start, last))
 	if err != nil {
 		return fmt.Errorf("fetcher.GetData: %w", err)
 	}
@@ -172,10 +236,35 @@ func (clf certLeafFetcher) Batch(start uint64, leaves [][]byte) error {
 	return nil
 }
 
+func (cf ctFetcher) latestCheckpoint() (CTCheckpointResponse, error) {
+	r := CTCheckpointResponse{}
+	cpbs, err := cf.f.GetData("ct/v1/get-sth")
+	if err != nil {
+		return r, fmt.Errorf("failed to find latest log checkpoint: %v", err)
+	}
+	if err := json.Unmarshal(cpbs, &r); err != nil {
+		return r, fmt.Errorf("failed to parse checkpoint: %v", err)
+	}
+	r.raw = cpbs
+	return r, nil
+}
+
 type getEntriesResponse struct {
 	Leaves []leafInput `json:"entries"`
 }
 
 type leafInput struct {
 	Data []byte `json:"leaf_input"`
+}
+
+// CTCheckpointResponse mirrors the RFC6962 STH format for `get-sth` to allow the
+// data to be easy unmarshalled from the JSON response.
+// TODO(mhutchinson): this was copied from ctverify. Deduplicate.
+type CTCheckpointResponse struct {
+	TreeSize  uint64 `json:"tree_size"`
+	Timestamp uint64 `json:"timestamp"`
+	RootHash  []byte `json:"sha256_root_hash"`
+	Sig       []byte `json:"tree_head_signature"`
+
+	raw []byte
 }

--- a/clone/cmd/ctclone/ctclone_test.go
+++ b/clone/cmd/ctclone/ctclone_test.go
@@ -60,7 +60,7 @@ func TestCertLeafFetcher(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			clf := certLeafFetcher{&fakeFetcher{test.urls}}
+			clf := ctFetcher{&fakeFetcher{test.urls}}
 			leaves := make([][]byte, test.count)
 			err := clf.Batch(test.start, leaves)
 			switch {

--- a/clone/internal/download/batch.go
+++ b/clone/internal/download/batch.go
@@ -109,6 +109,8 @@ type fetchWorker struct {
 }
 
 func (w fetchWorker) run(ctx context.Context) {
+	glog.V(2).Infof("fetchWorker %q started", w.label)
+	defer glog.V(2).Infof("fetchWorker %q finished", w.label)
 	defer close(w.out)
 	// TODO(mhutchinson): Consider some way to reset this after intermittent connectivity issue.
 	// If this is pushed in the loop then it fixes this issue, but at the cost that the worker

--- a/clone/internal/download/batch_test.go
+++ b/clone/internal/download/batch_test.go
@@ -16,70 +16,131 @@ package download
 
 import (
 	"context"
-	"fmt"
+	"strconv"
 	"testing"
 )
 
 func TestFetchWorkerRun(t *testing.T) {
-	wrc := make(chan workerResult, 10)
-	var first uint64
-	var batchSize uint = 10
+	for _, test := range []struct {
+		name        string
+		first, last uint64
+		batchSize   uint
+	}{
+		{
+			name:      "smallest batch",
+			first:     0,
+			last:      10,
+			batchSize: 1,
+		},
+		{
+			name:      "larger batch",
+			first:     0,
+			last:      110,
+			batchSize: 10,
+		},
+		{
+			name:      "batch size non-divisor of range",
+			first:     0,
+			last:      107,
+			batchSize: 10,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			wrc := make(chan workerResult)
 
-	fakeFetch := func(start uint64, leaves [][]byte) error {
-		return nil
-	}
-	fw := fetchWorker{
-		label:      "solipsism",
-		start:      first,
-		increment:  uint64(batchSize),
-		count:      batchSize,
-		out:        wrc,
-		batchFetch: fakeFetch,
-	}
+			fakeFetch := func(start uint64, leaves [][]byte) error {
+				return nil
+			}
+			fw := fetchWorker{
+				label:      test.name,
+				start:      test.first,
+				last:       test.last,
+				increment:  uint64(test.batchSize),
+				count:      test.batchSize,
+				out:        wrc,
+				batchFetch: fakeFetch,
+			}
 
-	go fw.run(context.Background())
+			go fw.run(context.Background())
 
-	for i := 0; i < 10; i++ {
-		r := <-wrc
-		if r.err != nil {
-			t.Fatal(r.err)
-		}
-		if got, want := r.start, uint64(i*10); got != want {
-			t.Errorf("%d got != want (%d != %d)", i, got, want)
-		}
+			var seen, i int
+			for r := range wrc {
+				if r.err != nil {
+					t.Fatal(r.err)
+				}
+				if got, want := r.start, uint64(i*int(test.batchSize)); got != want {
+					t.Errorf("%d got != want (%d != %d)", i, got, want)
+				}
+				seen = seen + len(r.leaves)
+				i++
+			}
+			if seen != int(test.last) {
+				t.Errorf("expected to see %d leaves but saw %d", test.last, seen)
+			}
+		})
 	}
 }
 
 func TestBulk(t *testing.T) {
-	brc := make(chan BulkResult, 10)
-	var first uint64
-	var workers uint = 4
-	var batchSize uint = 10
+	for _, test := range []struct {
+		name        string
+		first, last uint64
+		batchSize   uint
+		workers     uint
+	}{
+		{
+			name:      "smallest batch",
+			first:     0,
+			last:      10,
+			batchSize: 1,
+			workers:   1,
+		},
+		{
+			name:      "larger batch",
+			first:     0,
+			last:      110,
+			batchSize: 10,
+			workers:   4,
+		},
+		{
+			name:      "batch size non-divisor of range",
+			first:     0,
+			last:      107,
+			batchSize: 10,
+			workers:   4,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			brc := make(chan BulkResult)
+			fakeFetch := func(start uint64, leaves [][]byte) error {
+				for i := range leaves {
+					leaves[i] = []byte(strconv.Itoa(int(start) + i))
+				}
+				return nil
+			}
+			go Bulk(context.Background(), test.first, test.last, fakeFetch, test.workers, test.batchSize, brc)
 
-	fakeFetch := func(start uint64, leaves [][]byte) error {
-		for i := range leaves {
-			leaves[i] = []byte(fmt.Sprintf("%d.%d", start, i))
-		}
-		return nil
-	}
-	go Bulk(context.Background(), first, fakeFetch, workers, batchSize, brc)
-
-	for i := 0; i < 1000; i++ {
-		br := <-brc
-		if br.Err != nil {
-			t.Fatal(br.Err)
-		}
-		tens := (i / 10) * 10
-		units := i % 10
-		if got, want := string(br.Leaf), fmt.Sprintf("%d.%d", tens, units); got != want {
-			t.Errorf("%d got != want (%q != %q)", i, got, want)
-		}
+			i := 0
+			for br := range brc {
+				if br.Err != nil {
+					t.Fatal(br.Err)
+				}
+				if got, want := string(br.Leaf), strconv.Itoa(i); got != want {
+					t.Errorf("%d got != want (%q != %q)", i, got, want)
+				}
+				i++
+			}
+			if i != int(test.last) {
+				t.Errorf("expected %d leaves, got %d", test.last, i)
+			}
+		})
 	}
 }
 
 func TestBulkCancelled(t *testing.T) {
 	brc := make(chan BulkResult, 10)
 	var first uint64
+	var last uint64 = 1000
 	var workers uint = 4
 	var batchSize uint = 10
 
@@ -89,10 +150,10 @@ func TestBulkCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go Bulk(ctx, first, fakeFetch, workers, batchSize, brc)
+	go Bulk(ctx, first, last, fakeFetch, workers, batchSize, brc)
 
 	seen := 0
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < int(last); i++ {
 		br := <-brc
 		if br.Err != nil {
 			break
@@ -102,7 +163,7 @@ func TestBulkCancelled(t *testing.T) {
 			cancel()
 		}
 	}
-	if seen == 1000 {
+	if seen == int(last) {
 		t.Error("Expected cancellation to prevent all leaves being read")
 	}
 }
@@ -121,7 +182,7 @@ func BenchmarkBulk(b *testing.B) {
 		}
 		return nil
 	}
-	go Bulk(context.Background(), first, fakeFetch, workers, batchSize, brc)
+	go Bulk(context.Background(), first, uint64(b.N), fakeFetch, workers, batchSize, brc)
 
 	for n := 0; n < b.N; n++ {
 		for i := 0; i < 1000; i++ {


### PR DESCRIPTION
Previously this tool kept attempting to download full batches until it encountered too many errors and died. This would happen after it had overshot the end of the log.

This now fetches the latest checkpoint from the log and only downloads the number of leaves that commits to. After downloading all of the leaves, it verifies that the downloaded leaves match the checkpoint commitment. Once verified, this checkpoint is stored in the database.