### PR TITLE
[Serverless] no checkpoint state in storage

### DIFF
--- a/serverless/cmd/integrate/main.go
+++ b/serverless/cmd/integrate/main.go
@@ -113,7 +113,7 @@ func main() {
 	if _, err := cp.Unmarshal([]byte(vCp.Text)); err != nil {
 		glog.Exitf("Failed to unmarshal checkpoint: %q", err)
 	}
-	st, err := fs.Load(*storageDir, cp)
+	st, err := fs.Load(*storageDir, cp.Size)
 	if err != nil {
 		glog.Exitf("Failed to load storage: %q", err)
 	}

--- a/serverless/cmd/integrate/main.go
+++ b/serverless/cmd/integrate/main.go
@@ -81,11 +81,13 @@ func main() {
 	}
 
 	if *initialise {
-		st, err := fs.Create(*storageDir, h.EmptyRoot())
+		st, err := fs.Create(*storageDir)
 		if err != nil {
 			glog.Exitf("Failed to create log: %q", err)
 		}
-		cp := st.Checkpoint()
+		cp := fmtlog.Checkpoint{
+			Hash: h.EmptyRoot(),
+		}
 		if err := signAndWrite(&cp, cpNote, s, st); err != nil {
 			glog.Exitf("Failed to sign: %q", err)
 		}
@@ -111,13 +113,13 @@ func main() {
 	if _, err := cp.Unmarshal([]byte(vCp.Text)); err != nil {
 		glog.Exitf("Failed to unmarshal checkpoint: %q", err)
 	}
-	st, err := fs.Load(*storageDir, &cp)
+	st, err := fs.Load(*storageDir, cp)
 	if err != nil {
 		glog.Exitf("Failed to load storage: %q", err)
 	}
 
 	// Integrate new entries
-	newCp, err := log.Integrate(ctx, st, h)
+	newCp, err := log.Integrate(ctx, cp, st, h)
 	if err != nil {
 		glog.Exitf("Failed to integrate: %q", err)
 	}

--- a/serverless/cmd/sequence/main.go
+++ b/serverless/cmd/sequence/main.go
@@ -87,7 +87,7 @@ func main() {
 	if _, err := cp.Unmarshal([]byte(vCp.Text)); err != nil {
 		glog.Exitf("Failed to unmarshal checkpoint: %q", err)
 	}
-	st, err := fs.Load(*storageDir, cp)
+	st, err := fs.Load(*storageDir, cp.Size)
 	if err != nil {
 		glog.Exitf("Failed to load storage: %q", err)
 	}

--- a/serverless/cmd/sequence/main.go
+++ b/serverless/cmd/sequence/main.go
@@ -87,7 +87,7 @@ func main() {
 	if _, err := cp.Unmarshal([]byte(vCp.Text)); err != nil {
 		glog.Exitf("Failed to unmarshal checkpoint: %q", err)
 	}
-	st, err := fs.Load(*storageDir, &cp)
+	st, err := fs.Load(*storageDir, cp)
 	if err != nil {
 		glog.Exitf("Failed to load storage: %q", err)
 	}

--- a/serverless/experimental/wasm/main.go
+++ b/serverless/experimental/wasm/main.go
@@ -357,7 +357,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		logStorage, err = webstorage.Load(logPrefix, *cp)
+		logStorage, err = webstorage.Load(logPrefix, cp.Size)
 		if err != nil {
 			panic(err)
 		}

--- a/serverless/internal/storage/fs/fs.go
+++ b/serverless/internal/storage/fs/fs.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 
 	"github.com/golang/glog"
-	"github.com/google/trillian-examples/formats/log"
 	"github.com/google/trillian-examples/serverless/api"
 	"github.com/google/trillian-examples/serverless/api/layout"
 	"github.com/google/trillian-examples/serverless/internal/storage"
@@ -57,8 +56,9 @@ type Storage struct {
 
 const leavesPendingPathFmt = "leaves/pending/%0x"
 
-// Load returns a Storage instance initialised from the filesystem.
-func Load(rootDir string, checkpoint log.Checkpoint) (*Storage, error) {
+// Load returns a Storage instance initialised from the filesystem at the provided location.
+// cpSize should be the Size of the checkpoint produced from the last `log.Integrate` call.
+func Load(rootDir string, cpSize uint64) (*Storage, error) {
 	fi, err := os.Stat(rootDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to stat %q: %w", rootDir, err)
@@ -70,7 +70,7 @@ func Load(rootDir string, checkpoint log.Checkpoint) (*Storage, error) {
 
 	return &Storage{
 		rootDir: rootDir,
-		nextSeq: checkpoint.Size,
+		nextSeq: cpSize,
 	}, nil
 }
 

--- a/serverless/internal/storage/fs/fs.go
+++ b/serverless/internal/storage/fs/fs.go
@@ -53,14 +53,12 @@ type Storage struct {
 	// Note that nextSeq may be <= than the actual next available number, but
 	// never greater.
 	nextSeq uint64
-	// checkpoint is the latest known checkpoint of the log.
-	checkpoint log.Checkpoint
 }
 
 const leavesPendingPathFmt = "leaves/pending/%0x"
 
 // Load returns a Storage instance initialised from the filesystem.
-func Load(rootDir string, checkpoint *log.Checkpoint) (*Storage, error) {
+func Load(rootDir string, checkpoint log.Checkpoint) (*Storage, error) {
 	fi, err := os.Stat(rootDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to stat %q: %w", rootDir, err)
@@ -71,14 +69,13 @@ func Load(rootDir string, checkpoint *log.Checkpoint) (*Storage, error) {
 	}
 
 	return &Storage{
-		rootDir:    rootDir,
-		checkpoint: *checkpoint,
-		nextSeq:    checkpoint.Size,
+		rootDir: rootDir,
+		nextSeq: checkpoint.Size,
 	}, nil
 }
 
 // Create creates a new filesystem hierarchy and returns a Storage representation for it.
-func Create(rootDir string, emptyHash []byte) (*Storage, error) {
+func Create(rootDir string) (*Storage, error) {
 	_, err := os.Stat(rootDir)
 	if err == nil {
 		return nil, fmt.Errorf("%q %w", rootDir, os.ErrExist)
@@ -98,18 +95,9 @@ func Create(rootDir string, emptyHash []byte) (*Storage, error) {
 	fs := &Storage{
 		rootDir: rootDir,
 		nextSeq: 0,
-		checkpoint: log.Checkpoint{
-			Size: 0,
-			Hash: emptyHash,
-		},
 	}
 
 	return fs, nil
-}
-
-// Checkpoint returns the current Checkpoint.
-func (fs *Storage) Checkpoint() log.Checkpoint {
-	return fs.checkpoint
 }
 
 // Sequence assigns the given leaf entry to the next available sequence number.

--- a/serverless/internal/storage/fs/fs_test.go
+++ b/serverless/internal/storage/fs/fs_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/trillian-examples/formats/log"
 	"github.com/google/trillian-examples/serverless/internal/storage"
 )
 
@@ -51,15 +50,13 @@ func TestLoad(t *testing.T) {
 		t.Fatalf("Create = %v", err)
 	}
 
-	cp := log.Checkpoint{}
-
-	if _, err := Load(d, cp); err != nil {
+	if _, err := Load(d, 0); err != nil {
 		t.Fatalf("Load = %v, want no error", err)
 	}
 }
 
 func TestLoadForNonExistentDir(t *testing.T) {
-	if _, err := Load("5oi4egdf93uyjigedfk", log.Checkpoint{}); !errors.Is(err, os.ErrNotExist) {
+	if _, err := Load("5oi4egdf93uyjigedfk", 0); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("Load = %v, want not exists error", err)
 	}
 }

--- a/serverless/internal/storage/fs/fs_test.go
+++ b/serverless/internal/storage/fs/fs_test.go
@@ -15,7 +15,6 @@
 package fs
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"errors"
 	"os"
@@ -28,20 +27,10 @@ import (
 )
 
 func TestCreate(t *testing.T) {
-	empty := []byte("empty")
-
 	d := filepath.Join(t.TempDir(), "storage")
-	s, err := Create(d, empty)
+	_, err := Create(d)
 	if err != nil {
 		t.Fatalf("Create = %v", err)
-	}
-
-	cp := s.Checkpoint()
-	if got, want := cp.Size, uint64(0); got != want {
-		t.Errorf("New checkpoint has size %d, want %d", got, want)
-	}
-	if got, want := cp.Hash, empty; !bytes.Equal(got, want) {
-		t.Errorf("New checkpoint roothash %x, want %x", got, want)
 	}
 }
 
@@ -49,39 +38,36 @@ func TestCreateForExistingDirectory(t *testing.T) {
 	// This dir will already exist since the test framework just created it.
 	d := t.TempDir()
 
-	_, err := Create(d, []byte("empty"))
+	_, err := Create(d)
 	if !errors.Is(err, os.ErrExist) {
 		t.Fatalf("Create = %v, want already exists error", err)
 	}
 }
 
 func TestLoad(t *testing.T) {
-	empty := []byte("empty")
-
 	d := filepath.Join(t.TempDir(), "storage")
-	_, err := Create(d, empty)
+	_, err := Create(d)
 	if err != nil {
 		t.Fatalf("Create = %v", err)
 	}
 
 	cp := log.Checkpoint{}
 
-	if _, err := Load(d, &cp); err != nil {
+	if _, err := Load(d, cp); err != nil {
 		t.Fatalf("Load = %v, want no error", err)
 	}
 }
 
 func TestLoadForNonExistentDir(t *testing.T) {
-	if _, err := Load("5oi4egdf93uyjigedfk", nil); !errors.Is(err, os.ErrNotExist) {
+	if _, err := Load("5oi4egdf93uyjigedfk", log.Checkpoint{}); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("Load = %v, want not exists error", err)
 	}
 }
 
 func TestWriteLoadState(t *testing.T) {
-	empty := []byte("empty")
 
 	d := filepath.Join(t.TempDir(), "storage")
-	s, err := Create(d, empty)
+	s, err := Create(d)
 	if err != nil {
 		t.Fatalf("Create = %v", err)
 	}
@@ -124,7 +110,7 @@ func TestSequence(t *testing.T) {
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			d := filepath.Join(t.TempDir(), "storage")
-			s, err := Create(d, []byte("empty"))
+			s, err := Create(d)
 			if err != nil {
 				t.Fatalf("Create = %v", err)
 			}

--- a/serverless/internal/storage/webstorage/fs.go
+++ b/serverless/internal/storage/webstorage/fs.go
@@ -93,23 +93,18 @@ func createExclusive(k string, v []byte) error {
 }
 
 // Load returns a Storage instance initialised from webstorage prefixed at root.
-func Load(root string, checkpoint *log.Checkpoint) (*Storage, error) {
+func Load(root string, checkpoint log.Checkpoint) (*Storage, error) {
 	return &Storage{
-		root:       root,
-		checkpoint: *checkpoint,
-		nextSeq:    checkpoint.Size,
+		root:    root,
+		nextSeq: checkpoint.Size,
 	}, nil
 }
 
 // Create creates a new filesystem hierarchy and returns a Storage representation for it.
-func Create(root string, emptyHash []byte) (*Storage, error) {
+func Create(root string) (*Storage, error) {
 	fs := &Storage{
 		root:    root,
 		nextSeq: 0,
-		checkpoint: log.Checkpoint{
-			Size: 0,
-			Hash: emptyHash,
-		},
 	}
 
 	return fs, nil
@@ -156,11 +151,6 @@ func (fs *Storage) DeletePending(f string) error {
 	}
 	getStorage().Call("removeItem", f)
 	return nil
-}
-
-// Checkpoint returns the current Checkpoint.
-func (fs *Storage) Checkpoint() log.Checkpoint {
-	return fs.checkpoint
 }
 
 // Sequence assigns the given leaf entry to the next available sequence number.

--- a/serverless/internal/storage/webstorage/fs.go
+++ b/serverless/internal/storage/webstorage/fs.go
@@ -93,10 +93,11 @@ func createExclusive(k string, v []byte) error {
 }
 
 // Load returns a Storage instance initialised from webstorage prefixed at root.
-func Load(root string, checkpoint log.Checkpoint) (*Storage, error) {
+// cpSize should be the Size of the checkpoint produced from the last `log.Integrate` call.
+func Load(root string, cpSize uint64) (*Storage, error) {
 	return &Storage{
 		root:    root,
-		nextSeq: checkpoint.Size,
+		nextSeq: cpSize,
 	}, nil
 }
 


### PR DESCRIPTION
Storage was previously parsing a signed note as a checkpoint, now the caller of `log.Integrate` passes in the checkpoint data.
