### PR TITLE
Add a check that the log string doesn't change after TOFU

### DIFF
--- a/witness/golang/cmd/witness/internal/witness/witness.go
+++ b/witness/golang/cmd/witness/internal/witness/witness.go
@@ -175,6 +175,9 @@ func (w *Witness) Update(ctx context.Context, logID string, nextRaw []byte, proo
 	if err != nil {
 		return nil, fmt.Errorf("couldn't parse stored checkpoint: %v", err)
 	}
+	if next.Ecosystem != prev.Ecosystem {
+		return nil, fmt.Errorf("line 0 (log/ecosystem string) changed. Was %q, but attempting to set to %q", prev.Ecosystem, next.Ecosystem)
+	}
 	// Parse the compact range if we're using one.
 	var prevRange log.Proof
 	if logInfo.UseCompact {

--- a/witness/golang/cmd/witness/internal/witness/witness_test.go
+++ b/witness/golang/cmd/witness/internal/witness/witness_test.go
@@ -278,6 +278,15 @@ func TestUpdate(t *testing.T) {
 			pf:       consProof,
 			useCR:    false,
 			isGood:   true,
+		},
+		{
+			desc:     "vanilla path, but the first line changed",
+			initC:    mInit,
+			initSize: 5,
+			newC:     []byte("Frog Checkpoint v0\n8\nV8K9aklZ4EPB+RMOk1/8VsJUdFZR77GDtZUQq84vSbo=\n\n— monkeys 202ffgCVdfZmrroccRdQoEfn2TfmXHez4R++GvVrFvFiaI85O12aTV5GpNOvWsuQW77eNxQ2b7ggYeglzF/QSy/EBws=\n"),
+			pf:       consProof,
+			useCR:    false,
+			isGood:   false,
 		}, {
 			desc:     "vanilla consistency smaller checkpoint",
 			initC:    mNext,


### PR DESCRIPTION
This string shouldn't change once the log is configured. If the string changes (e.g. new version) then this is effectively a new log.