### PR TITLE
Support fetching partial tiles

### DIFF
--- a/sumdbaudit/audit/service.go
+++ b/sumdbaudit/audit/service.go
@@ -230,7 +230,7 @@ func (s *Service) VerifyTiles(ctx context.Context, checkpoint *Checkpoint) error
 				}
 				return fmt.Errorf("failed to get tile hashes: %w", err)
 			}
-			sumDBHashes, err := s.sumDB.TileHashes(level, offset)
+			sumDBHashes, err := s.sumDB.TileHashes(level, offset, 0)
 			if err != nil {
 				return fmt.Errorf("failed to get tile hashes: %w", err)
 			}

--- a/sumdbaudit/audit/sumdb.go
+++ b/sumdbaudit/audit/sumdb.go
@@ -144,8 +144,13 @@ func dataToLeaves(data []byte) [][]byte {
 }
 
 // TileHashes gets the hashes at the given level and offset.
-func (c *SumDBClient) TileHashes(level, offset int) ([]tlog.Hash, error) {
-	data, err := c.fetcher.GetData(fmt.Sprintf("/tile/%d/%d/%s", c.height, level, c.tilePath(offset)))
+// If partial > 0 then a partial tile will be fetched with the number of hashes.
+func (c *SumDBClient) TileHashes(level, offset, partial int) ([]tlog.Hash, error) {
+	url := fmt.Sprintf("/tile/%d/%d/%s", c.height, level, c.tilePath(offset))
+	if partial > 0 {
+		url = fmt.Sprintf("%s.p/%d", url, partial)
+	}
+	data, err := c.fetcher.GetData(url)
 	if err != nil {
 		return nil, err
 	}

--- a/sumdbaudit/audit/sumdb_test.go
+++ b/sumdbaudit/audit/sumdb_test.go
@@ -112,7 +112,7 @@ func TestTileHashes(t *testing.T) {
 			values: map[string]string{"/tile/2/0/000": string(hashData)},
 		},
 	}
-	hashes, err := sumdb.TileHashes(0, 0)
+	hashes, err := sumdb.TileHashes(0, 0, 0)
 	if err != nil {
 		t.Fatalf("failed to get hashes: %v", err)
 	}


### PR DESCRIPTION
This can probably be better used in this witness, but for now preserve the old behaviour.

This API is being used by the new feeder being implemented, and partial tile fetching is important for that.