### PR TITLE
Witness client: Update returns latest Checkpoint

### DIFF
--- a/serverless/cmd/feeder/impl/feeder.go
+++ b/serverless/cmd/feeder/impl/feeder.go
@@ -42,6 +42,8 @@ type Witness interface {
 	// Must return os.ErrNotExists if the logID is known, but it has no checkpoint for that log.
 	GetLatestCheckpoint(ctx context.Context, logID string) ([]byte, error)
 	// Update attempts to clock the witness forward for the given logID.
+	// The latest signed checkpoint will be returned if this succeeds, or if the error is
+	// http.ErrCheckpointTooOld. In all other cases no checkpoint should be expected.
 	Update(ctx context.Context, logID string, newCP []byte, proof [][]byte) ([]byte, error)
 }
 

--- a/serverless/cmd/feeder/impl/feeder.go
+++ b/serverless/cmd/feeder/impl/feeder.go
@@ -42,7 +42,7 @@ type Witness interface {
 	// Must return os.ErrNotExists if the logID is known, but it has no checkpoint for that log.
 	GetLatestCheckpoint(ctx context.Context, logID string) ([]byte, error)
 	// Update attempts to clock the witness forward for the given logID.
-	Update(ctx context.Context, logID string, newCP []byte, proof [][]byte) error
+	Update(ctx context.Context, logID string, newCP []byte, proof [][]byte) ([]byte, error)
 }
 
 // FeedOpts holds parameters when calling the Feed function.
@@ -220,7 +220,9 @@ func submitToWitness(ctx context.Context, cpRaw []byte, cpSubmit log.Checkpoint,
 			}
 		}
 
-		if err := w.Update(ctx, logID, cpRaw, conP); err != nil {
+		// TODO(mhutchinson): This returns the checkpoint, which can be used instead of getting
+		// the latest each time around the loop.
+		if _, err := w.Update(ctx, logID, cpRaw, conP); err != nil {
 			glog.Warningf("%s: failed to submit checkpoint to witness: %v", wSigV.Name(), err)
 			continue
 		}

--- a/serverless/cmd/feeder/impl/feeder_test.go
+++ b/serverless/cmd/feeder/impl/feeder_test.go
@@ -140,18 +140,18 @@ func (fw *fakeWitness) GetLatestCheckpoint(_ context.Context, logID string) ([]b
 	return fw.latestCP, nil
 }
 
-func (fw *fakeWitness) Update(_ context.Context, logID string, newCP []byte, proof [][]byte) error {
+func (fw *fakeWitness) Update(_ context.Context, logID string, newCP []byte, proof [][]byte) ([]byte, error) {
 	if fw.rejectUpdate {
-		return errors.New("computer says 'no'")
+		return nil, errors.New("computer says 'no'")
 	}
 
 	csCP, err := cosignCP(newCP, fw.logSigV, fw.witSig)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	fw.latestCP = csCP
 
-	return nil
+	return fw.latestCP, nil
 }
 
 func mustOpenCheckpoint(t *testing.T, cp []byte, v note.Verifier) log.Checkpoint {

--- a/witness/golang/client/http/witness_client.go
+++ b/witness/golang/client/http/witness_client.go
@@ -67,7 +67,9 @@ func (w Witness) GetLatestCheckpoint(ctx context.Context, logID string) ([]byte,
 	return ioutil.ReadAll(resp.Body)
 }
 
-// Update attempts to clock the witness forward for the given log ID.
+// Update attempts to clock the witness forward for the given logID.
+// The latest signed checkpoint will be returned if this succeeds, or if the error is
+// http.ErrCheckpointTooOld. In all other cases no checkpoint should be expected.
 func (w Witness) Update(ctx context.Context, logID string, cp []byte, proof [][]byte) ([]byte, error) {
 	reqBody, err := json.MarshalIndent(&wit_api.UpdateRequest{
 		Checkpoint: cp,

--- a/witness/golang/client/http/witness_client.go
+++ b/witness/golang/client/http/witness_client.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -28,6 +29,9 @@ import (
 	wit_api "github.com/google/trillian-examples/witness/golang/api"
 	"golang.org/x/mod/sumdb/note"
 )
+
+// ErrCheckpointTooOld is returned if the checkpoint passed to Update needs to be updated.
+var ErrCheckpointTooOld error = errors.New("checkpoint too old")
 
 // Witness is a simple client for interacting with witnesses over HTTP.
 type Witness struct {
@@ -64,29 +68,36 @@ func (w Witness) GetLatestCheckpoint(ctx context.Context, logID string) ([]byte,
 }
 
 // Update attempts to clock the witness forward for the given log ID.
-func (w Witness) Update(ctx context.Context, logID string, cp []byte, proof [][]byte) error {
+func (w Witness) Update(ctx context.Context, logID string, cp []byte, proof [][]byte) ([]byte, error) {
 	reqBody, err := json.MarshalIndent(&wit_api.UpdateRequest{
 		Checkpoint: cp,
 		Proof:      proof,
 	}, "", " ")
 	if err != nil {
-		return fmt.Errorf("failed to marshal update request: %v", err)
+		return nil, fmt.Errorf("failed to marshal update request: %v", err)
 	}
 	u, err := w.URL.Parse(fmt.Sprintf(wit_api.HTTPUpdate, logID))
 	if err != nil {
-		return fmt.Errorf("failed to parse URL: %v", err)
+		return nil, fmt.Errorf("failed to parse URL: %v", err)
 	}
 	req, err := http.NewRequest("PUT", u.String(), bytes.NewReader(reqBody))
 	if err != nil {
-		return fmt.Errorf("failed to create request: %v", err)
+		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
 	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
 	if err != nil {
-		return fmt.Errorf("failed to do http request: %v", err)
+		return nil, fmt.Errorf("failed to do http request: %v", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("bad status response: %s", resp.Status)
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read body: %v", err)
 	}
-	return nil
+	if resp.StatusCode != 200 {
+		if resp.StatusCode == 409 {
+			return body, ErrCheckpointTooOld
+		}
+		return nil, fmt.Errorf("bad status response (%s): %q", resp.Status, body)
+	}
+	return body, nil
 }

--- a/witness/golang/cmd/witness/internal/http/server.go
+++ b/witness/golang/cmd/witness/internal/http/server.go
@@ -63,7 +63,11 @@ func (s *Server) update(w http.ResponseWriter, r *http.Request) {
 		// just out of date.  Give the returned checkpoint to help them
 		// form a new request.
 		if status.Code(err) == codes.FailedPrecondition {
-			http.Error(w, string(chkpt), http.StatusConflict)
+			// This is the implementation of http.Error except we don't add any trailing newline chars.
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			w.WriteHeader(http.StatusConflict)
+			fmt.Fprint(w, err)
 			return
 		}
 		http.Error(w, fmt.Sprintf("failed to update to new checkpoint: %v", err), httpForCode(http.StatusInternalServerError))


### PR DESCRIPTION
The witness client returns the latest checkpoint when it is available so that feeders don't need to make another call to GetCheckpoint.

It also includes a small fix on the witness to not add a trailing newline to the checkpoint when we return StatusConflict. This avoids stripping characters on the client to avoid malformed notes.