### PR TITLE
SumDB feeder for the generic witness

### DIFF
--- a/sumdbaudit/witness/README.md
+++ b/sumdbaudit/witness/README.md
@@ -1,0 +1,38 @@
+# Lightweight Witness for SumDB
+
+This directory contains a dockerized deployment for a lightweight witness and feeder.
+Unlike the SumDB mirror & witness implementation in this repository, this version only acquires and stores a minimal amount of information.
+This makes it much easier & cheaper to deploy.
+
+The feeder will poll the SumDB periodically, and if the size of its checkpoint is larger than the one committed to by the witness, then a consistency proof will be generated and sent to the witness.
+The witness is simply a deployment of the [generic witness](../../witness/golang/README.md).
+
+## Running
+
+### Initial Setup
+
+Before running the witness, first prepare a config directory containing `witness.config`.
+If this is copied anywhere other than `/etc/witness/config/witness.config` then `WITNESS_CONFIG_DIR` and `WITNESS_CONFIG_FILE` environment variables must be set when running docker compose later.
+
+You should also generate a keypair for the witness using `note.GenerateKey`, e.g. https://play.golang.org/p/uWUKLNK6h9v.
+
+### Running The Witness
+
+Change the environment variables below to the values you have generated, and set the config directory/file variables similarly if needed.
+
+```bash
+export WITNESS_PRIVATE_KEY="PRIVATE+KEY+WitnessName+privatekey"; \
+export WITNESS_PUBLIC_KEY="WitnessName+publickey"; \
+docker compose -f ./sumdbaudit/witness/docker-compose.yaml up -d
+```
+
+To confirm this is working you can run `curl localhost:8100/witness/v0/logs/sumdb/checkpoint` which should give something like:
+
+```
+go.sum database tree
+6353345
+d5kp6/RTbWj/e9AMga1hdcHZHcLdFKA2fjHfKJ8FfR4=
+
+— sum.golang.org Az3grhfKc0hf9eAH1x5p0VjY99pEe8l9JKKLGyf9F0m4JTrJjcsr9rUDh6kvNIl7vdzWqULpk3+azvpfJo9aOMZaYQE=
+— mdh.SumDB.Witness MwRoUvap0myxmJQ+D1EuU61mmID6Fu1anufFrU0E0FgqaVj8ZAjWSJ7eWzi8tQ4dOljZ2cVlDmSesoaeBAMC1t94Mgc
+```

--- a/sumdbaudit/witness/README.md
+++ b/sumdbaudit/witness/README.md
@@ -4,7 +4,7 @@ This directory contains a dockerized deployment for a lightweight witness and fe
 Unlike the SumDB mirror & witness implementation in this repository, this version only acquires and stores a minimal amount of information.
 This makes it much easier & cheaper to deploy.
 
-The feeder will poll the SumDB periodically, and if the size of its checkpoint is larger than the one committed to by the witness, then a consistency proof will be generated and sent to the witness.
+The feeder will poll the SumDB periodically, and if the size of its checkpoint is larger than the one committed to by the witness, then the feeder will generate a consistency proof and send this to the witness.
 The witness is simply a deployment of the [generic witness](../../witness/golang/README.md).
 
 ## Running

--- a/sumdbaudit/witness/cmd/feeder/Dockerfile
+++ b/sumdbaudit/witness/cmd/feeder/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:buster AS builder
+
+ARG GOFLAGS=""
+ENV GOFLAGS=$GOFLAGS
+ENV GO111MODULE=on
+
+# Move to working directory /build
+WORKDIR /build
+
+# Copy and download dependency using go mod
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+# Copy the code into the container
+COPY . .
+
+# Build the application
+RUN go build -o /build/bin/feeder ./sumdbaudit/witness/cmd/feeder
+
+# Build release image
+FROM golang:buster
+
+COPY --from=builder /build/bin/feeder /bin/feeder
+ENTRYPOINT ["/bin/feeder"]

--- a/sumdbaudit/witness/cmd/feeder/main.go
+++ b/sumdbaudit/witness/cmd/feeder/main.go
@@ -1,0 +1,295 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// feeder polls the sumdb log and pushes the results to a generic witness.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/formats/log"
+	"github.com/google/trillian-examples/sumdbaudit/audit"
+	"github.com/google/trillian-examples/witness/golang/client/http"
+	"github.com/google/trillian/merkle/compact"
+	"github.com/google/trillian/merkle/rfc6962"
+	"golang.org/x/mod/sumdb/note"
+	"golang.org/x/mod/sumdb/tlog"
+)
+
+var (
+	vkey         = flag.String("k", "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8", "key")
+	witness      = flag.String("w", "", "The endpoint of the witness HTTP REST API")
+	witnessKey   = flag.String("wk", "", "The public key of the witness")
+	logID        = flag.String("lid", "", "The ID of the log within the witness")
+	pollInterval = flag.Duration("poll", 10*time.Second, "How quickly to poll the sumdb to get updates")
+
+	rf = &compact.RangeFactory{
+		Hash: rfc6962.DefaultHasher.HashChildren,
+	}
+)
+
+const (
+	tileHeight    = 8
+	leavesPerTile = 1 << tileHeight
+)
+
+func main() {
+	flag.Parse()
+	ctx := context.Background()
+	sdb := audit.NewSumDB(tileHeight, *vkey)
+	var w http.Witness
+	if wURL, err := url.Parse(*witness); err != nil {
+		glog.Exitf("Failed to parse witness URL: %v", err)
+	} else {
+		w = http.Witness{
+			URL:      wURL,
+			Verifier: mustCreateVerifier(*witnessKey),
+		}
+	}
+
+	wcp := &log.Checkpoint{}
+	if wcpRaw, err := w.GetLatestCheckpoint(ctx, *logID); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			glog.Exitf("Failed to get witness checkpoint: %v", err)
+		}
+	} else {
+		n, err := note.Open(wcpRaw, note.VerifierList(w.Verifier))
+		if err != nil {
+			glog.Exitf("Failed to open CP: %v", err)
+		}
+
+		_, err = wcp.Unmarshal([]byte(n.Text))
+		if err != nil {
+			glog.Exitf("Failed to unmarshal CP: %v", err)
+		}
+	}
+
+	feeder := feeder{
+		wcp: wcp,
+		sdb: sdb,
+		w:   w,
+	}
+
+	tik := time.NewTicker(*pollInterval)
+	for {
+		glog.V(2).Infof("Tick: start feedOnce (witness size %d)", feeder.wcp.Size)
+		if err := feeder.feedOnce(ctx); err != nil {
+			glog.Exitf("Failed to feed: %v", err)
+		}
+		glog.V(2).Infof("Tick: feedOnce complete (witness size %d)", feeder.wcp.Size)
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-tik.C:
+		}
+	}
+}
+
+// feeder encapsulates the main logic and state of the feeder.
+// The residual logic outside of this should simply be initialization and
+// orchestration with a timer.
+// Note that feeder maintains its own state that represents the witness state.
+// This is optimized for the case where this is the only feeder for this log to
+// the witness. If the witness state is updated outwith this feeder, then the
+// number of successful updates from this feeder will drop. On the other hand,
+// if this is the only feeder then it avoids making requests to get the latest
+// checkpoint from the witness when it isn't changing.
+type feeder struct {
+	wcp *log.Checkpoint
+	sdb *audit.SumDBClient
+	w   http.Witness
+}
+
+// feedOnce gets the latest checkpoint from the SumDB server, and if this is more
+// recent than the witness state then it will construct a compact range proof by
+// requesting the minimal set of tiles, and then update the witness with the new
+// checkpoint. Finally, it will update the feeder's view of the witness state.
+func (f *feeder) feedOnce(ctx context.Context) error {
+	sdbcp, err := f.sdb.LatestCheckpoint()
+	if err != nil {
+		return fmt.Errorf("failed to get latest checkpoint: %v", err)
+	}
+	if int64(f.wcp.Size) >= sdbcp.N {
+		glog.V(1).Infof("Witness size %d >= SumDB size %d - nothing to do", f.wcp.Size, sdbcp.N)
+		return nil
+	}
+
+	glog.Infof("Updating witness from size %d to %d", f.wcp.Size, sdbcp.N)
+
+	broker := newTileBroker(sdbcp.N, f.sdb.TileHashes)
+
+	required := compact.RangeNodes(f.wcp.Size, uint64(sdbcp.N))
+	proof := make([][]byte, 0, len(required))
+	for _, n := range required {
+		i, r := convertToSumDBTiles(n)
+		t, err := broker.tile(i)
+		if err != nil {
+			return fmt.Errorf("failed to lookup %s: %v", i, err)
+		}
+		h := t.hash(r)
+		proof = append(proof, h)
+	}
+
+	wcpRaw, err := f.w.Update(ctx, *logID, sdbcp.Raw, proof)
+
+	if err != nil && !errors.Is(err, http.ErrCheckpointTooOld) {
+		return fmt.Errorf("failed to update checkpoint: %v", err)
+	}
+
+	// An optimization would be to immediately retry the Update if we get
+	// http.ErrCheckpointTooOld. For now, we'll update the local state and
+	// retry only the next time this method is called.
+
+	n, err := note.Open(wcpRaw, note.VerifierList(f.w.Verifier))
+	if err != nil {
+		return fmt.Errorf("failed to open CP: %v", err)
+	}
+	_, err = f.wcp.Unmarshal([]byte(n.Text))
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal CP: %v", err)
+	}
+	return nil
+}
+
+// convertToSumDBTiles takes a NodeID pointing to a node within the overall log,
+// and returns the tile coordinate that it will be found in, along with the nodeID
+// that references the node within that tile.
+func convertToSumDBTiles(n compact.NodeID) (tileIndex, compact.NodeID) {
+	sdbLevel := n.Level / tileHeight
+	rLevel := uint(n.Level % tileHeight)
+
+	// The last leaf that n commits to.
+	lastLeaf := (1<<n.Level)*(n.Index+1) - 1
+	// How many proper leaves are committed to by a tile at sdbLevel.
+	tileLeaves := 1 << ((1 + sdbLevel) * tileHeight)
+
+	sdbOffset := lastLeaf / uint64(tileLeaves)
+	rLeaves := lastLeaf % uint64(tileLeaves)
+	rIndex := rLeaves / (1 << n.Level)
+
+	return tileIndex{
+		level:  int(sdbLevel),
+		offset: int(sdbOffset),
+	}, compact.NewNodeID(rLevel, rIndex)
+}
+
+// tileIndex is the location of a tile.
+// We could have used compact.NodeID, but that would overload its meaning;
+// with this usage tileIndex points to a tile, and NodeID points to a node.
+type tileIndex struct {
+	level, offset int
+}
+
+func (i tileIndex) String() string {
+	return fmt.Sprintf("T(%d,%d)", i.level, i.offset)
+}
+
+type tile struct {
+	leaves [][]byte
+}
+
+func newTile(hs []tlog.Hash) tile {
+	leaves := make([][]byte, len(hs))
+	for i, h := range hs {
+		h := h
+		leaves[i] = h[:]
+	}
+	return tile{
+		leaves: leaves,
+	}
+}
+
+// hash returns the hash of the subtree within this tile identified by n.
+// Note that the coordinate system starts with the bottom left of the tile
+// being (0,0), no matter where this tile appears within the overall log.
+func (t tile) hash(n compact.NodeID) []byte {
+	r := rf.NewEmptyRange(0)
+
+	left := n.Index << uint64(n.Level)
+	right := (n.Index + 1) << uint64(n.Level)
+
+	if len(t.leaves) < int(right) {
+		panic(fmt.Sprintf("index %d out of range of %d leaves", right, len(t.leaves)))
+	}
+	for _, l := range t.leaves[left:right] {
+		r.Append(l[:], nil)
+	}
+	root, err := r.GetRootHash(nil)
+	if err != nil {
+		panic(err)
+	}
+	return root
+}
+
+// tileBroker takes requests for tiles and returns the appropriate tile for the tree size.
+// This will cache results for the lifetime of the broker, and it will ensure that requests
+// for incomplete tiles are requested as partial tiles.
+type tileBroker struct {
+	pts    map[tileIndex]int
+	ts     map[tileIndex]tile
+	lookup func(level, offset, partial int) ([]tlog.Hash, error)
+}
+
+func newTileBroker(size int64, lookup func(level, offset, partial int) ([]tlog.Hash, error)) tileBroker {
+	pts := make(map[tileIndex]int)
+	l := 0
+	t := size / leavesPerTile
+	o := size % leavesPerTile
+	for {
+		i := tileIndex{l, int(t)}
+		pts[i] = int(o)
+		if t == 0 {
+			break
+		}
+		o = t % leavesPerTile
+		t = t / leavesPerTile
+		l++
+	}
+	return tileBroker{
+		pts:    pts,
+		ts:     make(map[tileIndex]tile),
+		lookup: lookup,
+	}
+}
+
+func (tb *tileBroker) tile(i tileIndex) (tile, error) {
+	if t, ok := tb.ts[i]; ok {
+		return t, nil
+	}
+	partial := tb.pts[i]
+	glog.V(2).Infof("Looking up %s (partial=%d) from remote", i, partial)
+	hs, err := tb.lookup(i.level, i.offset, partial)
+	if err != nil {
+		return tile{}, fmt.Errorf("lookup failed: %v", err)
+	}
+	t := newTile(hs)
+	tb.ts[i] = t
+	return t, nil
+}
+
+func mustCreateVerifier(pub string) note.Verifier {
+	v, err := note.NewVerifier(pub)
+	if err != nil {
+		glog.Exitf("Failed to create signature verifier from %q: %v", pub, err)
+	}
+	return v
+}

--- a/sumdbaudit/witness/cmd/feeder/main.go
+++ b/sumdbaudit/witness/cmd/feeder/main.go
@@ -109,7 +109,7 @@ func main() {
 // orchestration with a timer.
 // Note that feeder maintains its own state that represents the witness state.
 // This is optimized for the case where this is the only feeder for this log to
-// the witness. If the witness state is updated outwith this feeder, then the
+// the witness. If the witness state is updated by another entity, then the
 // number of successful updates from this feeder will drop. On the other hand,
 // if this is the only feeder then it avoids making requests to get the latest
 // checkpoint from the witness when it isn't changing.

--- a/sumdbaudit/witness/cmd/feeder/main_test.go
+++ b/sumdbaudit/witness/cmd/feeder/main_test.go
@@ -1,0 +1,201 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/google/trillian/merkle/compact"
+	"golang.org/x/mod/sumdb/tlog"
+)
+
+func TestConvertToSumDBTiles(t *testing.T) {
+	for _, test := range []struct {
+		n     compact.NodeID
+		wantT tileIndex
+		wantN compact.NodeID
+	}{
+		{
+			n:     compact.NewNodeID(0, 0),
+			wantT: tileIndex{0, 0},
+			wantN: compact.NewNodeID(0, 0),
+		},
+		{
+			n:     compact.NewNodeID(0, 255),
+			wantT: tileIndex{0, 0},
+			wantN: compact.NewNodeID(0, 255),
+		},
+		{
+			n:     compact.NewNodeID(0, 256),
+			wantT: tileIndex{0, 1},
+			wantN: compact.NewNodeID(0, 0),
+		},
+		{
+			n:     compact.NewNodeID(1, 127),
+			wantT: tileIndex{0, 0},
+			wantN: compact.NewNodeID(1, 127),
+		},
+		{
+			n:     compact.NewNodeID(1, 128),
+			wantT: tileIndex{0, 1},
+			wantN: compact.NewNodeID(1, 0),
+		},
+		{
+			n:     compact.NewNodeID(8, 0),
+			wantT: tileIndex{1, 0},
+			wantN: compact.NewNodeID(0, 0),
+		},
+		{
+			n:     compact.NewNodeID(8, 1),
+			wantT: tileIndex{1, 0},
+			wantN: compact.NewNodeID(0, 1),
+		},
+		{
+			n:     compact.NewNodeID(22, 0),
+			wantT: tileIndex{2, 0},
+			wantN: compact.NewNodeID(6, 0),
+		},
+		{
+			n:     compact.NewNodeID(8, 24338),
+			wantT: tileIndex{1, 95},
+			wantN: compact.NewNodeID(0, 18),
+		},
+	} {
+		t.Run(string(fmt.Sprintf("(%d,%d)", test.n.Level, test.n.Index)), func(t *testing.T) {
+			gotT, gotN := convertToSumDBTiles(test.n)
+			if gotT != test.wantT {
+				t.Errorf("got %d, want %d", gotT, test.wantT)
+			}
+			if gotN != test.wantN {
+				t.Errorf("got %d, want %d", gotN, test.wantN)
+			}
+		})
+	}
+}
+
+func TestTileBroker(t *testing.T) {
+	for _, test := range []struct {
+		desc       string
+		size       int64
+		i          tileIndex
+		wantLeaves int
+	}{
+		{
+			desc:       "big tree complete tile",
+			size:       12345678,
+			i:          tileIndex{0, 0},
+			wantLeaves: 256,
+		},
+		{
+			desc:       "small tree partial tile",
+			size:       3,
+			i:          tileIndex{0, 0},
+			wantLeaves: 3,
+		},
+		{
+			desc:       "medium tree partial leaf tile",
+			size:       257,
+			i:          tileIndex{0, 1},
+			wantLeaves: 1,
+		},
+		{
+			desc:       "medium tree partial tile in upper row",
+			size:       257,
+			i:          tileIndex{1, 0},
+			wantLeaves: 1,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			var lookupTimes int
+			lookup := func(level, offset, partial int) ([]tlog.Hash, error) {
+				n := partial
+				if n == 0 {
+					n = 256
+				}
+				r := make([]tlog.Hash, n)
+				for i := 0; i < n; i++ {
+					r[i] = tlog.RecordHash([]byte(fmt.Sprintf("%d %d: %d", level, offset, i)))
+				}
+				lookupTimes++
+				return r, nil
+			}
+			broker := newTileBroker(test.size, lookup)
+
+			tile, err := broker.tile(test.i)
+			if err != nil {
+				t.Fatalf("failed to get tile: %v", err)
+			}
+			if got, want := len(tile.leaves), test.wantLeaves; got != want {
+				t.Errorf("got %d leaves, wanted %d", got, want)
+			}
+			broker.tile(test.i)
+			if lookupTimes != 1 {
+				t.Errorf("broker cache not working")
+			}
+		})
+	}
+}
+
+func TestTile(t *testing.T) {
+	for _, test := range []struct {
+		desc     string
+		size     int
+		nodeID   compact.NodeID
+		wantHash []byte
+	}{
+		{
+			desc:     "first leaf",
+			size:     8,
+			nodeID:   compact.NewNodeID(0, 0),
+			wantHash: mustDecodeHex("1bb97dcc21635d47e2663efdfd0a174686d98dd701352dd2cd06e8b43fd3d305"),
+		},
+		{
+			desc:     "last leaf",
+			size:     8,
+			nodeID:   compact.NewNodeID(0, 7),
+			wantHash: mustDecodeHex("4b4711d056b2278392c231fd41858adea8ca893ad0c7048f57da2682002845fe"),
+		},
+		{
+			desc:     "interior node",
+			size:     8,
+			nodeID:   compact.NewNodeID(0, 3),
+			wantHash: mustDecodeHex("58bd1496e1684aac9201c2e687ee7ae4f51c96a8b0d81ef3583628b93d3cd345"),
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			ls := make([]tlog.Hash, test.size)
+			for i := 0; i < test.size; i++ {
+				ls[i] = tlog.RecordHash([]byte(fmt.Sprintf("leaf %d", i)))
+			}
+			tile := newTile(ls)
+
+			hash := tile.hash(test.nodeID)
+			if !bytes.Equal(hash, test.wantHash) {
+				t.Errorf("mismatched hash: wanted %x got %x", test.wantHash, hash)
+			}
+		})
+	}
+}
+
+func mustDecodeHex(h string) []byte {
+	r, err := hex.DecodeString(h)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}

--- a/sumdbaudit/witness/docker-compose.yaml
+++ b/sumdbaudit/witness/docker-compose.yaml
@@ -1,0 +1,39 @@
+version: '3.2'
+services:
+  witness:
+    build:
+      context: ../..
+      dockerfile: ./witness/golang/cmd/witness/Dockerfile
+    volumes:
+        - type: volume
+          source: data
+          target: /data
+          volume:
+            nocopy: true
+        - type: bind
+          source: ${WITNESS_CONFIG_DIR:-/etc/witness/config}
+          target: /witness-config
+          read_only: true
+    command:
+      - "--listen=:8100"
+      - "--db_file=/data/witness.sqlite"
+      - "--private_key=${WITNESS_PRIVATE_KEY}"
+      - "--config_file=/witness-config/${WITNESS_CONFIG_FILE:-witness.config}"
+      - "--logtostderr"
+    restart: always
+    ports:
+      - "8100:8100"
+  feeder:
+    depends_on:
+      - witness
+    build:
+      context: ../..
+      dockerfile: ./sumdbaudit/witness/cmd/feeder/Dockerfile
+    command:
+      - "--w=http://witness:8100"
+      - "--wk=${WITNESS_PUBLIC_KEY}"
+      - "--lid=sumdb"
+      - "--alsologtostderr"
+      - "--v=1"
+volumes:
+  data:

--- a/sumdbaudit/witness/witness.config
+++ b/sumdbaudit/witness/witness.config
@@ -1,0 +1,10 @@
+{
+    "logs": [
+        {
+            "hashStrategy": "default",
+            "logID": "sumdb",
+            "pubKey": "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8",
+            "useCompact": true
+        }
+    ]
+}


### PR DESCRIPTION
This constructs compact ranges from the SumDB API and feeds these to the witness.

Setting this up with docker is fairly simple and is documented in the README.