### PR TITLE
A note parser and verifier for checkpoints 

### DIFF
--- a/formats/log/note.go
+++ b/formats/log/note.go
@@ -15,70 +15,43 @@
 package log
 
 import (
+	"errors"
 	"fmt"
 
 	"golang.org/x/mod/sumdb/note"
 )
 
-// CheckpointParser is responsible for parsing checkpoints for a specific log.
-// Any valid note must have been signed by all verifiers known by this parser.
-type CheckpointParser struct {
-	logVerifier       note.Verifier
-	logID             string
-	otherVerifiers    note.Verifiers
-	requiredOtherSigs int
-}
+// ParseCheckpoint takes a raw checkpoint as bytes and returns a parsed checkpoint
+// providing that a valid log signature is found, the checkpoint unmarshals
+// correctly, and the log origin is that expected. In all other cases, an empty
+// checkpoint is returned. The underlying note is always returned where possible.
+// The signatures on the note will include the log signature if no error is returned,
+// plus any signatures from otherVerifiers that were found.
+func ParseCheckpoint(origin string, logVerifier note.Verifier, otherVerifiers []note.Verifier, chkpt []byte) (Checkpoint, *note.Note, error) {
+	vs := make([]note.Verifier, len(otherVerifiers)+1)
+	vs[0] = logVerifier
+	if n := copy(vs[1:], otherVerifiers); n < len(otherVerifiers) {
+		return Checkpoint{}, nil, errors.New("failed to create verifier list")
+	}
+	verifiers := note.VerifierList(vs...)
 
-// NewCheckpointParser creates a parser for checkpoints that must be signed by the log
-// which is verified by logVKey, and *all* of the other verifiers under otherVerifiers.
-func NewCheckpointParser(logVKey string, logID string, otherVerifiers ...string) (CheckpointParser, error) {
-	logVerifier, err := note.NewVerifier(string(logVKey))
+	n, err := note.Open(chkpt, verifiers)
 	if err != nil {
-		return CheckpointParser{}, fmt.Errorf("NewVerifier(%s): %v", logVKey, err)
+		return Checkpoint{}, n, fmt.Errorf("failed to verify signatures on checkpoint: %v", err)
 	}
 
-	ovs := make([]note.Verifier, len(otherVerifiers))
-	for i, k := range otherVerifiers {
-		ovs[i], err = note.NewVerifier(k)
-		if err != nil {
-			return CheckpointParser{}, fmt.Errorf("NewVerifier(%s): %v", k, err)
+	for _, s := range n.Sigs {
+		if s.Hash == logVerifier.KeyHash() && s.Name == logVerifier.Name() {
+			// The log has signed this checkpoint. It is now safe to parse.
+			cp := &Checkpoint{}
+			if _, err := cp.Unmarshal([]byte(n.Text)); err != nil {
+				return Checkpoint{}, n, fmt.Errorf("failed to unmarshal checkpoint: %v", err)
+			}
+			if cp.Origin != origin {
+				return Checkpoint{}, n, fmt.Errorf("got Origin %q but expected %q", cp.Origin, origin)
+			}
+			return *cp, n, nil
 		}
 	}
-	return CheckpointParser{
-		logVerifier:       logVerifier,
-		logID:             logID,
-		otherVerifiers:    note.VerifierList(ovs...),
-		requiredOtherSigs: len(otherVerifiers),
-	}, nil
-}
-
-// Parse returns a checkpoint parsed from the raw note, and any error if the note could
-// not be parsed, or any of the required signatures were missing.
-func (p CheckpointParser) Parse(chkptRaw []byte) (Checkpoint, *note.Note, error) {
-	r := &Checkpoint{}
-	n, err := note.Open(chkptRaw, note.VerifierList(p.logVerifier))
-	if err != nil {
-		return *r, n, fmt.Errorf("failed to verify log signature on checkpoint: %v", err)
-	}
-	if _, err := r.Unmarshal([]byte(n.Text)); err != nil {
-		return *r, n, fmt.Errorf("failed to unmarshal new checkpoint: %v", err)
-	}
-	// TODO(mhutchinson): This assumes the first line is the LogID.
-	// This is proposal 2B. If we put the LogID further in the message (e.g. 4th line; 1A)
-	// then this should be updated.
-	if r.Ecosystem != p.logID {
-		return *r, n, fmt.Errorf("got logID %q but expected %q", r.Ecosystem, p.logID)
-	}
-
-	if p.requiredOtherSigs == 0 {
-		return *r, n, nil
-	}
-
-	if n, err = note.Open(chkptRaw, p.otherVerifiers); err != nil {
-		return *r, n, fmt.Errorf("failed to verify required signatures on checkpoint: %v", err)
-	}
-	if len(n.Sigs) != p.requiredOtherSigs {
-		return *r, n, fmt.Errorf("required %d non-log signatures but got %d", p.requiredOtherSigs, len(n.Sigs))
-	}
-	return *r, n, nil
+	return Checkpoint{}, n, fmt.Errorf("no log signature found on note")
 }

--- a/formats/log/note.go
+++ b/formats/log/note.go
@@ -1,0 +1,82 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+
+	"golang.org/x/mod/sumdb/note"
+)
+
+// CheckpointParser is responsible for parsing checkpoints for a specific log.
+// Any valid note must have been signed by all verifiers known by this parser.
+type CheckpointParser struct {
+	logVerifier       note.Verifier
+	logID             string
+	otherVerifiers    note.Verifiers
+	requiredOtherSigs int
+}
+
+// NewCheckpointParser creates a parser for checkpoints that must be signed by the log
+// which is verified by logVKey, and *all* of the other verifiers under otherVerifiers.
+func NewCheckpointParser(logVKey string, otherVerifiers ...string) (CheckpointParser, error) {
+	logVerifier, err := note.NewVerifier(string(logVKey))
+	if err != nil {
+		return CheckpointParser{}, fmt.Errorf("NewVerifier(%s): %v", logVKey, err)
+	}
+	logVKHash := sha256.Sum256([]byte(logVKey))
+
+	ovs := make([]note.Verifier, len(otherVerifiers))
+	for i, k := range otherVerifiers {
+		ovs[i], err = note.NewVerifier(k)
+		if err != nil {
+			return CheckpointParser{}, fmt.Errorf("NewVerifier(%s): %v", k, err)
+		}
+	}
+	return CheckpointParser{
+		logVerifier:       logVerifier,
+		logID:             base64.StdEncoding.EncodeToString(logVKHash[:]),
+		otherVerifiers:    note.VerifierList(ovs...),
+		requiredOtherSigs: len(otherVerifiers),
+	}, nil
+}
+
+// Parse returns a checkpoint parsed from the raw note, and any error if the note could
+// not be parsed, or any of the required signatures were missing.
+func (p CheckpointParser) Parse(chkptRaw []byte) (Checkpoint, error) {
+	r := &Checkpoint{}
+	n, err := note.Open(chkptRaw, note.VerifierList(p.logVerifier))
+	if err != nil {
+		return *r, fmt.Errorf("failed to verify log signature on checkpoint: %v", err)
+	}
+	if _, err := r.Unmarshal([]byte(n.Text)); err != nil {
+		return *r, fmt.Errorf("failed to unmarshal new checkpoint: %v", err)
+	}
+	// TODO(mhutchinson): This is where we'd check the message contains p.logID
+
+	if p.requiredOtherSigs == 0 {
+		return *r, nil
+	}
+
+	if n, err = note.Open(chkptRaw, p.otherVerifiers); err != nil {
+		return *r, fmt.Errorf("failed to verify required signatures on checkpoint: %v", err)
+	}
+	if len(n.Sigs) != p.requiredOtherSigs {
+		return *r, fmt.Errorf("required %d non-log signatures but got %d", p.requiredOtherSigs, len(n.Sigs))
+	}
+	return *r, nil
+}

--- a/formats/log/note_test.go
+++ b/formats/log/note_test.go
@@ -230,8 +230,15 @@ mb8QLQIs0Z0yP5Cstq6guj87oXWeC9gEM8oVikmm9Wk=
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			cp, _, err := log.ParseCheckpoint(test.logID, logVerifier, []note.Verifier{}, []byte(noteString))
-			if err != nil && !test.wantErr {
-				t.Fatalf("Failed to parse checkpoint note: %v", err)
+			if err != nil {
+				if !test.wantErr {
+					t.Fatalf("Failed to parse checkpoint note: %v", err)
+				}
+				if cp.Size > 0 {
+					t.Errorf("Expected empty checkpoint because of error but got %+v", cp)
+				}
+				// Always return after error because remaining checks are for cp, which is empty.
+				return
 			}
 			if err == nil && test.wantErr {
 				t.Fatal("Expected error but didn't get it")

--- a/formats/log/note_test.go
+++ b/formats/log/note_test.go
@@ -163,7 +163,6 @@ mb8QLQIs0Z0yP5Cstq6guj87oXWeC9gEM8oVikmm9Wk=
 	for _, test := range []struct {
 		desc    string
 		logID   string
-		sigs    []note.Signer
 		wantErr bool
 	}{
 		{

--- a/formats/log/note_test.go
+++ b/formats/log/note_test.go
@@ -184,7 +184,7 @@ func TestParseCheckpoint(t *testing.T) {
 			}
 
 			// Now parse what we have created.
-			cp, n, err := log.ParseCheckpoint(test.logID, logVerifier, []note.Verifier{known1Verifier, known2Verifier}, nBs)
+			_, n, err := log.ParseCheckpoint(test.logID, logVerifier, []note.Verifier{known1Verifier, known2Verifier}, nBs)
 			if gotErr := err != nil; gotErr != test.wantErr {
 				t.Errorf("gotErr %t != wantErr %t (%v)", gotErr, test.wantErr, err)
 			}
@@ -195,7 +195,6 @@ func TestParseCheckpoint(t *testing.T) {
 			if gotSigs != test.wantSigs {
 				t.Errorf("got %d signatures but wanted %d", gotSigs, test.wantSigs)
 			}
-			_ = cp
 		})
 	}
 }
@@ -234,13 +233,13 @@ mb8QLQIs0Z0yP5Cstq6guj87oXWeC9gEM8oVikmm9Wk=
 				if !test.wantErr {
 					t.Fatalf("Failed to parse checkpoint note: %v", err)
 				}
-				if cp.Size > 0 {
+				if cp != nil {
 					t.Errorf("Expected empty checkpoint because of error but got %+v", cp)
 				}
-				// Always return after error because remaining checks are for cp, which is empty.
+				// Always return after error because remaining checks are for cp, which is nil.
 				return
 			}
-			if err == nil && test.wantErr {
+			if test.wantErr {
 				t.Fatal("Expected error but didn't get it")
 			}
 			if got, want := cp.Size, uint64(6476701); got != want {

--- a/formats/log/note_test.go
+++ b/formats/log/note_test.go
@@ -143,7 +143,7 @@ func TestParseCheckpoint(t *testing.T) {
 			}
 
 			// Now parse what we have created.
-			cp, err := parser.Parse(n)
+			cp, _, err := parser.Parse(n)
 			if gotErr := err != nil; gotErr != test.wantErr {
 				t.Fatalf("gotErr %t != wantErr %t (%v)", gotErr, test.wantErr, err)
 			}
@@ -185,7 +185,7 @@ mb8QLQIs0Z0yP5Cstq6guj87oXWeC9gEM8oVikmm9Wk=
 			if err != nil {
 				t.Fatalf("Failed to create parser: %v", err)
 			}
-			cp, err := parser.Parse([]byte(noteString))
+			cp, _, err := parser.Parse([]byte(noteString))
 			if err != nil && !test.wantErr {
 				t.Fatalf("Failed to parse checkpoint note: %v", err)
 			}

--- a/formats/log/note_test.go
+++ b/formats/log/note_test.go
@@ -1,0 +1,137 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log_test
+
+import (
+	"testing"
+
+	"github.com/google/trillian-examples/formats/log"
+	"golang.org/x/mod/sumdb/note"
+)
+
+var (
+	logVK = "Log+2271c621+AemuH5ooBpEPcr+W8onrjA1NfuzBVHdezakU81Ekarvs"
+	logSK = "PRIVATE+KEY+Log+2271c621+AdEIq9FLRQni54Wg68T96VJO+iayOaulswav2DUMKgvQ"
+
+	known1VK = "Known+451c786d+AXAQ0T7lbwuY4ABJ9/MYY9bWV3hmSyOGVt2x42NkmdUH"
+	known1SK = "PRIVATE+KEY+Known+451c786d+AQPRoE2+Z+Ed1HaHBA9F/FfracvcZ2rDU39kCecMEoci"
+
+	known2VK = "KnownAgain+4893b26c+AQ+LR7BFF/F/dkpIBjBpSvT0crkteizuUkavAoGeaYMj"
+	known2SK = "PRIVATE+KEY+KnownAgain+4893b26c+ARhZda/l25zjGZswYLDZsLNRzNpmv5wYTN9IoTr1OJ2+"
+
+	unknownVK = "Unknown+fdbb2e08+AWgRIYZ+8x1Vl+1Q+sR8zciNHiYI1SdlBjNw+RV0rots"
+	unknownSK = "PRIVATE+KEY+Unknown+fdbb2e08+Aav2knTC6orbhXX8pMWuNiWgO+Wwk2DB+h1eU2Q1W1nU"
+
+	_ = unknownVK
+)
+
+func TestParseCheckpoint(t *testing.T) {
+	cp := log.Checkpoint{
+		Ecosystem: "TestParseCheckpoint",
+		Size:      42,
+		Hash:      []byte("abcdef"),
+	}
+	noteBody := cp.Marshal()
+
+	lns, err := note.NewSigner(logSK)
+	if err != nil {
+		t.Fatalf("couldn't create log signer: %v", err)
+	}
+	k1ns, err := note.NewSigner(known1SK)
+	if err != nil {
+		t.Fatalf("couldn't create known signer: %v", err)
+	}
+	k2ns, err := note.NewSigner(known2SK)
+	if err != nil {
+		t.Fatalf("couldn't create known signer: %v", err)
+	}
+	uns, err := note.NewSigner(unknownSK)
+	if err != nil {
+		t.Fatalf("couldn't create unknown signer: %v", err)
+	}
+
+	for _, test := range []struct {
+		desc    string
+		sigs    []note.Signer
+		wantErr bool
+	}{
+		{
+			desc:    "no sigs",
+			sigs:    []note.Signer{},
+			wantErr: true,
+		},
+		{
+			desc:    "just log sig",
+			sigs:    []note.Signer{lns},
+			wantErr: true,
+		},
+		{
+			desc:    "log and known1 sig",
+			sigs:    []note.Signer{lns, k1ns},
+			wantErr: true,
+		},
+		{
+			desc:    "log and known2 sig",
+			sigs:    []note.Signer{lns, k1ns},
+			wantErr: true,
+		},
+		{
+			desc:    "log, known1, and unknown sig",
+			sigs:    []note.Signer{lns, k1ns, uns},
+			wantErr: true,
+		},
+		{
+			desc:    "just required sigs",
+			sigs:    []note.Signer{lns, k1ns, k2ns},
+			wantErr: false,
+		},
+		{
+			desc:    "one verifier signs twice",
+			sigs:    []note.Signer{lns, k1ns, k1ns},
+			wantErr: true,
+		},
+		{
+			desc:    "just required sigs in mixed order",
+			sigs:    []note.Signer{k2ns, lns, k1ns},
+			wantErr: false,
+		}, {
+			desc:    "all sigs",
+			sigs:    []note.Signer{lns, k1ns, k2ns, uns},
+			wantErr: false,
+		}, {
+			desc:    "just known",
+			sigs:    []note.Signer{k1ns, k2ns},
+			wantErr: true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			parser, err := log.NewCheckpointParser(logVK, known1VK, known2VK)
+			if err != nil {
+				t.Fatalf("NewCheckpointParser: %v", err)
+			}
+			n, err := note.Sign(&note.Note{Text: string(noteBody)}, test.sigs...)
+			if err != nil {
+				t.Fatalf("Failed to sign note: %v", err)
+			}
+
+			// Now parse what we have created.
+			cp, err := parser.Parse(n)
+			if gotErr := err != nil; gotErr != test.wantErr {
+				t.Fatalf("gotErr %t != wantErr %t (%v)", gotErr, test.wantErr, err)
+			}
+			_ = cp
+		})
+	}
+}


### PR DESCRIPTION
This handles parsing the note, and verifying that the log has signed it. Optionally, other required verifiers can be specified. If these are provided, then all of the signatures from these verifiers must be present.

This also checks the first line of the message is the LogID that was set to be expected when the parser was constructed. This part isn't decided (other proposals exist for where the LogID should live) but I've added this check here as a strawman.