### PR TITLE
Speed up serverless tests

### DIFF
--- a/serverless/integration/integration_test.go
+++ b/serverless/integration/integration_test.go
@@ -120,6 +120,8 @@ func RunIntegration(t *testing.T, s log.Storage, f client.Fetcher, lh *rfc6962.H
 }
 
 func TestServerlessViaFile(t *testing.T) {
+	t.Parallel()
+
 	h := rfc6962.DefaultHasher
 
 	// Create log instance
@@ -149,6 +151,8 @@ func TestServerlessViaFile(t *testing.T) {
 }
 
 func TestServerlessViaHTTP(t *testing.T) {
+	t.Parallel()
+
 	h := rfc6962.DefaultHasher
 
 	// Create log instance


### PR DESCRIPTION
Running the integration tests in parallel saves a good minute on the total test time for `go test ./...`.

The change to the marshal test to only check roundtripping for a few interesting tile sizes drops the test time from 8+s to under 1s.