### PR TITLE
Speed up CloudBuild runs

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -60,27 +60,27 @@ steps:
   args: ['go', 'get', 'github.com/golang/protobuf/protoc-gen-go']
   waitFor: ['prepare']
 
-# Run the presubmit tests
+# Run the presubmit build, generate, and test with coverage enabled.
 - name: gcr.io/$PROJECT_ID/testbase
   entrypoint: 'bash'
-  id: 'presubmit'
+  id: 'presubmit-build-and-test-with-coverage'
   args:
     - '-exc'
     - |
-      ./scripts/presubmit.sh
+      ./scripts/presubmit.sh --coverage --no-linters --no-actions --no-docker --no-serverless-wasm
       # Check re-generation didn't change anything.
       echo "Checking that generated files are the same as checked-in versions."
       git diff --  --exit-code
   waitFor: ['go-get-proto', 'go-get-proto-gen']
 
-# Run the presubmit tests with coverage enabled in parallel
+# Run the presubmit linters
 - name: gcr.io/$PROJECT_ID/testbase
   entrypoint: 'bash'
-  id: 'presubmit-with-coverage'
+  id: 'presubmit-lint'
   args:
     - '-exc'
     - |
-      ./scripts/presubmit.sh --coverage
+      ./scripts/presubmit.sh --no-build --no-generate --no-actions --no-docker --no-serverless-wasm
   waitFor: ['go-get-proto', 'go-get-proto-gen']
 
 # Build serverless actions
@@ -90,7 +90,7 @@ steps:
   args:
     - '-exc'
     - |
-      ./scripts/presubmit.sh --no-build --no-generate --no-docker --no-serverless-wasm
+      ./scripts/presubmit.sh --no-build --no-linters --no-generate --no-docker --no-serverless-wasm
   waitFor: ['go-get-proto', 'go-get-proto-gen']
 
 # Build serverless wasm
@@ -100,7 +100,7 @@ steps:
   args:
     - '-exc'
     - |
-      ./scripts/presubmit.sh --no-build --no-generate --no-docker --no-actions
+      ./scripts/presubmit.sh --no-build --no-linters --no-generate --no-docker --no-actions
   waitFor: ['go-get-proto', 'go-get-proto-gen']
 
 # Build docker images
@@ -110,7 +110,7 @@ steps:
   args:
     - '-exc'
     - |
-      ./scripts/presubmit.sh --no-build --no-generate --no-actions --no-serverless-wasm
+      ./scripts/presubmit.sh --no-build --no-linters --no-generate --no-actions --no-serverless-wasm
   waitFor: ['go-get-proto', 'go-get-proto-gen']
 
 # Test the USB Armory code as best we can
@@ -154,7 +154,7 @@ steps:
   - 'VCS_PULL_REQUEST=$_PR_NUMBER'
   - 'CI_BUILD_ID=$BUILD_ID'
   - 'CODECOV_TOKEN=$_CODECOV_TOKEN' # _CODECOV_TOKEN is specified in the cloud build trigger
-  waitFor: ['presubmit-with-coverage', 'firmware-integration-test']
+  waitFor: ['presubmit-build-and-test-with-coverage', 'firmware-integration-test']
 
 images:
   - 'gcr.io/$PROJECT_ID/testbase:latest'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -83,6 +83,36 @@ steps:
       ./scripts/presubmit.sh --coverage
   waitFor: ['go-get-proto', 'go-get-proto-gen']
 
+# Build serverless actions
+- name: gcr.io/$PROJECT_ID/testbase
+  entrypoint: 'bash'
+  id: 'presubmit-build-actions'
+  args:
+    - '-exc'
+    - |
+      ./scripts/presubmit.sh --no-build --no-generate --no-docker --no-serverless-wasm
+  waitFor: ['go-get-proto', 'go-get-proto-gen']
+
+# Build serverless wasm
+- name: gcr.io/$PROJECT_ID/testbase
+  entrypoint: 'bash'
+  id: 'presubmit-build-serverless-wasm'
+  args:
+    - '-exc'
+    - |
+      ./scripts/presubmit.sh --no-build --no-generate --no-docker --no-actions
+  waitFor: ['go-get-proto', 'go-get-proto-gen']
+
+# Build docker images
+- name: gcr.io/$PROJECT_ID/testbase
+  entrypoint: 'bash'
+  id: 'presubmit-build-docker'
+  args:
+    - '-exc'
+    - |
+      ./scripts/presubmit.sh --no-build --no-generate --no-actions --no-serverless-wasm
+  waitFor: ['go-get-proto', 'go-get-proto-gen']
+
 # Test the USB Armory code as best we can
 - name: gcr.io/$PROJECT_ID/testbase
   id: 'usbarmory'

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -102,10 +102,6 @@ main() {
     go build ./...
 
     echo 'running go test'
-    # Install test deps so that individual test runs below can reuse them.
-    echo 'installing test deps'
-    go test -i ./...
-
     if [[ ${coverage} -eq 1 ]]; then
         local coverflags="-covermode=atomic -coverprofile=coverage.txt"
 


### PR DESCRIPTION
- Adds some more parallel steps in the CloudBuild config for building docker images, action images, wasm, running linters, etc.
- Removes obsolete `go test -i` flag

Last couple of CB runs with these changes are down to < 4m.