### PR TITLE
Move sumdb client into separate package

### DIFF
--- a/sumdbaudit/cli/clone/clone.go
+++ b/sumdbaudit/cli/clone/clone.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/glog"
 
 	"github.com/google/trillian-examples/sumdbaudit/audit"
+	"github.com/google/trillian-examples/sumdbaudit/client"
 )
 
 var (
@@ -48,7 +49,7 @@ func main() {
 		glog.Exitf("failed to init DB: %v", err)
 	}
 
-	sumDB := audit.NewSumDB(*height, *vkey)
+	sumDB := client.NewSumDB(*height, *vkey)
 	checkpoint, err := sumDB.LatestCheckpoint()
 	if err != nil {
 		glog.Exitf("failed to get latest checkpoint: %s", err)

--- a/sumdbaudit/cli/mirror/mirror.go
+++ b/sumdbaudit/cli/mirror/mirror.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/sumdbaudit/audit"
+	"github.com/google/trillian-examples/sumdbaudit/client"
 )
 
 var (
@@ -44,7 +45,7 @@ func main() {
 	if err != nil {
 		glog.Exitf("Failed to init DB: %v", err)
 	}
-	sumDB := audit.NewSumDB(*height, *vkey)
+	sumDB := client.NewSumDB(*height, *vkey)
 	s := audit.NewService(db, sumDB, *height)
 
 	for {

--- a/sumdbaudit/cli/witness/witness.go
+++ b/sumdbaudit/cli/witness/witness.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/sumdbaudit/audit"
+	"github.com/google/trillian-examples/sumdbaudit/client"
 	"github.com/gorilla/mux"
 )
 
@@ -91,7 +92,7 @@ func main() {
 		glog.Exitf("Failed to open DB: %v", err)
 	}
 
-	sumDB := audit.NewSumDB(*height, *vkey)
+	sumDB := client.NewSumDB(*height, *vkey)
 	auditor := audit.NewService(db, sumDB, *height)
 	server := &server{a: auditor}
 

--- a/sumdbaudit/client/sumdb.go
+++ b/sumdbaudit/client/sumdb.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package audit
+// client contains a basic client for the SumDB log.
+package client
 
 import (
 	"fmt"

--- a/sumdbaudit/client/sumdb_test.go
+++ b/sumdbaudit/client/sumdb_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package audit
+package client
 
 import (
 	"bytes"

--- a/sumdbaudit/witness/cmd/feeder/main.go
+++ b/sumdbaudit/witness/cmd/feeder/main.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/formats/log"
-	"github.com/google/trillian-examples/sumdbaudit/audit"
+	"github.com/google/trillian-examples/sumdbaudit/client"
 	"github.com/google/trillian-examples/witness/golang/client/http"
 	"github.com/google/trillian/merkle/compact"
 	"github.com/google/trillian/merkle/rfc6962"
@@ -54,7 +54,7 @@ const (
 func main() {
 	flag.Parse()
 	ctx := context.Background()
-	sdb := audit.NewSumDB(tileHeight, *vkey)
+	sdb := client.NewSumDB(tileHeight, *vkey)
 	var w http.Witness
 	if wURL, err := url.Parse(*witness); err != nil {
 		glog.Exitf("Failed to parse witness URL: %v", err)
@@ -115,7 +115,7 @@ func main() {
 // checkpoint from the witness when it isn't changing.
 type feeder struct {
 	wcp *log.Checkpoint
-	sdb *audit.SumDBClient
+	sdb *client.SumDBClient
 	w   http.Witness
 }
 


### PR DESCRIPTION
This is generally useful and should be usable without pulling in the Service or Database. More importantly, Database defines flags which conflict with the flags I'm trying to define and use in the sumdbclone tool based on the ctclone system.