### PR TITLE
SumDB clone tool that downloads the DB quickly 

### DIFF
--- a/clone/README.md
+++ b/clone/README.md
@@ -37,7 +37,7 @@ MariaDB [(none)]> FLUSH PRIVILEGES;
 ## Tuning
 
 The clone library logs information as it runs using `glog`.
-Providing `--alsologtostderr` is provided to any tool using the library, you should see output such as the following during the cloning process:
+Providing `--alsologtostderr` is passed to any tool using the library, you should see output such as the following during the cloning process:
 
 ```
 I0824 11:09:23.517796 2881011 clone.go:71] Fetching [4459168, 95054738): Remote leaves: 95054738. Local leaves: 4459168 (0 verified).
@@ -47,7 +47,7 @@ I0824 11:09:38.518542 2881011 clone.go:177] 1024.0 leaves/s, last leaf=4470430 (
 ```
 
 When tuning, it is recommended to also provide `--v=1` to see more verbose output.
-In particular, this will allow you to see if the tool is encountering errors (such as being told to back off) by the log server if you see lines such as `Retryable error getting data` in the output.
+In particular, this will allow you to see if the tool is encountering errors (such as being told to back off) by the log server, e.g. if you see lines such as `Retryable error getting data` in the output.
 
 Assuming you aren't being rate limited, then optimization goes as follows:
   1. Get the `working` percentage regularly around 100%: this measures how much time is being spent writing to the database. To do this, increase the number of `workers` to ensure that data is always available to the database writer

--- a/clone/README.md
+++ b/clone/README.md
@@ -1,15 +1,31 @@
 # Log Cloner
 
-A log client that copies a CT log to a local database for processing.
-The tool downloads batches of leaves in parallel, but always writes them to the local database in sequence.
-This ensures there are no missing ranges, which keeps state tracking easier.
+This directory contains a library, database, and tools for cloning transparency logs.
+The core library and database is log-agnostic, and each tool tailors this generic library to a specific log.
 
-One important implementation feature is that the download tools will exponentially back off if there are errors
-communicating with the log; this prevents the client from performing a DoS on any log it is downloading.
+The core library attempts to balance optimization of the following goals:
+  1. Downloading as quickly as possible
+  2. Backing off when requested by the log (i.e. not DoSing the log)
+  3. Simple local state / recovery
 
-## Setup
+This is achieved by:
+  1. Downloading batches of leaves in parallel
+  2. Using exponential backoff on transient failures
+  3. Writing leaves to the local database strictly in sequence
+     1. This ensures there are no missing ranges, which keeps state tracking easier
 
-In MariaDB, create a database and user:
+These tools are written to clone the log at a point in time.
+The first step is to download a checkpoint from the log, and then attempt to download all the leaves committed to by that checkpoint.
+Once all the leaves have been downloaded, the Merkle tree is computed for the downloaded leaves and compared against the checkpoint.
+If this verification succeeds, the checkpoint is persisted to a table in the database along with a compact range.
+The compact range allows further runs of the tool to quickly synthesize the Merkle structure of the existing leaves, which makes incremental verification much faster.
+
+This is designed such that downstream tooling can be written that reads from this local mirror of the log.
+Such tooling should only trust leaves that are committed to by a checkpoint; checkpoints are only written after verification, where leaves are written blindly and verified afterwards.
+
+## Database Setup
+
+In MariaDB, create a database and user. Below is an example of doing this for MariaDB 10.6, creating a database `google_xenon2022`, with a user `clonetool` with password `letmein`.
 
 ```
 MariaDB [(none)]> CREATE DATABASE google_xenon2022;
@@ -18,40 +34,32 @@ MariaDB [(none)]> GRANT ALL PRIVILEGES ON google_xenon2022.* TO 'clonetool'@loca
 MariaDB [(none)]> FLUSH PRIVILEGES;
 ```
 
-Now you can clone the log with:
+## Tuning
+
+The clone library logs information as it runs using `glog`.
+Providing `--alsologtostderr` is provided to any tool using the library, you should see output such as the following during the cloning process:
 
 ```
-go run ./clone/cmd/ctclone --alsologtostderr --v=1 --log_url https://ct.googleapis.com/logs/xenon2022/ --mysql_uri 'clonetool:letmein@tcp(localhost)/google_xenon2022'
+I0824 11:09:23.517796 2881011 clone.go:71] Fetching [4459168, 95054738): Remote leaves: 95054738. Local leaves: 4459168 (0 verified).
+I0824 11:09:28.519257 2881011 clone.go:177] 1202.8 leaves/s, last leaf=4459168 (remaining: 90595569, ETA: 20h55m21s), time working=24.2%
+I0824 11:09:33.518444 2881011 clone.go:177] 1049.6 leaves/s, last leaf=4465183 (remaining: 90589554, ETA: 23h58m29s), time working=23.0%
+I0824 11:09:38.518542 2881011 clone.go:177] 1024.0 leaves/s, last leaf=4470430 (remaining: 90584307, ETA: 24h34m21s), time working=23.3%
 ```
 
-See the optional flags in the `ctclone` tool to configure tuning parameters.
-## Docker
+When tuning, it is recommended to also provide `--v=1` to see more verbose output.
+In particular, this will allow you to see if the tool is encountering errors (such as being told to back off) by the log server if you see lines such as `Retryable error getting data` in the output.
 
-To build a docker image, run the following from the `trillian-examples` root directory:
+Assuming you aren't being rate limited, then optimization goes as follows:
+  1. Get the `working` percentage regularly around 100%: this measures how much time is being spent writing to the database. To do this, increase the number of `workers` to ensure that data is always available to the database writer
+  2. If `working %` is around 100, then increasing the DB write batch size will increase throughput, to a point
 
-```
-docker build . -t ctclone -f ./clone/cmd/ctclone/Dockerfile
-```
+This process is somewhat iterative to find what works for your setup.
+It depends on many variables such as log latency and rate limiting, the database, the machine running the clone tool, etc.
 
-This can be pointed at a local MySQL instance running outside of docker using:
+## Download Clients
 
-```
-docker run --name clone_xenon2022 -d ctclone --alsologtostderr --v=1 --log_url https://ct.googleapis.com/logs/xenon2022/ --mysql_uri 'clonetool:letmein@tcp(host.docker.internal)/google_xenon2022'
-```
-
-# Verification
-
-The downloaded log contents should be checked against the checkpoints provided by the log.
-There isn't yet any support in the DB for storing checkpoints, so maintaining them is a DIY project for now.
-The `ctverify` tool takes a CT STH and uses its tree size to compute the root hash from the local data.
-The root hashes are compared, and the tool exits with a failure if they do not match.
-
-One way to accomplish this could be:
-
-```bash
-# 1. Get the checkpoint
-wget -O xenon2022.checkpoint https://ct.googleapis.com/logs/xenon2022/ct/v1/get-sth
-# 2. Clone the log as above ...
-# 3. Pipe the original checkpoint into verify tool to check the downloaded content matches
-cat xenon2022.checkpoint | go run ./clone/cmd/ctverify --alsologtostderr --mysql_uri 'mirror:letmein@tcp(localhost)/google_xenon2022'
-```
+Download clients are provided for:
+  * [CT](cmd/ctclone/)
+  * [sum.golang.org](cmd/sumdbclone/)
+ 
+See the documentation for these for specifics of each tool.

--- a/clone/cmd/ctclone/README.md
+++ b/clone/cmd/ctclone/README.md
@@ -1,0 +1,30 @@
+# `ctclone`
+
+This tool clones a Certificate Transparency (RFC6962) log.
+See background and database setup in the [parent docs](../../README.md).
+
+## Cloning
+
+Assuming the database is provisioned, the log can be downloaded with:
+
+```
+go run ./clone/cmd/ctclone --alsologtostderr --v=1 --log_url https://ct.googleapis.com/logs/xenon2022/ --mysql_uri 'clonetool:letmein@tcp(localhost)/google_xenon2022'
+```
+
+## Tuning
+
+In addition the general tuning flags (`workers` and `write_batch_size`) mentioned in the parents docs, the CT clone tool also has `fetch_batch_size`. As a rule of thumb, this should be set to the maximum size that the log supports for a single batch.
+
+## Docker
+
+To build a docker image, run the following from the `trillian-examples` root directory:
+
+```
+docker build . -t ctclone -f ./clone/cmd/ctclone/Dockerfile
+```
+
+This can be pointed at a local MySQL instance running outside of docker using:
+
+```
+docker run --name clone_xenon2022 -d ctclone --alsologtostderr --v=1 --log_url https://ct.googleapis.com/logs/xenon2022/ --mysql_uri 'clonetool:letmein@tcp(host.docker.internal)/google_xenon2022'
+```

--- a/clone/cmd/sumdbclone/Dockerfile
+++ b/clone/cmd/sumdbclone/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:buster AS builder
+
+ARG GOFLAGS=""
+ENV GOFLAGS=$GOFLAGS
+ENV GO111MODULE=on
+
+# Move to working directory /build
+WORKDIR /build
+
+# Copy and download dependency using go mod
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+# Copy the code into the container
+COPY . .
+
+# Build the application
+RUN go build ./clone/cmd/sumdbclone
+
+# Build release image
+FROM golang:buster
+
+COPY --from=builder /build/sumdbclone /bin/sumdbclone
+ENTRYPOINT ["/bin/sumdbclone"]

--- a/clone/cmd/sumdbclone/README.md
+++ b/clone/cmd/sumdbclone/README.md
@@ -1,0 +1,26 @@
+# `sumdbclone`
+
+This tool clones the log for sum.golang.org.
+See background and database setup in the [parent docs](../../README.md).
+
+## Cloning
+
+Assuming the database is provisioned (with database called `sumdbclone`), the log can be downloaded with:
+
+```
+go run ./clone/cmd/sumdbclone --alsologtostderr --v=1 --mysql_uri 'clonetool:letmein@tcp(localhost)/sumdbclone'
+```
+
+## Docker
+
+To build a docker image, run the following from the `trillian-examples` root directory:
+
+```
+docker build . -t sumdbclone -f ./clone/cmd/sumdbclone/Dockerfile
+```
+
+This can be pointed at a local MySQL instance running outside of docker using:
+
+```
+docker run --name clone_sumdb -d sumdbclone --alsologtostderr --v=1 --mysql_uri 'clonetool:letmein@tcp(host.docker.internal)/sumdbclone'
+```

--- a/clone/cmd/sumdbclone/sumdbclone.go
+++ b/clone/cmd/sumdbclone/sumdbclone.go
@@ -1,0 +1,145 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// sumdbclone is a one-shot tool for downloading entries from sum.golang.org.
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/clone/internal/cloner"
+	"github.com/google/trillian-examples/clone/internal/verify"
+	"github.com/google/trillian-examples/clone/logdb"
+	sdbclient "github.com/google/trillian-examples/sumdbaudit/client"
+	"github.com/google/trillian/merkle/rfc6962"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+var (
+	height         = flag.Int("h", 8, "tile height")
+	vkey           = flag.String("k", "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8", "key")
+	mysqlURI       = flag.String("mysql_uri", "", "URL of a MySQL database to clone the log into. The DB should contain only one log.")
+	writeBatchSize = flag.Uint("write_batch_size", 1024, "The number of leaves to write in each DB transaction.")
+	workers        = flag.Uint("workers", 4, "The number of worker threads to run in parallel to fetch entries.")
+)
+
+func main() {
+	flag.Parse()
+
+	if len(*mysqlURI) == 0 {
+		glog.Exit("Missing required parameter 'mysql_uri'")
+	}
+
+	ctx := context.Background()
+	db, err := logdb.NewDatabase(*mysqlURI)
+	if err != nil {
+		glog.Exitf("Failed to connect to database: %q", err)
+	}
+
+	client := sdbclient.NewSumDB(*height, *vkey)
+	targetCp, err := client.LatestCheckpoint()
+	if err != nil {
+		glog.Exitf("Failed to get latest checkpoint from log: %v", err)
+	}
+	glog.Infof("Target checkpoint is for tree size %d", targetCp.N)
+
+	if err := clone(ctx, db, client, targetCp); err != nil {
+		glog.Exitf("Failed to clone log: %v", err)
+	}
+
+	// Verify the downloaded leaves with the target checkpoint, and if it verifies, persist the checkpoint.
+	h := rfc6962.DefaultHasher
+	lh := func(_ uint64, preimage []byte) []byte {
+		return h.HashLeaf(preimage)
+	}
+	v := verify.NewLogVerifier(db, lh, h.HashChildren)
+	root, crs, err := v.MerkleRoot(ctx, uint64(targetCp.N))
+	if err != nil {
+		glog.Exitf("Failed to compute root: %q", err)
+	}
+	if !bytes.Equal(targetCp.Hash[:], root) {
+		glog.Exitf("Computed root %x != provided checkpoint %x for tree size %d", root, targetCp.Hash, targetCp.N)
+	}
+	glog.Infof("Got matching roots for tree size %d: %x", targetCp.N, root)
+	if err := db.WriteCheckpoint(ctx, uint64(targetCp.N), targetCp.Raw, crs); err != nil {
+		glog.Exitf("Failed to update database with new checkpoint: %v", err)
+	}
+}
+
+func clone(ctx context.Context, db *logdb.Database, client *sdbclient.SumDBClient, targetCp *sdbclient.Checkpoint) error {
+	fullTileSize := 1 << *height
+	cl := cloner.New(*workers, uint(fullTileSize), *writeBatchSize, db)
+
+	next, err := cl.Next()
+	if err != nil {
+		return fmt.Errorf("couldn't determine first leaf to fetch: %v", err)
+	}
+	if next >= uint64(targetCp.N) {
+		glog.Infof("No work to do. Local tree size = %d, latest log tree size = %d", next, targetCp.N)
+		return nil
+	}
+
+	// batchFetch gets full or partial tiles depending on the number of leaves requested.
+	// start must always be the first index within a tile or it is being used wrong.
+	batchFetch := func(start uint64, leaves [][]byte) error {
+		if start%uint64(fullTileSize) > 0 {
+			return backoff.Permanent(fmt.Errorf("%d is not the first leaf in a tile", start))
+		}
+		offset := int(start >> *height)
+
+		var got [][]byte
+		var err error
+		if len(leaves) == fullTileSize {
+			got, err = client.FullLeavesAtOffset(offset)
+		} else {
+			got, err = client.PartialLeavesAtOffset(offset, len(leaves))
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get leaves at offset %d: %v", offset, err)
+		}
+		copy(leaves, got)
+		return nil
+	}
+
+	// Download any remainder of a previous partial tile before calling Clone,
+	// which is optimized for chunks perfectly aligning with tiles.
+	if rem := next % uint64(fullTileSize); rem > 0 {
+		tileStart := next - rem
+		needed := fullTileSize
+		if d := targetCp.N - int64(tileStart); int(d) < needed {
+			needed = int(d)
+		}
+		leaves := make([][]byte, needed)
+		glog.Infof("Next=%d does not align with tile boundary; prefetching tile [%d, %d)", next, tileStart, tileStart+uint64(len(leaves)))
+		if err := batchFetch(tileStart, leaves); err != nil {
+			return err
+		}
+		if err := db.WriteLeaves(ctx, next, leaves[rem:]); err != nil {
+			return fmt.Errorf("failed to write to DB for batch starting at %d: %q", next, err)
+		}
+	}
+
+	// The database must now contain only complete tiles, or else be matched with
+	// the targetCp. Either way, the preconditions for the cloner configuration are met.
+	if err := cl.Clone(ctx, uint64(targetCp.N), batchFetch); err != nil {
+		return fmt.Errorf("failed to clone log: %v", err)
+	}
+	return nil
+}

--- a/clone/cmd/sumdbclone/sumdbclone.go
+++ b/clone/cmd/sumdbclone/sumdbclone.go
@@ -40,7 +40,7 @@ var (
 )
 
 const (
-	height = 8
+	tileHeight = 8
 )
 
 func main() {
@@ -56,7 +56,7 @@ func main() {
 		glog.Exitf("Failed to connect to database: %q", err)
 	}
 
-	client := sdbclient.NewSumDB(height, *vkey)
+	client := sdbclient.NewSumDB(tileHeight, *vkey)
 	targetCp, err := client.LatestCheckpoint()
 	if err != nil {
 		glog.Exitf("Failed to get latest checkpoint from log: %v", err)
@@ -87,7 +87,7 @@ func main() {
 }
 
 func clone(ctx context.Context, db *logdb.Database, client *sdbclient.SumDBClient, targetCp *sdbclient.Checkpoint) error {
-	fullTileSize := 1 << height
+	fullTileSize := 1 << tileHeight
 	cl := cloner.New(*workers, uint(fullTileSize), *writeBatchSize, db)
 
 	next, err := cl.Next()
@@ -105,7 +105,7 @@ func clone(ctx context.Context, db *logdb.Database, client *sdbclient.SumDBClien
 		if start%uint64(fullTileSize) > 0 {
 			return backoff.Permanent(fmt.Errorf("%d is not the first leaf in a tile", start))
 		}
-		offset := int(start >> height)
+		offset := int(start >> tileHeight)
 
 		var got [][]byte
 		var err error


### PR DESCRIPTION
This is consistent with the ctclone tool and uses much of the same machinery to get the job done. There is a little additional complexity here where we need to always be downloading a tile per worker to realize the parallelism dream. This means that when the previous download finished mid-tile, we need to do a little neatening up before we can invoke the Bulk command. Otherwise, this drops in cleanly if I say so myself.
