### PR TITLE
Make the feeder warn instead of exiting on failure

### DIFF
--- a/sumdbaudit/witness/cmd/feeder/main.go
+++ b/sumdbaudit/witness/cmd/feeder/main.go
@@ -92,7 +92,7 @@ func main() {
 	for {
 		glog.V(2).Infof("Tick: start feedOnce (witness size %d)", feeder.wcp.Size)
 		if err := feeder.feedOnce(ctx); err != nil {
-			glog.Exitf("Failed to feed: %v", err)
+			glog.Warningf("Failed to feed: %v", err)
 		}
 		glog.V(2).Infof("Tick: feedOnce complete (witness size %d)", feeder.wcp.Size)
 


### PR DESCRIPTION
Future work could be done to make this exit after some duration (or number of attempts) without success. For now though, this is strictly better than restarting (or exiting) what should be a long-lived service