### PR TITLE
Update go tooling to 1.17 for docker images

### DIFF
--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,5 +1,5 @@
 # This Dockerfile builds a base image for the CloudBuild integration testing.
-FROM golang:buster as testbase
+FROM golang:go1.17-buster as testbase
 
 WORKDIR /testbase
 
@@ -21,7 +21,7 @@ RUN mkdir protoc && \
 # Tamago bits
 RUN apt-get -y install binutils-arm-none-eabi build-essential make u-boot-tools && \
     apt-get -y install -t buster-backports fuse fuse2fs
-RUN curl -sfL https://github.com/f-secure-foundry/tamago-go/releases/download/tamago-go1.16.5/tamago-go1.16.5.linux-amd64.tar.gz | tar -xzf - -C /
+RUN curl -sfL https://github.com/f-secure-foundry/tamago-go/releases/download/tamago-go1.17/tamago-go1.17.linux-amd64.tar.gz | tar -xzf - -C /
 ENV TAMAGO=/usr/local/tamago-go/bin/go
 
 ENV GOPATH /go

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,5 +1,5 @@
 # This Dockerfile builds a base image for the CloudBuild integration testing.
-FROM golang:go1.17-buster as testbase
+FROM golang:1.17-buster as testbase
 
 WORKDIR /testbase
 

--- a/serverless/deploy/github/distributor/combine_witness_signatures/Dockerfile
+++ b/serverless/deploy/github/distributor/combine_witness_signatures/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine AS build
+FROM golang:1.17-alpine AS build
 
 WORKDIR /src/
 COPY . ./

--- a/serverless/deploy/github/log/sequence_and_integrate/Dockerfile
+++ b/serverless/deploy/github/log/sequence_and_integrate/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine AS build
+FROM golang:1.17-alpine AS build
 
 WORKDIR /src/
 COPY . ./


### PR DESCRIPTION
This updates things that were explicitly using 1.16 things, and makes the reference to the "latest" version of buster explicitly locked to a version in the same way that we have done in the main trillian repo.