### PR TITLE
Used log.ParseCheckpoint in a few easy places

### DIFF
--- a/helloworld/client.go
+++ b/helloworld/client.go
@@ -79,15 +79,10 @@ func (c Client) VerIncl(entry []byte, pf *trillian.Proof) bool {
 // UpdateChkpt allows a client to update its stored checkpoint.  In a real use
 // case it would be important for the client to check the signature contained
 // in the checkpoint before verifying consistency.
-func (c Client) UpdateChkpt(chkptNewRaw personality.SignedCheckpoint, pf *trillian.Proof) error {
-	n, err := note.Open(chkptNewRaw, note.VerifierList(c.sigVerifier))
+func (c *Client) UpdateChkpt(chkptNewRaw personality.SignedCheckpoint, pf *trillian.Proof) error {
+	chkptNew, _, err := log.ParseCheckpoint("Hello World Log", c.sigVerifier, []note.Verifier{}, chkptNewRaw)
 	if err != nil {
 		return fmt.Errorf("failed to verify checkpoint: %w", err)
-	}
-	chkptNew := &log.Checkpoint{}
-	_, err = chkptNew.Unmarshal([]byte(n.Text))
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal new checkpoint: %w", err)
 	}
 	// If there is no checkpoint then just use this one no matter what.
 	if c.chkpt.Size != 0 {

--- a/helloworld/helloworld_test.go
+++ b/helloworld/helloworld_test.go
@@ -61,14 +61,9 @@ func mustGetVerifier(t *testing.T) note.Verifier {
 
 func mustOpenCheckpoint(t *testing.T, cRaw []byte) *log.Checkpoint {
 	t.Helper()
-	r, err := note.Open(cRaw, note.VerifierList(mustGetVerifier(t)))
+	cp, _, err := log.ParseCheckpoint("Hello World Log", mustGetVerifier(t), []note.Verifier{}, cRaw)
 	if err != nil {
 		t.Fatalf("Failed to open checkpoint: %q", err)
-	}
-	cp := &log.Checkpoint{}
-	_, err = cp.Unmarshal([]byte(r.Text))
-	if err != nil {
-		t.Fatalf("Failed to unmarshal checkpoint: %q", err)
 	}
 	return cp
 }


### PR DESCRIPTION
Also made client.UpdateChkpt declared on the pointer to fix no-op assignment bug spotted while doing this.

There are plenty of other places also doing checkpoint parsing, but the origin string is not easily available so these changes will require more work.