### PR TITLE
Reordered parameters to ParseCheckpoint

### DIFF
--- a/formats/log/note.go
+++ b/formats/log/note.go
@@ -29,7 +29,7 @@ import (
 // checkpoint is returned. The underlying note is always returned where possible.
 // The signatures on the note will include the log signature if no error is returned,
 // plus any signatures from otherVerifiers that were found.
-func ParseCheckpoint(origin string, logVerifier note.Verifier, otherVerifiers []note.Verifier, chkpt []byte) (*Checkpoint, *note.Note, error) {
+func ParseCheckpoint(chkpt []byte, origin string, logVerifier note.Verifier, otherVerifiers ...note.Verifier) (*Checkpoint, *note.Note, error) {
 	vs := append(append(make([]note.Verifier, 0, len(otherVerifiers)+1), logVerifier), otherVerifiers...)
 	verifiers := note.VerifierList(vs...)
 

--- a/formats/log/note_test.go
+++ b/formats/log/note_test.go
@@ -184,7 +184,7 @@ func TestParseCheckpoint(t *testing.T) {
 			}
 
 			// Now parse what we have created.
-			_, n, err := log.ParseCheckpoint(test.logID, logVerifier, []note.Verifier{known1Verifier, known2Verifier}, nBs)
+			_, n, err := log.ParseCheckpoint(nBs, test.logID, logVerifier, known1Verifier, known2Verifier)
 			if gotErr := err != nil; gotErr != test.wantErr {
 				t.Errorf("gotErr %t != wantErr %t (%v)", gotErr, test.wantErr, err)
 			}
@@ -228,7 +228,7 @@ mb8QLQIs0Z0yP5Cstq6guj87oXWeC9gEM8oVikmm9Wk=
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			cp, _, err := log.ParseCheckpoint(test.logID, logVerifier, []note.Verifier{}, []byte(noteString))
+			cp, _, err := log.ParseCheckpoint([]byte(noteString), test.logID, logVerifier)
 			if err != nil {
 				if !test.wantErr {
 					t.Fatalf("Failed to parse checkpoint note: %v", err)
@@ -322,7 +322,7 @@ mb8QLQIs0Z0yP5Cstq6guj87oXWeC9gEM8oVikmm9Wk=
 				note = fmt.Sprintf("%s%s\n", note, s)
 			}
 			for n := 0; n < b.N; n++ {
-				if _, _, err := log.ParseCheckpoint("go.sum database tree", logVerifier, vs, []byte(note)); err != nil {
+				if _, _, err := log.ParseCheckpoint([]byte(note), "go.sum database tree", logVerifier, vs...); err != nil {
 					b.Fatalf("Failed to parse: %v", err)
 				}
 			}

--- a/helloworld/client.go
+++ b/helloworld/client.go
@@ -80,7 +80,7 @@ func (c Client) VerIncl(entry []byte, pf *trillian.Proof) bool {
 // case it would be important for the client to check the signature contained
 // in the checkpoint before verifying consistency.
 func (c *Client) UpdateChkpt(chkptNewRaw personality.SignedCheckpoint, pf *trillian.Proof) error {
-	chkptNew, _, err := log.ParseCheckpoint("Hello World Log", c.sigVerifier, []note.Verifier{}, chkptNewRaw)
+	chkptNew, _, err := log.ParseCheckpoint(chkptNewRaw, "Hello World Log", c.sigVerifier)
 	if err != nil {
 		return fmt.Errorf("failed to verify checkpoint: %w", err)
 	}

--- a/helloworld/helloworld_test.go
+++ b/helloworld/helloworld_test.go
@@ -61,7 +61,7 @@ func mustGetVerifier(t *testing.T) note.Verifier {
 
 func mustOpenCheckpoint(t *testing.T, cRaw []byte) *log.Checkpoint {
 	t.Helper()
-	cp, _, err := log.ParseCheckpoint("Hello World Log", mustGetVerifier(t), []note.Verifier{}, cRaw)
+	cp, _, err := log.ParseCheckpoint(cRaw, "Hello World Log", mustGetVerifier(t))
 	if err != nil {
 		t.Fatalf("Failed to open checkpoint: %q", err)
 	}

--- a/sumdbaudit/witness/cmd/feeder/main.go
+++ b/sumdbaudit/witness/cmd/feeder/main.go
@@ -72,7 +72,7 @@ func main() {
 			glog.Exitf("Failed to get witness checkpoint: %v", err)
 		}
 	} else {
-		wcp, _, err = log.ParseCheckpoint(*origin, w.Verifier, []note.Verifier{}, wcpRaw)
+		wcp, _, err = log.ParseCheckpoint(wcpRaw, *origin, w.Verifier)
 		if err != nil {
 			glog.Exitf("Failed to open CP: %v", err)
 		}
@@ -154,7 +154,7 @@ func (f *feeder) feedOnce(ctx context.Context) error {
 	// An optimization would be to immediately retry the Update if we get
 	// http.ErrCheckpointTooOld. For now, we'll update the local state and
 	// retry only the next time this method is called.
-	f.wcp, _, err = log.ParseCheckpoint(*origin, f.w.Verifier, []note.Verifier{}, wcpRaw)
+	f.wcp, _, err = log.ParseCheckpoint(wcpRaw, *origin, f.w.Verifier)
 	if err != nil {
 		return fmt.Errorf("failed to parse checkpoint: %v", err)
 	}


### PR DESCRIPTION
This makes it much easier in the common case that there aren't additional verifiers