### PR TITLE
Perform checks on Origin consistently within FT demo

### DIFF
--- a/binary_transparency/firmware/api/http.go
+++ b/binary_transparency/firmware/api/http.go
@@ -74,24 +74,24 @@ func (l LogCheckpoint) Marshal() []byte {
 // enforcing that a timestamp is included in the `otherdata`, and returning a
 // LogCheckpoint constructed from this data.
 func ParseCheckpoint(chkpt []byte, logVerifier note.Verifier, otherVerifiers ...note.Verifier) (*LogCheckpoint, *log.CheckpointNote, error) {
-	cp, n, err := log.ParseCheckpoint(chkpt, FTLogOrigin, logVerifier, otherVerifiers...)
+	cn, err := log.ParseCheckpoint(chkpt, FTLogOrigin, logVerifier, otherVerifiers...)
 	if err != nil {
-		return nil, n, err
+		return nil, cn, err
 	}
 	const delim = "\n"
-	lines := strings.Split(strings.TrimRight(string(n.OtherData), delim), delim)
+	lines := strings.Split(strings.TrimRight(string(cn.OtherData), delim), delim)
 	if el := len(lines); el != 1 {
-		return nil, n, fmt.Errorf("expected 1 line of other data, got %d", el)
+		return nil, cn, fmt.Errorf("expected 1 line of other data, got %d", el)
 	}
 	ts, err := strconv.ParseUint(lines[0], 10, 64)
 	if err != nil {
-		return nil, n, fmt.Errorf("failed to parse timestamp: %w", err)
+		return nil, cn, fmt.Errorf("failed to parse timestamp: %w", err)
 	}
 	return &LogCheckpoint{
-		Checkpoint:     *cp,
+		Checkpoint:     *cn.Checkpoint,
 		TimestampNanos: ts,
 		Envelope:       chkpt,
-	}, n, err
+	}, cn, err
 }
 
 // GetConsistencyRequest is sent to ask for a proof that the tree at ToSize

--- a/binary_transparency/firmware/api/http.go
+++ b/binary_transparency/firmware/api/http.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/google/trillian-examples/formats/log"
+	"golang.org/x/mod/sumdb/note"
 )
 
 const (
@@ -69,23 +70,28 @@ func (l LogCheckpoint) Marshal() []byte {
 	return b.Bytes()
 }
 
-// Unmarshal knows how to deserialise a LogCheckpoint.
-func (l *LogCheckpoint) Unmarshal(data []byte) error {
-	const delim = "\n"
-	rest, err := l.Checkpoint.Unmarshal(data)
+// ParseCheckpoint wraps `log.ParseCheckpoint` with the additional behaviour of
+// enforcing that a timestamp is included in the `otherdata`, and returning a
+// LogCheckpoint constructed from this data.
+func ParseCheckpoint(chkpt []byte, logVerifier note.Verifier, otherVerifiers ...note.Verifier) (*LogCheckpoint, *log.CheckpointNote, error) {
+	cp, n, err := log.ParseCheckpoint(chkpt, FTLogOrigin, logVerifier, otherVerifiers...)
 	if err != nil {
-		return err
+		return nil, n, err
 	}
-	lines := strings.Split(strings.TrimRight(string(rest), delim), delim)
+	const delim = "\n"
+	lines := strings.Split(strings.TrimRight(string(n.OtherData), delim), delim)
 	if el := len(lines); el != 1 {
-		return fmt.Errorf("expected 1 line of other data, got %d", el)
+		return nil, n, fmt.Errorf("expected 1 line of other data, got %d", el)
 	}
 	ts, err := strconv.ParseUint(lines[0], 10, 64)
 	if err != nil {
-		return fmt.Errorf("failed to parse timestamp: %w", err)
+		return nil, n, fmt.Errorf("failed to parse timestamp: %w", err)
 	}
-	l.TimestampNanos = ts
-	return nil
+	return &LogCheckpoint{
+		Checkpoint:     *cp,
+		TimestampNanos: ts,
+		Envelope:       chkpt,
+	}, n, err
 }
 
 // GetConsistencyRequest is sent to ask for a proof that the tree at ToSize

--- a/binary_transparency/firmware/api/http.go
+++ b/binary_transparency/firmware/api/http.go
@@ -73,25 +73,25 @@ func (l LogCheckpoint) Marshal() []byte {
 // ParseCheckpoint wraps `log.ParseCheckpoint` with the additional behaviour of
 // enforcing that a timestamp is included in the `otherdata`, and returning a
 // LogCheckpoint constructed from this data.
-func ParseCheckpoint(chkpt []byte, logVerifier note.Verifier, otherVerifiers ...note.Verifier) (*LogCheckpoint, *log.CheckpointNote, error) {
-	cn, err := log.ParseCheckpoint(chkpt, FTLogOrigin, logVerifier, otherVerifiers...)
+func ParseCheckpoint(chkpt []byte, logVerifier note.Verifier, otherVerifiers ...note.Verifier) (*LogCheckpoint, error) {
+	cp, otherData, _, err := log.ParseCheckpoint(chkpt, FTLogOrigin, logVerifier, otherVerifiers...)
 	if err != nil {
-		return nil, cn, err
+		return nil, err
 	}
 	const delim = "\n"
-	lines := strings.Split(strings.TrimRight(string(cn.OtherData), delim), delim)
+	lines := strings.Split(strings.TrimRight(string(otherData), delim), delim)
 	if el := len(lines); el != 1 {
-		return nil, cn, fmt.Errorf("expected 1 line of other data, got %d", el)
+		return nil, fmt.Errorf("expected 1 line of other data, got %d", el)
 	}
 	ts, err := strconv.ParseUint(lines[0], 10, 64)
 	if err != nil {
-		return nil, cn, fmt.Errorf("failed to parse timestamp: %w", err)
+		return nil, fmt.Errorf("failed to parse timestamp: %w", err)
 	}
 	return &LogCheckpoint{
-		Checkpoint:     *cn.Checkpoint,
+		Checkpoint:     *cp,
 		TimestampNanos: ts,
 		Envelope:       chkpt,
-	}, cn, err
+	}, err
 }
 
 // GetConsistencyRequest is sent to ask for a proof that the tree at ToSize

--- a/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
+++ b/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
@@ -181,18 +181,14 @@ func verifyUpdate(c *client.ReadonlyClient, logSigVerifier note.Verifier, up api
 	if err != nil {
 		return pb, fwMeta, fmt.Errorf("failed to fetch the device checkpoint: %w", err)
 	}
-	dcNote, err := note.Open(n, note.VerifierList(logSigVerifier))
+	dc, _, err := api.ParseCheckpoint([]byte(n), logSigVerifier)
 	if err != nil {
 		return pb, fwMeta, fmt.Errorf("failed to open the device checkpoint: %w", err)
-	}
-	dc := api.LogCheckpoint{Envelope: []byte(n)}
-	if err := dc.Unmarshal([]byte(dcNote.Text)); err != nil {
-		return pb, fwMeta, fmt.Errorf("failed to unmarshal the device checkpoint: %w", err)
 	}
 
 	cpFunc := getConsistencyFunc(c)
 	fwHash := sha512.Sum512(up.FirmwareImage)
-	pb, fwMeta, err = verify.BundleForUpdate(up.ProofBundle, fwHash[:], dc, cpFunc, logSigVerifier)
+	pb, fwMeta, err = verify.BundleForUpdate(up.ProofBundle, fwHash[:], *dc, cpFunc, logSigVerifier)
 	if err != nil {
 		return pb, fwMeta, fmt.Errorf("failed to verify proof bundle: %w", err)
 	}

--- a/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
+++ b/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
@@ -181,7 +181,7 @@ func verifyUpdate(c *client.ReadonlyClient, logSigVerifier note.Verifier, up api
 	if err != nil {
 		return pb, fwMeta, fmt.Errorf("failed to fetch the device checkpoint: %w", err)
 	}
-	dc, _, err := api.ParseCheckpoint([]byte(n), logSigVerifier)
+	dc, err := api.ParseCheckpoint([]byte(n), logSigVerifier)
 	if err != nil {
 		return pb, fwMeta, fmt.Errorf("failed to open the device checkpoint: %w", err)
 	}

--- a/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
+++ b/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
@@ -85,14 +85,11 @@ func Main(ctx context.Context, opts MonitorOpts) error {
 		// This could fail here unless a force flag is provided, for better security.
 		glog.Warningf("State file %q did not exist; first log checkpoint will be trusted implicitly", opts.StateFile)
 	} else {
-		n, err := note.Open(state, note.VerifierList(opts.LogSigVerifier))
+		cp, _, err := api.ParseCheckpoint(state, opts.LogSigVerifier)
 		if err != nil {
 			return fmt.Errorf("failed to open state: %w", err)
 		}
-		latestCP.Envelope = state
-		if err := (&latestCP).Unmarshal([]byte(n.Text)); err != nil {
-			return fmt.Errorf("failed to unmarshal state: %w", err)
-		}
+		latestCP = *cp
 	}
 	head := latestCP.Size
 	follow := client.NewLogFollower(c)

--- a/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
+++ b/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
@@ -85,7 +85,7 @@ func Main(ctx context.Context, opts MonitorOpts) error {
 		// This could fail here unless a force flag is provided, for better security.
 		glog.Warningf("State file %q did not exist; first log checkpoint will be trusted implicitly", opts.StateFile)
 	} else {
-		cp, _, err := api.ParseCheckpoint(state, opts.LogSigVerifier)
+		cp, err := api.ParseCheckpoint(state, opts.LogSigVerifier)
 		if err != nil {
 			return fmt.Errorf("failed to open state: %w", err)
 		}

--- a/binary_transparency/firmware/cmd/ft_witness/internal/http/witness.go
+++ b/binary_transparency/firmware/cmd/ft_witness/internal/http/witness.go
@@ -59,7 +59,7 @@ func NewWitness(ws WitnessStore, logURL string, logSigVerifier note.Verifier, po
 		Envelope: gcpRaw,
 	}
 	if len(gcpRaw) > 0 {
-		cp, _, err := api.ParseCheckpoint(gcpRaw, logSigVerifier)
+		cp, err := api.ParseCheckpoint(gcpRaw, logSigVerifier)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open stored checkpoint: %w", err)
 		}

--- a/binary_transparency/firmware/cmd/ft_witness/internal/http/witness.go
+++ b/binary_transparency/firmware/cmd/ft_witness/internal/http/witness.go
@@ -59,13 +59,11 @@ func NewWitness(ws WitnessStore, logURL string, logSigVerifier note.Verifier, po
 		Envelope: gcpRaw,
 	}
 	if len(gcpRaw) > 0 {
-		n, err := note.Open(gcpRaw, note.VerifierList(logSigVerifier))
+		cp, _, err := api.ParseCheckpoint(gcpRaw, logSigVerifier)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open stored checkpoint: %w", err)
 		}
-		if err := gcp.Unmarshal([]byte(n.Text)); err != nil {
-			return nil, fmt.Errorf("failed to parse stored checkpoint: %w", err)
-		}
+		gcp = *cp
 	}
 
 	return &Witness{

--- a/binary_transparency/firmware/cmd/ft_witness/internal/http/witness_test.go
+++ b/binary_transparency/firmware/cmd/ft_witness/internal/http/witness_test.go
@@ -39,7 +39,7 @@ func TestGetWitnessCheckpoint(t *testing.T) {
 	}{
 		{
 			desc:     "Successful Witness Checkpoint retrieval",
-			wantBody: "Firmware Transparency Log v0\n1\nEjQ=\n123\n",
+			wantBody: "Firmware Transparency Log\n1\nEjQ=\n123\n",
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {

--- a/binary_transparency/firmware/devices/dummy/rom/rom.go
+++ b/binary_transparency/firmware/devices/dummy/rom/rom.go
@@ -75,7 +75,7 @@ func Reset(storagePath string) (Chain, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create sig verifier: %w", err)
 	}
-	if err := verify.BundleForBoot(bundleRaw, fwMeasurement[:], note.VerifierList(v)); err != nil {
+	if err := verify.BundleForBoot(bundleRaw, fwMeasurement[:], v); err != nil {
 		return nil, fmt.Errorf("failed to verify bundle: %w", err)
 	}
 

--- a/binary_transparency/firmware/devices/usbarmory/bootloader/ft.go
+++ b/binary_transparency/firmware/devices/usbarmory/bootloader/ft.go
@@ -1,4 +1,5 @@
-//+build armory
+//go:build armory
+// +build armory
 
 package main
 
@@ -45,7 +46,7 @@ func verifyIntegrity(proof, firmware *Partition) error {
 	fmt.Printf("firmware partition hash: 0x%x\n", h)
 	logSigVerifier, err := note.NewVerifier(crypto.TestFTPersonalityPub)
 
-	if err := verify.BundleForBoot(rawBundle, h, note.VerifierList(logSigVerifier)); err != nil {
+	if err := verify.BundleForBoot(rawBundle, h, logSigVerifier); err != nil {
 		return fmt.Errorf("failed to verify bundle: %w", err)
 	}
 	return nil

--- a/binary_transparency/firmware/internal/client/client.go
+++ b/binary_transparency/firmware/internal/client/client.go
@@ -140,7 +140,7 @@ func (c ReadonlyClient) GetCheckpoint() (*api.LogCheckpoint, error) {
 		return nil, fmt.Errorf("failed to read body: %w", err)
 	}
 
-	cp, _, err := api.ParseCheckpoint(b, c.LogSigVerifier)
+	cp, err := api.ParseCheckpoint(b, c.LogSigVerifier)
 	return cp, err
 }
 

--- a/binary_transparency/firmware/internal/client/client.go
+++ b/binary_transparency/firmware/internal/client/client.go
@@ -140,16 +140,8 @@ func (c ReadonlyClient) GetCheckpoint() (*api.LogCheckpoint, error) {
 		return nil, fmt.Errorf("failed to read body: %w", err)
 	}
 
-	n, err := note.Open(b, note.VerifierList(c.LogSigVerifier))
-	if err != nil {
-		return nil, err
-	}
-
-	cp := api.LogCheckpoint{Envelope: b}
-	if err := cp.Unmarshal([]byte(n.Text)); err != nil {
-		return nil, err
-	}
-	return &cp, nil
+	cp, _, err := api.ParseCheckpoint(b, c.LogSigVerifier)
+	return cp, err
 }
 
 // GetInclusion returns an inclusion proof for the statement under the given checkpoint.

--- a/binary_transparency/firmware/internal/client/client.go
+++ b/binary_transparency/firmware/internal/client/client.go
@@ -140,8 +140,7 @@ func (c ReadonlyClient) GetCheckpoint() (*api.LogCheckpoint, error) {
 		return nil, fmt.Errorf("failed to read body: %w", err)
 	}
 
-	cp, err := api.ParseCheckpoint(b, c.LogSigVerifier)
-	return cp, err
+	return api.ParseCheckpoint(b, c.LogSigVerifier)
 }
 
 // GetInclusion returns an inclusion proof for the statement under the given checkpoint.

--- a/binary_transparency/firmware/internal/client/wclient.go
+++ b/binary_transparency/firmware/internal/client/wclient.go
@@ -51,7 +51,7 @@ func (c WitnessClient) GetWitnessCheckpoint() (*api.LogCheckpoint, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read body: %w", err)
 	}
-	cp, _, err := api.ParseCheckpoint(b, c.LogSigVerifier)
+	cp, err := api.ParseCheckpoint(b, c.LogSigVerifier)
 	return cp, err
 }
 

--- a/binary_transparency/firmware/internal/client/wclient.go
+++ b/binary_transparency/firmware/internal/client/wclient.go
@@ -51,8 +51,7 @@ func (c WitnessClient) GetWitnessCheckpoint() (*api.LogCheckpoint, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read body: %w", err)
 	}
-	cp, err := api.ParseCheckpoint(b, c.LogSigVerifier)
-	return cp, err
+	return api.ParseCheckpoint(b, c.LogSigVerifier)
 }
 
 func errFromRsp(m string, r *http.Response) error {

--- a/binary_transparency/firmware/internal/client/wclient.go
+++ b/binary_transparency/firmware/internal/client/wclient.go
@@ -51,15 +51,8 @@ func (c WitnessClient) GetWitnessCheckpoint() (*api.LogCheckpoint, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read body: %w", err)
 	}
-	n, err := note.Open(b, note.VerifierList(c.LogSigVerifier))
-	if err != nil {
-		return nil, fmt.Errorf("failed to open returned checkpoint: %w", err)
-	}
-	wcp := api.LogCheckpoint{Envelope: b}
-	if err := wcp.Unmarshal([]byte(n.Text)); err != nil {
-		return nil, err
-	}
-	return &wcp, nil
+	cp, _, err := api.ParseCheckpoint(b, c.LogSigVerifier)
+	return cp, err
 }
 
 func errFromRsp(m string, r *http.Response) error {

--- a/binary_transparency/firmware/internal/verify/bundle.go
+++ b/binary_transparency/firmware/internal/verify/bundle.go
@@ -45,7 +45,7 @@ func BundleForUpdate(bundleRaw, fwHash []byte, dc api.LogCheckpoint, cpFunc Cons
 		return proofBundle, fwMeta, fmt.Errorf("firmware update image hash does not match metadata (0x%x != 0x%x)", got, want)
 	}
 
-	pc, _, err := api.ParseCheckpoint(proofBundle.Checkpoint, logSigVerifier)
+	pc, err := api.ParseCheckpoint(proofBundle.Checkpoint, logSigVerifier)
 	if err != nil {
 		return proofBundle, fwMeta, fmt.Errorf("failed to open the device checkpoint: %w", err)
 	}
@@ -74,7 +74,7 @@ func BundleConsistency(pb api.ProofBundle, rc api.LogCheckpoint, cpFunc Consiste
 		return fmt.Errorf("remote verification failed wcp treesize(%d)<device cp index(%d)", rc.Size, pb.InclusionProof.LeafIndex)
 	}
 
-	bundleCP, _, err := api.ParseCheckpoint(pb.Checkpoint, logSigVerifier)
+	bundleCP, err := api.ParseCheckpoint(pb.Checkpoint, logSigVerifier)
 	if err != nil {
 		return fmt.Errorf("failed to open the proof bundle checkpoint: %w", err)
 	}
@@ -115,7 +115,7 @@ func verifyBundle(bundleRaw []byte, logSigVerifier note.Verifier) (api.ProofBund
 		return api.ProofBundle{}, api.FirmwareMetadata{}, fmt.Errorf("failed to parse proof bundle: %w", err)
 	}
 
-	bundleCP, _, err := api.ParseCheckpoint(pb.Checkpoint, logSigVerifier)
+	bundleCP, err := api.ParseCheckpoint(pb.Checkpoint, logSigVerifier)
 	if err != nil {
 		return api.ProofBundle{}, api.FirmwareMetadata{}, fmt.Errorf("failed to open the proof bundle checkpoint: %w", err)
 	}

--- a/binary_transparency/firmware/internal/verify/bundle.go
+++ b/binary_transparency/firmware/internal/verify/bundle.go
@@ -36,7 +36,7 @@ type ConsistencyProofFunc func(from, to uint64) ([][]byte, error)
 // and device log point (for non zero device tree size). Upon successful verification
 // returns a proof bundle
 func BundleForUpdate(bundleRaw, fwHash []byte, dc api.LogCheckpoint, cpFunc ConsistencyProofFunc, logSigVerifier note.Verifier) (api.ProofBundle, api.FirmwareMetadata, error) {
-	proofBundle, fwMeta, err := verifyBundle(bundleRaw, note.VerifierList(logSigVerifier))
+	proofBundle, fwMeta, err := verifyBundle(bundleRaw, logSigVerifier)
 	if err != nil {
 		return proofBundle, fwMeta, err
 	}
@@ -45,13 +45,9 @@ func BundleForUpdate(bundleRaw, fwHash []byte, dc api.LogCheckpoint, cpFunc Cons
 		return proofBundle, fwMeta, fmt.Errorf("firmware update image hash does not match metadata (0x%x != 0x%x)", got, want)
 	}
 
-	pcNote, err := note.Open(proofBundle.Checkpoint, note.VerifierList(logSigVerifier))
+	pc, _, err := api.ParseCheckpoint(proofBundle.Checkpoint, logSigVerifier)
 	if err != nil {
 		return proofBundle, fwMeta, fmt.Errorf("failed to open the device checkpoint: %w", err)
-	}
-	pc := &api.LogCheckpoint{Envelope: proofBundle.Checkpoint}
-	if err := pc.Unmarshal([]byte(pcNote.Text)); err != nil {
-		return proofBundle, fwMeta, fmt.Errorf("failed to unmarshal the device checkpoint: %w", err)
 	}
 
 	cProof, err := cpFunc(dc.Size, pc.Size)
@@ -78,15 +74,11 @@ func BundleConsistency(pb api.ProofBundle, rc api.LogCheckpoint, cpFunc Consiste
 		return fmt.Errorf("remote verification failed wcp treesize(%d)<device cp index(%d)", rc.Size, pb.InclusionProof.LeafIndex)
 	}
 
-	bundleCPNote, err := note.Open(pb.Checkpoint, note.VerifierList(logSigVerifier))
+	bundleCP, _, err := api.ParseCheckpoint(pb.Checkpoint, logSigVerifier)
 	if err != nil {
 		return fmt.Errorf("failed to open the proof bundle checkpoint: %w", err)
 	}
-	bundleCP := api.LogCheckpoint{Envelope: pb.Checkpoint}
-	if err := bundleCP.Unmarshal([]byte(bundleCPNote.Text)); err != nil {
-		return fmt.Errorf("failed to unmarshal the proof bundle checkpoint: %w", err)
-	}
-	fromCP, toCP := rc, bundleCP
+	fromCP, toCP := rc, *bundleCP
 	// swap the remote checkpoint(fromCP) with published checkpoint (toCP) if it is ahead of published checkpoint
 	if rc.Size > bundleCP.Size {
 		fromCP, toCP = toCP, fromCP
@@ -104,8 +96,8 @@ func BundleConsistency(pb api.ProofBundle, rc api.LogCheckpoint, cpFunc Consiste
 // BundleForBoot checks that the manifest, checkpoint, and proofs in a bundle
 // are all self-consistent, and that the provided firmware measurement matches
 // the one expected by the bundle.
-func BundleForBoot(bundleRaw, measurement []byte, logSigVerifiers note.Verifiers) error {
-	_, fwMeta, err := verifyBundle(bundleRaw, logSigVerifiers)
+func BundleForBoot(bundleRaw, measurement []byte, logSigVerifier note.Verifier) error {
+	_, fwMeta, err := verifyBundle(bundleRaw, logSigVerifier)
 	if err != nil {
 		return err
 	}
@@ -117,19 +109,15 @@ func BundleForBoot(bundleRaw, measurement []byte, logSigVerifiers note.Verifiers
 }
 
 // verifyBundle parses a proof bundle and verifies its self-consistency.
-func verifyBundle(bundleRaw []byte, logSigVerifiers note.Verifiers) (api.ProofBundle, api.FirmwareMetadata, error) {
+func verifyBundle(bundleRaw []byte, logSigVerifier note.Verifier) (api.ProofBundle, api.FirmwareMetadata, error) {
 	var pb api.ProofBundle
 	if err := json.Unmarshal(bundleRaw, &pb); err != nil {
 		return api.ProofBundle{}, api.FirmwareMetadata{}, fmt.Errorf("failed to parse proof bundle: %w", err)
 	}
 
-	bundleCPNote, err := note.Open(pb.Checkpoint, logSigVerifiers)
+	bundleCP, _, err := api.ParseCheckpoint(pb.Checkpoint, logSigVerifier)
 	if err != nil {
 		return api.ProofBundle{}, api.FirmwareMetadata{}, fmt.Errorf("failed to open the proof bundle checkpoint: %w", err)
-	}
-	bundleCP := &api.LogCheckpoint{Envelope: pb.Checkpoint}
-	if err := bundleCP.Unmarshal([]byte(bundleCPNote.Text)); err != nil {
-		return api.ProofBundle{}, api.FirmwareMetadata{}, fmt.Errorf("failed to unmarshal the proof bundle checkpoint: %w", err)
 	}
 
 	var fwStatement api.SignedStatement

--- a/binary_transparency/firmware/internal/verify/bundle_test.go
+++ b/binary_transparency/firmware/internal/verify/bundle_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	goldenProofBundle   = `{"ManifestStatement":"eyJUeXBlIjoxMDIsIlN0YXRlbWVudCI6ImV5SkVaWFpwWTJWSlJDSTZJbVIxYlcxNUlpd2lSbWx5YlhkaGNtVlNaWFpwYzJsdmJpSTZNU3dpUm1seWJYZGhjbVZKYldGblpWTklRVFV4TWlJNkltZ3ZTblpLTURVeE1GZE5Ua05hZG1wWFQwTXdVMUZxTDFKUFJHVXpLMGh6Uld0dE5HMUhUbnBWVEhSd1lXVlVhblkyU2xrcmQzSTBlVk51Vm5aNVJqVXdZa055TVhSd2NYZERiMEZvWm5CeFFscHNNbUpSUFQwaUxDSkZlSEJsWTNSbFpFWnBjbTEzWVhKbFRXVmhjM1Z5WlcxbGJuUWlPaUkyZEZWWGVYbHJlbmRtYjI5dVIzVm5ibVl4WkV3clkyZGtObUpGVjFWb2IyeEJUbUZFVERoS1dVdFhkR1J0VUdORlpWbDJaMDgyYmsxeUwwbE1aMWRRWTFWWloyZDJRVUZ5Y25SaFUwSnRZVzQxU0RSTFp6MDlJaXdpUW5WcGJHUlVhVzFsYzNSaGJYQWlPaUl5TURJd0xURXdMVEV3VkRFMU9qTXdPakl3TGpFd1dpSjkiLCJTaWduYXR1cmUiOiJUeUxVdFpCdHJHbyt3anRoSjI2Rk8wVE5QUHpTTDZhU0c1V0ZTanRCcjZLZ2x4a0RjR3dmZUxTTEpjbklmUnhZMnVJZHZLL09tMStXMndLNEkxSFRUYTdIUFZlSHo2MmF0V09hZm9TL1ZGc01OdEx1RkplaU5WNE5uY2Y0bllYMFBDdnN0MHRpYm5TVFRzNnEwMUZ1cEhaMnFwc2lyY2hFVXgwLzFjOFFOM2hGZVArSXcwVWxPNTVvZUhlWGtlRGRwL2w5SCsvZjYxYndFMmpHZVl1cFcvbld2bmN2NFgrS00weXgrYW1oVi9od0lCMDQ2aitNQzVndkd4LzJ2TkkySk5JeTBOQk13YWRIK1VONnp1MzRIZzM5NkY4MkxJU2NTOXU2MENBY3hzRlozR3d5NGpoR1JXR1lwSnhXdEJ6Zk5hZ1IvaVdmUzRJY2tJVmZ5Z2ZQUXc9PSJ9","Checkpoint":"RmlybXdhcmUgVHJhbnNwYXJlbmN5IExvZyB2MAo1Clg2VEY4QWNkSUh2OVp0UWwrU1NhZVZOYy9aNVJjNDJweDFpRlJLVGNDdHc9CjE2MDc0NTA3MzgxMTE1MDYwODgKCuKAlCBmdF9wZXJzb25hbGl0eSA2S0pDdlVyOWRqRGJ5Wm44dlRmYU9UN0hqRzZtMzkyaUkzMStHc2Naak9hclFnRHRVVlZEY2YreG5QTU90ZG5pMEV5bmNQdmNENjA1VDVPeXhQNXM5a2ZnOUFjPQo=","InclusionProof":{"Value":null,"LeafIndex":4,"Proof":["KFh4IVeIwbsvbWyz2QHVCXXyjWTRDqusRa0ZEjS2fls="]}}`
+	goldenProofBundle   = `{"ManifestStatement":"eyJUeXBlIjoxMDIsIlN0YXRlbWVudCI6ImV5SkVaWFpwWTJWSlJDSTZJbVIxYlcxNUlpd2lSbWx5YlhkaGNtVlNaWFpwYzJsdmJpSTZNU3dpUm1seWJYZGhjbVZKYldGblpWTklRVFV4TWlJNkltZ3ZTblpLTURVeE1GZE5Ua05hZG1wWFQwTXdVMUZxTDFKUFJHVXpLMGh6Uld0dE5HMUhUbnBWVEhSd1lXVlVhblkyU2xrcmQzSTBlVk51Vm5aNVJqVXdZa055TVhSd2NYZERiMEZvWm5CeFFscHNNbUpSUFQwaUxDSkZlSEJsWTNSbFpFWnBjbTEzWVhKbFRXVmhjM1Z5WlcxbGJuUWlPaUkyZEZWWGVYbHJlbmRtYjI5dVIzVm5ibVl4WkV3clkyZGtObUpGVjFWb2IyeEJUbUZFVERoS1dVdFhkR1J0VUdORlpWbDJaMDgyYmsxeUwwbE1aMWRRWTFWWloyZDJRVUZ5Y25SaFUwSnRZVzQxU0RSTFp6MDlJaXdpUW5WcGJHUlVhVzFsYzNSaGJYQWlPaUl5TURJd0xURXdMVEV3VkRFMU9qTXdPakl3TGpFd1dpSjkiLCJTaWduYXR1cmUiOiJUeUxVdFpCdHJHbyt3anRoSjI2Rk8wVE5QUHpTTDZhU0c1V0ZTanRCcjZLZ2x4a0RjR3dmZUxTTEpjbklmUnhZMnVJZHZLL09tMStXMndLNEkxSFRUYTdIUFZlSHo2MmF0V09hZm9TL1ZGc01OdEx1RkplaU5WNE5uY2Y0bllYMFBDdnN0MHRpYm5TVFRzNnEwMUZ1cEhaMnFwc2lyY2hFVXgwLzFjOFFOM2hGZVArSXcwVWxPNTVvZUhlWGtlRGRwL2w5SCsvZjYxYndFMmpHZVl1cFcvbld2bmN2NFgrS00weXgrYW1oVi9od0lCMDQ2aitNQzVndkd4LzJ2TkkySk5JeTBOQk13YWRIK1VONnp1MzRIZzM5NkY4MkxJU2NTOXU2MENBY3hzRlozR3d5NGpoR1JXR1lwSnhXdEJ6Zk5hZ1IvaVdmUzRJY2tJVmZ5Z2ZQUXc9PSJ9","Checkpoint":"RmlybXdhcmUgVHJhbnNwYXJlbmN5IExvZwo1Clg2VEY4QWNkSUh2OVp0UWwrU1NhZVZOYy9aNVJjNDJweDFpRlJLVGNDdHc9CjE2MDc0NTA3MzgxMTE1MDYwODgKCuKAlCBmdF9wZXJzb25hbGl0eSA2S0pDdlg1NTYrSGxNSnozMlhnQVhBYit1ODVOUEpSTkt2eHJ5enU1WTVibGkxWTh0YURsNDNjS2lmeVdsT1pYQWVnYndCaDUyUlNWc3ZJSUovTXY1K2Z0WHdjPQo=","InclusionProof":{"Value":null,"LeafIndex":4,"Proof":["KFh4IVeIwbsvbWyz2QHVCXXyjWTRDqusRa0ZEjS2fls="]}}`
 	goldenFirmwareImage = `Firmware image`
 	// goldenFirmwareHashB64 is a base64 encoded string for ExpectedMeasurement field inside ManifestStatement.
 	// For the dummy device, this is SHA512("dummy"||img), where img is the base64 decoded bytes from
@@ -49,7 +49,7 @@ func mustGetLogSigVerifier(t *testing.T) note.Verifier {
 
 // This test is useful for creating the Checkpoint field of the goldenProofBundle above.
 func TestGenerateGoldenCheckpoint(t *testing.T) {
-	cp := "RmlybXdhcmUgVHJhbnNwYXJlbmN5IExvZyB2MAo1Clg2VEY4QWNkSUh2OVp0UWwrU1NhZVZOYy9aNVJjNDJweDFpRlJLVGNDdHc9CjE2MDc0NTA3MzgxMTE1MDYwODgK"
+	cp := "RmlybXdhcmUgVHJhbnNwYXJlbmN5IExvZwo1Clg2VEY4QWNkSUh2OVp0UWwrU1NhZVZOYy9aNVJjNDJweDFpRlJLVGNDdHc9CjE2MDc0NTA3MzgxMTE1MDYwODgKCuKAlCBmdF9wZXJzb25hbGl0eSA2S0pDdlg1NTYrSGxNSnozMlhnQVhBYit1ODVOUEpSTkt2eHJ5enU1WTVibGkxWTh0YURsNDNjS2lmeVdsT1pYQWVnYndCaDUyUlNWc3ZJSUovTXY1K2Z0WHdjPQo="
 	nb, _ := base64.StdEncoding.DecodeString(cp)
 	s, err := note.NewSigner(crypto.TestFTPersonalityPriv)
 	if err != nil {
@@ -61,7 +61,6 @@ func TestGenerateGoldenCheckpoint(t *testing.T) {
 	}
 	t.Log(string(n))
 	t.Log(base64.StdEncoding.EncodeToString(n))
-
 }
 
 func TestBundleForUpdate(t *testing.T) {
@@ -122,7 +121,7 @@ func TestBundleForBoot(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			err := verify.BundleForBoot([]byte(goldenProofBundle), test.measurement, note.VerifierList(mustGetLogSigVerifier(t)))
+			err := verify.BundleForBoot([]byte(goldenProofBundle), test.measurement, mustGetLogSigVerifier(t))
 			if (err != nil) != test.wantErr {
 				t.Fatalf("want err %v, got %q", test.wantErr, err)
 			}

--- a/formats/log/note.go
+++ b/formats/log/note.go
@@ -20,17 +20,8 @@ import (
 	"golang.org/x/mod/sumdb/note"
 )
 
-// CheckpointNote is a parsed Checkpoint Note. This embeds the Note object to
-// allow clients to find any signatures, and also provides access to the
-// parsed Checkpoint and unparsed OtherData.
-type CheckpointNote struct {
-	*note.Note
-	Checkpoint *Checkpoint
-	OtherData  []byte
-}
-
 // ParseCheckpoint takes a raw checkpoint as bytes and returns a parsed checkpoint
-// note providing that:
+// and any otherData in the body, providing that:
 // * a valid log signature is found; and
 // * the checkpoint unmarshals correctly; and
 // * the log origin is that expected.
@@ -38,31 +29,28 @@ type CheckpointNote struct {
 // returned where possible.
 // The signatures on the note will include the log signature if no error is returned,
 // plus any signatures from otherVerifiers that were found.
-func ParseCheckpoint(chkpt []byte, origin string, logVerifier note.Verifier, otherVerifiers ...note.Verifier) (*CheckpointNote, error) {
+func ParseCheckpoint(chkpt []byte, origin string, logVerifier note.Verifier, otherVerifiers ...note.Verifier) (*Checkpoint, []byte, *note.Note, error) {
 	vs := append(append(make([]note.Verifier, 0, len(otherVerifiers)+1), logVerifier), otherVerifiers...)
 	verifiers := note.VerifierList(vs...)
 
 	n, err := note.Open(chkpt, verifiers)
 	if err != nil {
-		return nil, fmt.Errorf("failed to verify signatures on checkpoint: %v", err)
-	}
-	cn := &CheckpointNote{
-		Note: n,
+		return nil, nil, nil, fmt.Errorf("failed to verify signatures on checkpoint: %v", err)
 	}
 
 	for _, s := range n.Sigs {
 		if s.Hash == logVerifier.KeyHash() && s.Name == logVerifier.Name() {
 			// The log has signed this checkpoint. It is now safe to parse.
 			cp := &Checkpoint{}
-			if cn.OtherData, err = cp.Unmarshal([]byte(n.Text)); err != nil {
-				return cn, fmt.Errorf("failed to unmarshal checkpoint: %v", err)
+			var otherData []byte
+			if otherData, err = cp.Unmarshal([]byte(n.Text)); err != nil {
+				return nil, nil, n, fmt.Errorf("failed to unmarshal checkpoint: %v", err)
 			}
 			if cp.Origin != origin {
-				return cn, fmt.Errorf("got Origin %q but expected %q", cp.Origin, origin)
+				return nil, nil, n, fmt.Errorf("got Origin %q but expected %q", cp.Origin, origin)
 			}
-			cn.Checkpoint = cp
-			return cn, nil
+			return cp, otherData, n, nil
 		}
 	}
-	return cn, fmt.Errorf("no log signature found on note")
+	return nil, nil, n, fmt.Errorf("no log signature found on note")
 }

--- a/formats/log/note.go
+++ b/formats/log/note.go
@@ -20,6 +20,13 @@ import (
 	"golang.org/x/mod/sumdb/note"
 )
 
+// CheckpointNote is a Note that also exposes additional data that was included
+// in the signed note, but not part of the base checkpoint.
+type CheckpointNote struct {
+	*note.Note
+	OtherData []byte
+}
+
 // ParseCheckpoint takes a raw checkpoint as bytes and returns a parsed checkpoint
 // providing that:
 // * a valid log signature is found; and
@@ -29,27 +36,30 @@ import (
 // checkpoint is returned. The underlying note is always returned where possible.
 // The signatures on the note will include the log signature if no error is returned,
 // plus any signatures from otherVerifiers that were found.
-func ParseCheckpoint(chkpt []byte, origin string, logVerifier note.Verifier, otherVerifiers ...note.Verifier) (*Checkpoint, *note.Note, error) {
+func ParseCheckpoint(chkpt []byte, origin string, logVerifier note.Verifier, otherVerifiers ...note.Verifier) (*Checkpoint, *CheckpointNote, error) {
 	vs := append(append(make([]note.Verifier, 0, len(otherVerifiers)+1), logVerifier), otherVerifiers...)
 	verifiers := note.VerifierList(vs...)
 
 	n, err := note.Open(chkpt, verifiers)
 	if err != nil {
-		return nil, n, fmt.Errorf("failed to verify signatures on checkpoint: %v", err)
+		return nil, nil, fmt.Errorf("failed to verify signatures on checkpoint: %v", err)
+	}
+	cn := &CheckpointNote{
+		Note: n,
 	}
 
 	for _, s := range n.Sigs {
 		if s.Hash == logVerifier.KeyHash() && s.Name == logVerifier.Name() {
 			// The log has signed this checkpoint. It is now safe to parse.
 			cp := &Checkpoint{}
-			if _, err := cp.Unmarshal([]byte(n.Text)); err != nil {
-				return nil, n, fmt.Errorf("failed to unmarshal checkpoint: %v", err)
+			if cn.OtherData, err = cp.Unmarshal([]byte(n.Text)); err != nil {
+				return nil, cn, fmt.Errorf("failed to unmarshal checkpoint: %v", err)
 			}
 			if cp.Origin != origin {
-				return nil, n, fmt.Errorf("got Origin %q but expected %q", cp.Origin, origin)
+				return nil, cn, fmt.Errorf("got Origin %q but expected %q", cp.Origin, origin)
 			}
-			return cp, n, nil
+			return cp, cn, nil
 		}
 	}
-	return nil, n, fmt.Errorf("no log signature found on note")
+	return nil, cn, fmt.Errorf("no log signature found on note")
 }

--- a/formats/log/note_test.go
+++ b/formats/log/note_test.go
@@ -184,13 +184,13 @@ func TestParseCheckpoint(t *testing.T) {
 			}
 
 			// Now parse what we have created.
-			cn, err := log.ParseCheckpoint(nBs, test.logID, logVerifier, known1Verifier, known2Verifier)
+			_, _, n, err := log.ParseCheckpoint(nBs, test.logID, logVerifier, known1Verifier, known2Verifier)
 			if gotErr := err != nil; gotErr != test.wantErr {
 				t.Errorf("gotErr %t != wantErr %t (%v)", gotErr, test.wantErr, err)
 			}
 			gotSigs := 0
-			if cn != nil {
-				gotSigs = len(cn.Sigs)
+			if n != nil {
+				gotSigs = len(n.Sigs)
 			}
 			if gotSigs != test.wantSigs {
 				t.Errorf("got %d signatures but wanted %d", gotSigs, test.wantSigs)
@@ -228,12 +228,12 @@ mb8QLQIs0Z0yP5Cstq6guj87oXWeC9gEM8oVikmm9Wk=
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			cn, err := log.ParseCheckpoint([]byte(noteString), test.logID, logVerifier)
+			cp, _, _, err := log.ParseCheckpoint([]byte(noteString), test.logID, logVerifier)
 			if err != nil {
 				if !test.wantErr {
 					t.Fatalf("Failed to parse checkpoint note: %v", err)
 				}
-				if cp := cn.Checkpoint; cp != nil {
+				if cp != nil {
 					t.Errorf("Expected empty checkpoint because of error but got %+v", cp)
 				}
 				// Always return after error because remaining checks are for cp, which is nil.
@@ -242,7 +242,6 @@ mb8QLQIs0Z0yP5Cstq6guj87oXWeC9gEM8oVikmm9Wk=
 			if test.wantErr {
 				t.Fatal("Expected error but didn't get it")
 			}
-			cp := cn.Checkpoint
 			if got, want := cp.Size, uint64(6476701); got != want {
 				t.Errorf("expected size %d but got %d", want, got)
 			}
@@ -323,7 +322,7 @@ mb8QLQIs0Z0yP5Cstq6guj87oXWeC9gEM8oVikmm9Wk=
 				note = fmt.Sprintf("%s%s\n", note, s)
 			}
 			for n := 0; n < b.N; n++ {
-				if _, err := log.ParseCheckpoint([]byte(note), "go.sum database tree", logVerifier, vs...); err != nil {
+				if _, _, _, err := log.ParseCheckpoint([]byte(note), "go.sum database tree", logVerifier, vs...); err != nil {
 					b.Fatalf("Failed to parse: %v", err)
 				}
 			}

--- a/formats/log/note_test.go
+++ b/formats/log/note_test.go
@@ -184,13 +184,13 @@ func TestParseCheckpoint(t *testing.T) {
 			}
 
 			// Now parse what we have created.
-			_, n, err := log.ParseCheckpoint(nBs, test.logID, logVerifier, known1Verifier, known2Verifier)
+			cn, err := log.ParseCheckpoint(nBs, test.logID, logVerifier, known1Verifier, known2Verifier)
 			if gotErr := err != nil; gotErr != test.wantErr {
 				t.Errorf("gotErr %t != wantErr %t (%v)", gotErr, test.wantErr, err)
 			}
 			gotSigs := 0
-			if n != nil {
-				gotSigs = len(n.Sigs)
+			if cn != nil {
+				gotSigs = len(cn.Sigs)
 			}
 			if gotSigs != test.wantSigs {
 				t.Errorf("got %d signatures but wanted %d", gotSigs, test.wantSigs)
@@ -228,12 +228,12 @@ mb8QLQIs0Z0yP5Cstq6guj87oXWeC9gEM8oVikmm9Wk=
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			cp, _, err := log.ParseCheckpoint([]byte(noteString), test.logID, logVerifier)
+			cn, err := log.ParseCheckpoint([]byte(noteString), test.logID, logVerifier)
 			if err != nil {
 				if !test.wantErr {
 					t.Fatalf("Failed to parse checkpoint note: %v", err)
 				}
-				if cp != nil {
+				if cp := cn.Checkpoint; cp != nil {
 					t.Errorf("Expected empty checkpoint because of error but got %+v", cp)
 				}
 				// Always return after error because remaining checks are for cp, which is nil.
@@ -242,6 +242,7 @@ mb8QLQIs0Z0yP5Cstq6guj87oXWeC9gEM8oVikmm9Wk=
 			if test.wantErr {
 				t.Fatal("Expected error but didn't get it")
 			}
+			cp := cn.Checkpoint
 			if got, want := cp.Size, uint64(6476701); got != want {
 				t.Errorf("expected size %d but got %d", want, got)
 			}
@@ -322,7 +323,7 @@ mb8QLQIs0Z0yP5Cstq6guj87oXWeC9gEM8oVikmm9Wk=
 				note = fmt.Sprintf("%s%s\n", note, s)
 			}
 			for n := 0; n < b.N; n++ {
-				if _, _, err := log.ParseCheckpoint([]byte(note), "go.sum database tree", logVerifier, vs...); err != nil {
+				if _, err := log.ParseCheckpoint([]byte(note), "go.sum database tree", logVerifier, vs...); err != nil {
 					b.Fatalf("Failed to parse: %v", err)
 				}
 			}

--- a/helloworld/client.go
+++ b/helloworld/client.go
@@ -80,10 +80,11 @@ func (c Client) VerIncl(entry []byte, pf *trillian.Proof) bool {
 // case it would be important for the client to check the signature contained
 // in the checkpoint before verifying consistency.
 func (c *Client) UpdateChkpt(chkptNewRaw personality.SignedCheckpoint, pf *trillian.Proof) error {
-	chkptNew, _, err := log.ParseCheckpoint(chkptNewRaw, "Hello World Log", c.sigVerifier)
+	cn, err := log.ParseCheckpoint(chkptNewRaw, "Hello World Log", c.sigVerifier)
 	if err != nil {
 		return fmt.Errorf("failed to verify checkpoint: %w", err)
 	}
+	chkptNew := cn.Checkpoint
 	// If there is no checkpoint then just use this one no matter what.
 	if c.chkpt.Size != 0 {
 		// Else make sure this new checkpoint is consistent with the current one.

--- a/helloworld/client.go
+++ b/helloworld/client.go
@@ -80,11 +80,10 @@ func (c Client) VerIncl(entry []byte, pf *trillian.Proof) bool {
 // case it would be important for the client to check the signature contained
 // in the checkpoint before verifying consistency.
 func (c *Client) UpdateChkpt(chkptNewRaw personality.SignedCheckpoint, pf *trillian.Proof) error {
-	cn, err := log.ParseCheckpoint(chkptNewRaw, "Hello World Log", c.sigVerifier)
+	chkptNew, _, _, err := log.ParseCheckpoint(chkptNewRaw, "Hello World Log", c.sigVerifier)
 	if err != nil {
 		return fmt.Errorf("failed to verify checkpoint: %w", err)
 	}
-	chkptNew := cn.Checkpoint
 	// If there is no checkpoint then just use this one no matter what.
 	if c.chkpt.Size != 0 {
 		// Else make sure this new checkpoint is consistent with the current one.

--- a/helloworld/helloworld_test.go
+++ b/helloworld/helloworld_test.go
@@ -61,11 +61,11 @@ func mustGetVerifier(t *testing.T) note.Verifier {
 
 func mustOpenCheckpoint(t *testing.T, cRaw []byte) *log.Checkpoint {
 	t.Helper()
-	cn, err := log.ParseCheckpoint(cRaw, "Hello World Log", mustGetVerifier(t))
+	cp, _, _, err := log.ParseCheckpoint(cRaw, "Hello World Log", mustGetVerifier(t))
 	if err != nil {
 		t.Fatalf("Failed to open checkpoint: %q", err)
 	}
-	return cn.Checkpoint
+	return cp
 }
 
 // TestAppend appends a random entry to the log and ensures that the

--- a/helloworld/helloworld_test.go
+++ b/helloworld/helloworld_test.go
@@ -61,11 +61,11 @@ func mustGetVerifier(t *testing.T) note.Verifier {
 
 func mustOpenCheckpoint(t *testing.T, cRaw []byte) *log.Checkpoint {
 	t.Helper()
-	cp, _, err := log.ParseCheckpoint(cRaw, "Hello World Log", mustGetVerifier(t))
+	cn, err := log.ParseCheckpoint(cRaw, "Hello World Log", mustGetVerifier(t))
 	if err != nil {
 		t.Fatalf("Failed to open checkpoint: %q", err)
 	}
-	return cp
+	return cn.Checkpoint
 }
 
 // TestAppend appends a random entry to the log and ensures that the

--- a/sumdbaudit/witness/cmd/feeder/main.go
+++ b/sumdbaudit/witness/cmd/feeder/main.go
@@ -72,10 +72,11 @@ func main() {
 			glog.Exitf("Failed to get witness checkpoint: %v", err)
 		}
 	} else {
-		wcp, _, err = log.ParseCheckpoint(wcpRaw, *origin, w.Verifier)
+		cn, err := log.ParseCheckpoint(wcpRaw, *origin, w.Verifier)
 		if err != nil {
 			glog.Exitf("Failed to open CP: %v", err)
 		}
+		wcp = cn.Checkpoint
 	}
 
 	feeder := feeder{
@@ -154,10 +155,11 @@ func (f *feeder) feedOnce(ctx context.Context) error {
 	// An optimization would be to immediately retry the Update if we get
 	// http.ErrCheckpointTooOld. For now, we'll update the local state and
 	// retry only the next time this method is called.
-	f.wcp, _, err = log.ParseCheckpoint(wcpRaw, *origin, f.w.Verifier)
+	cn, err := log.ParseCheckpoint(wcpRaw, *origin, f.w.Verifier)
 	if err != nil {
 		return fmt.Errorf("failed to parse checkpoint: %v", err)
 	}
+	f.wcp = cn.Checkpoint
 	return nil
 }
 

--- a/sumdbaudit/witness/cmd/feeder/main.go
+++ b/sumdbaudit/witness/cmd/feeder/main.go
@@ -72,11 +72,10 @@ func main() {
 			glog.Exitf("Failed to get witness checkpoint: %v", err)
 		}
 	} else {
-		cn, err := log.ParseCheckpoint(wcpRaw, *origin, w.Verifier)
+		wcp, _, _, err = log.ParseCheckpoint(wcpRaw, *origin, w.Verifier)
 		if err != nil {
 			glog.Exitf("Failed to open CP: %v", err)
 		}
-		wcp = cn.Checkpoint
 	}
 
 	feeder := feeder{
@@ -155,11 +154,10 @@ func (f *feeder) feedOnce(ctx context.Context) error {
 	// An optimization would be to immediately retry the Update if we get
 	// http.ErrCheckpointTooOld. For now, we'll update the local state and
 	// retry only the next time this method is called.
-	cn, err := log.ParseCheckpoint(wcpRaw, *origin, f.w.Verifier)
+	f.wcp, _, _, err = log.ParseCheckpoint(wcpRaw, *origin, f.w.Verifier)
 	if err != nil {
 		return fmt.Errorf("failed to parse checkpoint: %v", err)
 	}
-	f.wcp = cn.Checkpoint
 	return nil
 }
 


### PR DESCRIPTION
This change identified a few tests that were still passing using the old origin string that was replaced in #470. I think this is compelling that reusing the same parsing code reduces bugs.