### PR TITLE
[Serverless] Simplify to one witness per feeder

### DIFF
--- a/serverless/cmd/feeder/impl/feeder_test.go
+++ b/serverless/cmd/feeder/impl/feeder_test.go
@@ -37,70 +37,50 @@ func TestFeed(t *testing.T) {
 	witSig := mustCreateSigner(t, testWitnessSecretKey)
 	witSigV := mustCreateVerifier(t, testWitnessPublicKey)
 	for _, test := range []struct {
-		desc        string
-		submitCP    []byte
-		numRequired int
-		witnesses   []Witness
-		wantErr     bool
+		desc     string
+		submitCP []byte
+		witness  Witness
+		wantErr  bool
 	}{
 		{
-			desc:        "works",
-			submitCP:    testdata.Checkpoint(t, 2),
-			numRequired: 1,
-			witnesses: []Witness{
-				&fakeWitness{
-					logSigV:  logSigV,
-					witSig:   witSig,
-					witSigV:  witSigV,
-					latestCP: mustCosignCP(t, testdata.Checkpoint(t, 1), logSigV, witSig),
-				},
+			desc:     "works",
+			submitCP: testdata.Checkpoint(t, 2),
+			witness: &fakeWitness{
+				logSigV:  logSigV,
+				witSig:   witSig,
+				witSigV:  witSigV,
+				latestCP: mustCosignCP(t, testdata.Checkpoint(t, 1), logSigV, witSig),
 			},
 		}, {
-			desc:        "works - submitCP == latest",
-			submitCP:    testdata.Checkpoint(t, 1),
-			numRequired: 1,
-			witnesses: []Witness{
-				&fakeWitness{
-					logSigV:  logSigV,
-					witSig:   witSig,
-					witSigV:  witSigV,
-					latestCP: mustCosignCP(t, testdata.Checkpoint(t, 1), logSigV, witSig),
-				},
+			desc:     "works - submitCP == latest",
+			submitCP: testdata.Checkpoint(t, 1),
+			witness: &fakeWitness{
+				logSigV:  logSigV,
+				witSig:   witSig,
+				witSigV:  witSigV,
+				latestCP: mustCosignCP(t, testdata.Checkpoint(t, 1), logSigV, witSig),
 			},
 		}, {
-			desc:        "no new sigs added",
-			submitCP:    mustCosignCP(t, testdata.Checkpoint(t, 1), logSigV, witSig),
-			numRequired: 1,
-			witnesses: []Witness{
-				&fakeWitness{
-					logSigV:  logSigV,
-					witSig:   witSig,
-					witSigV:  witSigV,
-					latestCP: mustCosignCP(t, testdata.Checkpoint(t, 1), logSigV, witSig),
-				},
+			desc:     "no new sigs added",
+			submitCP: mustCosignCP(t, testdata.Checkpoint(t, 1), logSigV, witSig),
+			witness: &fakeWitness{
+				logSigV:  logSigV,
+				witSig:   witSig,
+				witSigV:  witSigV,
+				latestCP: mustCosignCP(t, testdata.Checkpoint(t, 1), logSigV, witSig),
 			},
 			wantErr: true,
 		}, {
 			desc:    "submitting stale CP",
 			wantErr: true,
 			// This checkpoint is older than the witness' latestCP below:
-			submitCP:    testdata.Checkpoint(t, 1),
-			numRequired: 1,
-			witnesses: []Witness{
-				&fakeWitness{
-					logSigV:  logSigV,
-					witSig:   witSig,
-					witSigV:  witSigV,
-					latestCP: mustCosignCP(t, testdata.Checkpoint(t, 2), logSigV, witSig),
-				},
+			submitCP: testdata.Checkpoint(t, 1),
+			witness: &fakeWitness{
+				logSigV:  logSigV,
+				witSig:   witSig,
+				witSigV:  witSigV,
+				latestCP: mustCosignCP(t, testdata.Checkpoint(t, 2), logSigV, witSig),
 			},
-		}, {
-			desc:    "invalid opts - numRequired > num witnesses",
-			wantErr: true,
-			// Whoops:
-			numRequired: 100,
-			submitCP:    testdata.Checkpoint(t, 1),
-			witnesses:   []Witness{&fakeWitness{}},
 		},
 	} {
 		sCP := mustOpenCheckpoint(t, test.submitCP, testdata.LogSigVerifier(t))
@@ -108,8 +88,7 @@ func TestFeed(t *testing.T) {
 		opts := FeedOpts{
 			LogFetcher:     f.Fetcher(),
 			LogSigVerifier: testdata.LogSigVerifier(t),
-			NumRequired:    test.numRequired,
-			Witnesses:      test.witnesses,
+			Witness:        test.witness,
 		}
 		t.Run(test.desc, func(t *testing.T) {
 			_, err := Feed(ctx, test.submitCP, opts)

--- a/serverless/cmd/feeder/main.go
+++ b/serverless/cmd/feeder/main.go
@@ -43,7 +43,6 @@ var (
 )
 
 type WitnessConfig struct {
-	Name      string `json:"name"`
 	URL       string `json:"url"`
 	PublicKey string `json:"public_key"`
 }
@@ -56,11 +55,8 @@ type Config struct {
 	LogPublicKey string `json:"log_public_key"`
 	// LogURL is the URL of the root of the log.
 	LogURL string `json:"log_url"`
-	// Witnesses is a list of all configured witnesses.
-	Witnesses []WitnessConfig `json:"witnesses"`
-	// NumRequired is the minimum number of cosignatures required for a feeding run
-	// to be considered successful.
-	NumRequired int `json:"num_required"`
+	// Witnesses is the configured witness.
+	Witness WitnessConfig `json:"witness"`
 }
 
 func main() {
@@ -83,17 +79,14 @@ func main() {
 		LogID:          cfg.LogID,
 		LogFetcher:     f,
 		LogSigVerifier: mustCreateVerifier(cfg.LogPublicKey),
-		NumRequired:    cfg.NumRequired,
 	}
-	for _, w := range cfg.Witnesses {
-		u, err := url.Parse(w.URL)
-		if err != nil {
-			glog.Exitf("Failed to parse witness URL %q: %v", w.URL, err)
-		}
-		opts.Witnesses = append(opts.Witnesses, wit_http.Witness{
-			URL:      u,
-			Verifier: mustCreateVerifier(w.PublicKey),
-		})
+	u, err := url.Parse(cfg.Witness.URL)
+	if err != nil {
+		glog.Exitf("Failed to parse witness URL %q: %v", cfg.Witness.URL, err)
+	}
+	opts.Witness = wit_http.Witness{
+		URL:      u,
+		Verifier: mustCreateVerifier(cfg.Witness.PublicKey),
 	}
 
 	cp, err := readCP(ctx, *input)


### PR DESCRIPTION
Keep things simple for the moment, we can re-add support for 1:N later if need be.