### PR TITLE
Witness: move expected Origin to log config

### DIFF
--- a/sumdbaudit/witness/witness.config
+++ b/sumdbaudit/witness/witness.config
@@ -3,6 +3,7 @@
         {
             "hashStrategy": "default",
             "logID": "sumdb",
+            "origin": "go.sum database tree",
             "pubKey": "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8",
             "useCompact": true
         }

--- a/witness/golang/README.md
+++ b/witness/golang/README.md
@@ -28,6 +28,7 @@ can be found in the `cmd/witness` directory), with the following flags:
   sample configuration file is at `cmd/witness/example.conf`, and in general it
   is necessary to specify the following fields for each log:
     - `logID`, which is the identifier for the log.
+    - `origin`, which is the expected first line of the checkpoint from this log.
     - `pubKey`, which is the public key of the log.  Given the current reliance on the Go [note format](https://pkg.go.dev/golang.org/x/exp/sumdb@v0.0.2/internal/note), the witness supports only Ed25519 signatures.
     - `hashStrategy`, which is the way in which recursive hashes are formed in the verifiable log.  The witness currently supports only `default` for this field.
     - `useCompact`, which is a boolean indicating if the log proves consistency via "regular" consistency proofs, in which case the witness stores only the latest checkpoint in its database, or via compact ranges, in which case the witness stores the latest checkpoint and compact range.

--- a/witness/golang/cmd/witness/example.conf
+++ b/witness/golang/cmd/witness/example.conf
@@ -3,6 +3,7 @@
         {
             "hashStrategy": "default",
             "logID": "testlog",
+            "origin": "origin string (first line of checkpoint)",
             "pubKey": "testlog+b69ecd61+AXCbEtyrQUhoUcMV/fZz905iDDoe7UAq3X0oD5ZUVyMS",
             "useCompact": false
         }

--- a/witness/golang/cmd/witness/impl/witness.go
+++ b/witness/golang/cmd/witness/impl/witness.go
@@ -40,6 +40,7 @@ type LogConfig struct {
 // strategy, and public key.
 type LogInfo struct {
 	LogID        string `json:"logID"`
+	Origin       string `json:"origin"`
 	HashStrategy string `json:"hashStrategy"`
 	PubKey       string `json:"pubKey"`
 	UseCompact   bool   `json:"useCompact"`
@@ -70,9 +71,9 @@ func buildLogMap(config LogConfig) (map[string]witness.LogInfo, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create signature verifier: %v", err)
 		}
-		sigVs := []note.Verifier{logV}
 		logInfo := witness.LogInfo{
-			SigVs:      sigVs,
+			SigV:       logV,
+			Origin:     log.Origin,
 			Hasher:     h,
 			UseCompact: log.UseCompact,
 		}

--- a/witness/golang/cmd/witness/internal/http/server_test.go
+++ b/witness/golang/cmd/witness/internal/http/server_test.go
@@ -62,8 +62,11 @@ var (
 	}
 )
 
+const logOrigin = "Log Checkpoint v0"
+
 type logOpts struct {
 	ID         string
+	origin     string
 	PK         string
 	useCompact bool
 }
@@ -81,9 +84,9 @@ func newWitness(t *testing.T, d *sql.DB, logs []logOpts) *witness.Witness {
 		if err != nil {
 			t.Fatalf("couldn't create a log verifier: %v", err)
 		}
-		sigV := []note.Verifier{logV}
 		logInfo := witness.LogInfo{
-			SigVs:      sigV,
+			Origin:     log.origin,
+			SigV:       logV,
 			Hasher:     h,
 			UseCompact: log.useCompact,
 		}
@@ -168,7 +171,9 @@ func TestGetLogs(t *testing.T) {
 			// Set up witness and give it some checkpoints.
 			logs := make([]logOpts, len(test.logIDs))
 			for i, logID := range test.logIDs {
-				logs[i] = logOpts{ID: logID,
+				logs[i] = logOpts{
+					ID:         logID,
+					origin:     logOrigin,
 					PK:         test.logPKs[i],
 					useCompact: false,
 				}
@@ -253,7 +258,9 @@ func TestGetChkpt(t *testing.T) {
 			defer closeFn()
 			ctx := context.Background()
 			// Set up witness.
-			w := newWitness(t, d, []logOpts{{ID: test.setID,
+			w := newWitness(t, d, []logOpts{{
+				ID:         test.setID,
+				origin:     logOrigin,
 				PK:         test.setPK,
 				useCompact: false}})
 			// Set a checkpoint for the log if we want to for this test.
@@ -349,7 +356,9 @@ func TestUpdate(t *testing.T) {
 			ctx := context.Background()
 			logID := "monkeys"
 			// Set up witness.
-			w := newWitness(t, d, []logOpts{{ID: logID,
+			w := newWitness(t, d, []logOpts{{
+				ID:         logID,
+				origin:     logOrigin,
 				PK:         mPK,
 				useCompact: test.useCR}})
 			// Set an initial checkpoint for the log.

--- a/witness/golang/cmd/witness/internal/witness/witness_test.go
+++ b/witness/golang/cmd/witness/internal/witness/witness_test.go
@@ -60,8 +60,11 @@ var (
 	_ = bSK
 )
 
+const logOrigin = "Log Checkpoint v0"
+
 type logOpts struct {
 	ID         string
+	origin     string
 	PK         string
 	useCompact bool
 }
@@ -79,9 +82,9 @@ func newWitness(t *testing.T, d *sql.DB, logs []logOpts) *Witness {
 		if err != nil {
 			t.Fatalf("couldn't create a log verifier: %v", err)
 		}
-		sigV := []note.Verifier{logV}
 		logInfo := LogInfo{
-			SigVs:      sigV,
+			Origin:     log.origin,
+			SigV:       logV,
 			Hasher:     h,
 			UseCompact: log.useCompact,
 		}
@@ -150,7 +153,9 @@ func TestGetLogs(t *testing.T) {
 			// Set up witness.
 			logs := make([]logOpts, len(test.logIDs))
 			for i, logID := range test.logIDs {
-				logs[i] = logOpts{ID: logID,
+				logs[i] = logOpts{
+					ID:         logID,
+					origin:     logOrigin,
 					PK:         test.logPKs[i],
 					useCompact: false,
 				}
@@ -221,7 +226,9 @@ func TestGetChkpt(t *testing.T) {
 			defer closeFn()
 			ctx := context.Background()
 			// Set up witness.
-			w := newWitness(t, d, []logOpts{{ID: test.setID,
+			w := newWitness(t, d, []logOpts{{
+				ID:         test.setID,
+				origin:     logOrigin,
 				PK:         test.setPK,
 				useCompact: false}})
 			// Set a checkpoint for the log if we want to for this test.
@@ -340,7 +347,9 @@ func TestUpdate(t *testing.T) {
 			ctx := context.Background()
 			logID := "monkeys"
 			// Set up witness.
-			w := newWitness(t, d, []logOpts{{ID: logID,
+			w := newWitness(t, d, []logOpts{{
+				ID:         logID,
+				origin:     logOrigin,
 				PK:         mPK,
 				useCompact: test.useCR}})
 			// Set an initial checkpoint for the log.


### PR DESCRIPTION
Previously the Origin was only determined when the first checkpoint was provided for a log. That isn't wrong per se, but the Origin should be set at the same time as the public key. This also allows the witness code to reuse the common checkpoint parsing code.
