### PR TITLE
[Serverless] Add support for witness/distributor in client

### DIFF
--- a/serverless/client/witness/consensus.go
+++ b/serverless/client/witness/consensus.go
@@ -1,0 +1,103 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package witness provides client support for using witnesses.
+package witness
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/formats/log"
+	"github.com/google/trillian-examples/serverless/client"
+	"golang.org/x/mod/sumdb/note"
+)
+
+// CheckpointNConsensus returns a ConsensusCheckpoint function which selects the newest checkpoint available from
+// the available distributors which has signatures from at least N of the provided witnesses.
+func CheckpointNConsensus(logID string, distributors []client.Fetcher, witnesses []note.Verifier, N int) client.ConsensusCheckpoint {
+	// TODO(al): This implementation is pretty basic, and could be made better.
+	// In particular, there are cases where it will fail to build consensus
+	// where a more thorough algorithm would succeed.
+	// e.g. currently, it will simply fetch  checkpoint.N from each of the
+	// distributors and fail if either:
+	//  - no distributor has a checkpoint.N file
+	//  - no distributor has a checkpoint.N file signed by N of the known witnesses.
+	//
+	// It's good enough for now, though.
+	return func(ctx context.Context, logSigV note.Verifier, origin string) (*log.Checkpoint, []byte, error) {
+		type cp struct {
+			cp  *log.Checkpoint
+			n   *note.Note
+			raw []byte
+		}
+		cpc := make(chan cp, len(distributors))
+		wg := &sync.WaitGroup{}
+		for _, f := range distributors {
+			wg.Add(1)
+			go func(ctx context.Context, f client.Fetcher, logID string, N int, cpc chan<- cp) {
+				defer wg.Done()
+				c, n, cpRaw, err := getCheckpointN(ctx, f, logID, N, logSigV, origin, witnesses)
+				if err != nil {
+					glog.Infof("Error talking to distributor: %v", err)
+					return
+				}
+				cpc <- cp{
+					cp:  c,
+					n:   n,
+					raw: cpRaw,
+				}
+
+			}(ctx, f, logID, N, cpc)
+		}
+
+		wg.Wait()
+		close(cpc)
+
+		glog.Infof("considering %d cps", len(cpc))
+
+		var bestCP cp
+		for cp := range cpc {
+			if numWitSigs := len(cp.n.Sigs) - 1; numWitSigs < N {
+				glog.V(1).Infof("Discarding CP with %d witness sigs, want at least %d", numWitSigs, N)
+				continue
+			}
+			if bestCP.cp == nil || bestCP.cp.Size < cp.cp.Size {
+				bestCP = cp
+				continue
+			}
+		}
+		if bestCP.cp == nil {
+			return nil, nil, fmt.Errorf("unable to identify suitable checkpoint")
+		}
+		return bestCP.cp, bestCP.raw, nil
+
+	}
+}
+
+func getCheckpointN(ctx context.Context, f client.Fetcher, logID string, N int, logSigV note.Verifier, origin string, witSigVs []note.Verifier) (*log.Checkpoint, *note.Note, []byte, error) {
+	p := path.Join("logs", logID, fmt.Sprintf("checkpoint.%d", N))
+	cpRaw, err := f(ctx, p)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to fetch from distributor: %v", err)
+	}
+	cp, _, n, err := log.ParseCheckpoint(cpRaw, origin, logSigV, witSigVs...)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("error parsing Checkpoint from %q: %v", p, err)
+	}
+	return cp, n, cpRaw, nil
+}

--- a/serverless/client/witness/consensus.go
+++ b/serverless/client/witness/consensus.go
@@ -32,7 +32,7 @@ import (
 func CheckpointNConsensus(logID string, distributors []client.Fetcher, witnesses []note.Verifier, N int) (client.ConsensusCheckpointFunc, error) {
 
 	if nw := len(witnesses); N > nw {
-		return nil, fmt.Errorf("requeste consensus across %d witnesses, but only %d witnesses configured - consensus would always fail!", N, nw)
+		return nil, fmt.Errorf("requested consensus across %d witnesses, but only %d witnesses configured - consensus would always fail", N, nw)
 	}
 
 	// TODO(al): This implementation is pretty basic, and could be made better.

--- a/serverless/client/witness/consensus_test.go
+++ b/serverless/client/witness/consensus_test.go
@@ -1,0 +1,199 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package witness
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/formats/log"
+	"github.com/google/trillian-examples/serverless/client"
+	"golang.org/x/mod/sumdb/note"
+)
+
+const (
+	testOrigin = "test-origin"
+)
+
+func TestCheckpointNConsensus(t *testing.T) {
+	logS, logV := genKeyPair(t, "log")
+	wit1S, wit1V := genKeyPair(t, "w1")
+	wit2S, wit2V := genKeyPair(t, "w2")
+	wit3S, wit3V := genKeyPair(t, "w3")
+	logID := "test-log"
+	checkpointPath := func(i int) string { return fmt.Sprintf("logs/%s/checkpoint.%d", logID, i) }
+
+	for _, test := range []struct {
+		desc         string
+		logID        string
+		distributors []client.Fetcher
+		witnesses    []note.Verifier
+		N            int
+		wantErr      bool
+		wantCP       []byte
+	}{
+		{
+			desc:  "works N=1",
+			logID: logID,
+			N:     2,
+			distributors: []client.Fetcher{
+				fetcher(map[string][]byte{
+					checkpointPath(2): newCP(t, 11, logS, wit1S, wit2S, wit3S),
+				}),
+			},
+			witnesses: []note.Verifier{wit1V, wit2V, wit3V},
+			wantCP:    newCP(t, 11, logS, wit1S, wit2S, wit3S),
+		},
+		{
+			desc:  "works N=3",
+			logID: logID,
+			N:     3,
+			distributors: []client.Fetcher{
+				fetcher(map[string][]byte{
+					checkpointPath(3): newCP(t, 11, logS, wit1S, wit2S, wit3S),
+				}),
+			},
+			witnesses: []note.Verifier{wit1V, wit2V, wit3V},
+			wantCP:    newCP(t, 11, logS, wit1S, wit2S, wit3S),
+		},
+		{
+			desc:  "largest CP across distributors",
+			logID: logID,
+			N:     2,
+			distributors: []client.Fetcher{
+				fetcher(map[string][]byte{
+					checkpointPath(2): newCP(t, 11, logS, wit1S, wit2S, wit3S),
+				}),
+				fetcher(map[string][]byte{
+					checkpointPath(2): newCP(t, 15, logS, wit1S, wit2S, wit3S),
+				}),
+			},
+			witnesses: []note.Verifier{wit1V, wit2V, wit3V},
+			wantCP:    newCP(t, 15, logS, wit1S, wit2S, wit3S),
+		},
+		{
+			desc:  "largest CP with required sigs",
+			logID: logID,
+			N:     2,
+			distributors: []client.Fetcher{
+				fetcher(map[string][]byte{
+					checkpointPath(2): newCP(t, 11, logS, wit1S, wit2S, wit3S),
+				}),
+				fetcher(map[string][]byte{
+					checkpointPath(2): newCP(t, 15, logS, wit1S),
+				}),
+			},
+			witnesses: []note.Verifier{wit1V, wit2V, wit3V},
+			wantCP:    newCP(t, 11, logS, wit1S, wit2S, wit3S),
+		},
+		{
+			desc:  "err: no files",
+			logID: logID,
+			N:     2,
+			distributors: []client.Fetcher{
+				fetcher(map[string][]byte{}),
+				fetcher(map[string][]byte{}),
+			},
+			witnesses: []note.Verifier{wit1V, wit2V, wit3V},
+			wantErr:   true,
+		},
+		{
+			desc:  "err: unsatisfiable - not enough sigs",
+			logID: logID,
+			N:     20,
+			distributors: []client.Fetcher{
+				fetcher(map[string][]byte{
+					checkpointPath(20): newCP(t, 11, logS, wit1S, wit2S, wit3S),
+				}),
+			},
+			witnesses: []note.Verifier{wit1V, wit2V, wit3V},
+			wantErr:   true,
+		},
+		{
+			desc:  "err: unsatisfiable - unknown witnesses",
+			logID: logID,
+			N:     2,
+			distributors: []client.Fetcher{
+				fetcher(map[string][]byte{
+					checkpointPath(2): newCP(t, 11, logS, wit1S, wit2S, wit3S),
+				}),
+			},
+			witnesses: []note.Verifier{wit1V},
+			wantErr:   true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			f := CheckpointNConsensus(test.logID, test.distributors, test.witnesses, test.N)
+			_, raw, err := f(context.Background(), logV, testOrigin)
+			gotErr := err != nil
+			if gotErr != test.wantErr {
+				t.Errorf("Got err: %v, want err: %v", err, test.wantErr)
+			}
+			if got, want := string(raw), string(test.wantCP); got != want {
+				t.Errorf("got CP:\n%s\nWant:\n%s", got, want)
+			}
+		})
+		glog.Flush()
+	}
+}
+
+func fetcher(m map[string][]byte) client.Fetcher {
+	mf := mapFetcher(m)
+	return mf.Fetch
+}
+
+type mapFetcher map[string][]byte
+
+func (f mapFetcher) Fetch(_ context.Context, p string) ([]byte, error) {
+	v, ok := f[p]
+	if !ok {
+		return nil, fmt.Errorf("%q: %v", p, os.ErrNotExist)
+	}
+	return v, nil
+}
+
+func newCP(t *testing.T, size int, sigs ...note.Signer) []byte {
+	t.Helper()
+	cp := log.Checkpoint{
+		Origin: testOrigin,
+		Size:   uint64(size),
+		Hash:   []byte("banana"),
+	}
+	ret, err := note.Sign(&note.Note{Text: string(cp.Marshal())}, sigs...)
+	if err != nil {
+		t.Fatalf("Failed to sign note: %v", err)
+	}
+	return ret
+}
+
+func genKeyPair(t *testing.T, name string) (note.Signer, note.Verifier) {
+	t.Helper()
+	sKey, vKey, err := note.GenerateKey(nil, name)
+	if err != nil {
+		t.Fatalf("Failed to generate key %q: %v", name, err)
+	}
+	s, err := note.NewSigner(sKey)
+	if err != nil {
+		t.Fatalf("Failed to create signer %q: %v", name, err)
+	}
+	v, err := note.NewVerifier(vKey)
+	if err != nil {
+		t.Fatalf("Failed to create verifier %q: %v", name, err)
+	}
+	return s, v
+}

--- a/serverless/client/witness/consensus_test.go
+++ b/serverless/client/witness/consensus_test.go
@@ -115,10 +115,10 @@ func TestCheckpointNConsensus(t *testing.T) {
 		{
 			desc:  "err: unsatisfiable - not enough sigs",
 			logID: logID,
-			N:     20,
+			N:     3,
 			distributors: []client.Fetcher{
 				fetcher(map[string][]byte{
-					checkpointPath(20): newCP(t, 11, logS, wit1S, wit2S, wit3S),
+					checkpointPath(20): newCP(t, 11, logS, wit1S),
 				}),
 			},
 			witnesses: []note.Verifier{wit1V, wit2V, wit3V},
@@ -130,15 +130,18 @@ func TestCheckpointNConsensus(t *testing.T) {
 			N:     2,
 			distributors: []client.Fetcher{
 				fetcher(map[string][]byte{
-					checkpointPath(2): newCP(t, 11, logS, wit1S, wit2S, wit3S),
+					checkpointPath(2): newCP(t, 11, logS, wit1S, wit2S),
 				}),
 			},
-			witnesses: []note.Verifier{wit1V},
+			witnesses: []note.Verifier{wit1V, wit3V},
 			wantErr:   true,
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			f := CheckpointNConsensus(test.logID, test.distributors, test.witnesses, test.N)
+			f, err := CheckpointNConsensus(test.logID, test.distributors, test.witnesses, test.N)
+			if err != nil {
+				t.Fatalf("CheckpointNConsensus() = %v", err)
+			}
 			_, raw, err := f(context.Background(), logV, testOrigin)
 			gotErr := err != nil
 			if gotErr != test.wantErr {

--- a/serverless/cmd/client/client.go
+++ b/serverless/cmd/client/client.go
@@ -331,13 +331,12 @@ func storeLocalCheckpoint(logID string, cpRaw []byte) error {
 func logSigVerifier(f string) (note.Verifier, error) {
 	if len(f) > 0 {
 		return sigVerifierFromFile(f)
-	} else {
-		pubKey := os.Getenv("SERVERLESS_LOG_PUBLIC_KEY")
-		if len(pubKey) == 0 {
-			return nil, fmt.Errorf("supply public key file path using --log_public_key or set SERVERLESS_LOG_PUBLIC_KEY environment variable")
-		}
-		return note.NewVerifier(pubKey)
 	}
+	pubKey := os.Getenv("SERVERLESS_LOG_PUBLIC_KEY")
+	if len(pubKey) == 0 {
+		return nil, fmt.Errorf("supply public key file path using --log_public_key or set SERVERLESS_LOG_PUBLIC_KEY environment variable")
+	}
+	return note.NewVerifier(pubKey)
 }
 
 func witnessSigVerifiers(fs []string) ([]note.Verifier, error) {

--- a/serverless/cmd/client/client.go
+++ b/serverless/cmd/client/client.go
@@ -65,7 +65,7 @@ func flagStringList(name, usage string) *aString {
 
 var (
 	cacheDir            = flag.String("cache_dir", defaultCacheLocation(), "Where to cache client state for logs, if empty don't store anything locally.")
-	distributorURLs     = flagStringList("distributor_url", "URL identifying the root of a distrbutor (can specify this flag repeatedly)")
+	distributorURLs     = flagStringList("distributor_url", "URL identifying the root of a distributor (can specify this flag repeatedly)")
 	logURL              = flag.String("log_url", "", "Log storage root URL, e.g. file:///path/to/log or https://log.server/and/path")
 	logPubKeyFile       = flag.String("log_public_key", "", "Location of log public key file. If unset, uses the contents of the SERVERLESS_LOG_PUBLIC_KEY environment variable.")
 	logID               = flag.String("log_id", "", "LogID used by distributors.")

--- a/serverless/cmd/client/client.go
+++ b/serverless/cmd/client/client.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/serverless/client"
+	"github.com/google/trillian-examples/serverless/client/witness"
 	"github.com/google/trillian/merkle/logverifier"
 	"github.com/google/trillian/merkle/rfc6962"
 	"golang.org/x/mod/sumdb/note"
@@ -43,11 +44,34 @@ func defaultCacheLocation() string {
 	return fmt.Sprintf("%s/serverless", hd)
 }
 
+// aString is a flag Value which holds multiple strings, allowing the flag to
+// be specified multiple times on the command line.
+type aString []string
+
+func (a *aString) String() string {
+	return fmt.Sprintf("%v", *a)
+}
+
+func (a *aString) Set(v string) error {
+	*a = append(*a, v)
+	return nil
+}
+
+func flagStringList(name, usage string) *aString {
+	r := make(aString, 0)
+	flag.Var(&r, name, usage)
+	return &r
+}
+
 var (
-	logURL     = flag.String("log_url", "", "Log storage root URL, e.g. file:///path/to/log or https://log.server/and/path")
-	cacheDir   = flag.String("cache_dir", defaultCacheLocation(), "Where to cache client state for logs, if empty don't store anything locally.")
-	pubKeyFile = flag.String("public_key", "", "Location of public key file. If unset, uses the contents of the SERVERLESS_LOG_PUBLIC_KEY environment variable.")
-	origin     = flag.String("origin", "", "Expected first line of checkpoints from log.")
+	cacheDir            = flag.String("cache_dir", defaultCacheLocation(), "Where to cache client state for logs, if empty don't store anything locally.")
+	distributorURLs     = flagStringList("distributor_url", "URL identifying the root of a distrbutor (can specify this flag repeatedly")
+	logURL              = flag.String("log_url", "", "Log storage root URL, e.g. file:///path/to/log or https://log.server/and/path")
+	logPubKeyFile       = flag.String("log_public_key", "", "Location of log public key file. If unset, uses the contents of the SERVERLESS_LOG_PUBLIC_KEY environment variable.")
+	logID               = flag.String("log_id", "", "LogID used by distributors.")
+	origin              = flag.String("origin", "", "Expected first line of checkpoints from log.")
+	witnessPubKeyFiles  = flagStringList("witness_public_key", "File containing witness public key (can specify this flag repeatedly")
+	witnessSigsRequired = flag.Int("witness_sigs_required", 0, "Minimum number of witness signatures required for consensus")
 )
 
 func usage() {
@@ -61,19 +85,9 @@ func main() {
 	flag.Parse()
 	ctx := context.Background()
 
-	// Read log public key from file or environment variable
-	var pubKey string
-	if len(*pubKeyFile) > 0 {
-		k, err := ioutil.ReadFile(*pubKeyFile)
-		if err != nil {
-			glog.Exitf("failed to read public_key file: %q", err)
-		}
-		pubKey = string(k)
-	} else {
-		pubKey = os.Getenv("SERVERLESS_LOG_PUBLIC_KEY")
-		if len(pubKey) == 0 {
-			glog.Exit("supply public key file path using --public_key or set SERVERLESS_LOG_PUBLIC_KEY environment variable")
-		}
+	logSigV, err := logSigVerifier(*logPubKeyFile)
+	if err != nil {
+		glog.Exitf("failed to read log public key: %v", err)
 	}
 
 	if len(*logURL) == 0 {
@@ -82,20 +96,28 @@ func main() {
 
 	rootURL, err := url.Parse(*logURL)
 	if err != nil {
-		glog.Exitf("Invalid log URL: %q", err)
+		glog.Exitf("Invalid log URL: %v", err)
 	}
 
-	// Derive logID from log public key
-	v, err := note.NewVerifier(pubKey)
+	logID := *logID
+	witnesses, err := witnessSigVerifiers(*witnessPubKeyFiles)
 	if err != nil {
-		glog.Exitf("Failed to instantiate Verifier : %q", err)
+		glog.Exitf("Failed to read witness pub keys: %v", err)
 	}
-	logID := fmt.Sprintf("%d", v.KeyHash())
+
+	if want, got := *witnessSigsRequired, len(witnesses); want > got {
+		glog.Exitf("--witness_sigs_required=%d but only %d witnesses configured", want, got)
+	}
+
+	distribs, err := distributors()
+	if err != nil {
+		glog.Exitf("Failed to create distributors list: %v", err)
+	}
 
 	f := newFetcher(rootURL)
-	lc, err := newLogClientTool(ctx, logID, f, pubKey)
+	lc, err := newLogClientTool(ctx, logID, f, logSigV, witnesses, distribs)
 	if err != nil {
-		glog.Exitf("Failed to create new client: %q", err)
+		glog.Exitf("Failed to create new client: %v", err)
 	}
 
 	args := flag.Args()
@@ -132,7 +154,7 @@ type logClientTool struct {
 	Tracker  client.LogStateTracker
 }
 
-func newLogClientTool(ctx context.Context, logID string, f client.Fetcher, pubKey string) (logClientTool, error) {
+func newLogClientTool(ctx context.Context, logID string, logFetcher client.Fetcher, logSigV note.Verifier, witnesses []note.Verifier, distributors []client.Fetcher) (logClientTool, error) {
 	var cpRaw []byte
 	var err error
 	if len(*cacheDir) > 0 {
@@ -145,20 +167,25 @@ func newLogClientTool(ctx context.Context, logID string, f client.Fetcher, pubKe
 	}
 
 	hasher := rfc6962.DefaultHasher
-	lv := logverifier.New(hasher)
-	v, err := note.NewVerifier(pubKey)
-	if err != nil {
-		glog.Exitf("Failed to instantiate Verifier: %q", err)
+	var cons client.ConsensusCheckpoint
+	if *witnessSigsRequired == 0 {
+		glog.V(1).Infof("witness_sigs_required is 0, using YOLO consensus")
+		cons = client.YOLOConsensus(logFetcher)
+	} else {
+		glog.V(1).Infof("witness_sigs_required > 0, using checkpoint.N consensus")
+		cons = witness.CheckpointNConsensus(logID, distributors, witnesses, *witnessSigsRequired)
 	}
-	tracker, err := client.NewLogStateTracker(ctx, f, hasher, cpRaw, v, *origin)
+	tracker, err := client.NewLogStateTracker(ctx, logFetcher, hasher, cpRaw, logSigV, *origin, cons)
+
 	if err != nil {
+		glog.Warningf("%s", string(cpRaw))
 		glog.Exitf("Failed to create LogStateTracker: %q", err)
 	}
 
 	return logClientTool{
-		Fetcher:  f,
+		Fetcher:  logFetcher,
 		Hasher:   hasher,
-		Verifier: lv,
+		Verifier: logverifier.New(hasher),
 		Tracker:  tracker,
 	}, nil
 }
@@ -265,6 +292,15 @@ func readHTTP(ctx context.Context, u *url.URL) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	switch resp.StatusCode {
+	case 404:
+		glog.Infof("Not found: %q", u.String())
+		return nil, os.ErrNotExist
+	case 200:
+		break
+	default:
+		return nil, fmt.Errorf("unexpected http status %q", resp.Status)
+	}
 	defer resp.Body.Close()
 	return ioutil.ReadAll(resp.Body)
 }
@@ -289,4 +325,51 @@ func storeLocalCheckpoint(logID string, cpRaw []byte) error {
 		return err
 	}
 	return os.Rename(cpPathTmp, cpPath)
+}
+
+// Read log public key from file or environment variable
+func logSigVerifier(f string) (note.Verifier, error) {
+	if len(f) > 0 {
+		return sigVerifierFromFile(f)
+	} else {
+		pubKey := os.Getenv("SERVERLESS_LOG_PUBLIC_KEY")
+		if len(pubKey) == 0 {
+			return nil, fmt.Errorf("supply public key file path using --log_public_key or set SERVERLESS_LOG_PUBLIC_KEY environment variable")
+		}
+		return note.NewVerifier(pubKey)
+	}
+}
+
+func witnessSigVerifiers(fs []string) ([]note.Verifier, error) {
+	vs := make([]note.Verifier, 0, len(fs))
+	for _, f := range fs {
+		v, err := sigVerifierFromFile(f)
+		if err != nil {
+			return nil, err
+		}
+		glog.V(1).Infof("Found witness %q", v.Name())
+		vs = append(vs, v)
+	}
+	glog.V(1).Infof("Found %d witnesses", len(vs))
+	return vs, nil
+}
+
+func sigVerifierFromFile(f string) (note.Verifier, error) {
+	k, err := ioutil.ReadFile(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read public key from file %q: %v", f, err)
+	}
+	return note.NewVerifier(string(k))
+}
+
+func distributors() ([]client.Fetcher, error) {
+	distribs := make([]client.Fetcher, 0)
+	for _, d := range *distributorURLs {
+		u, err := url.Parse(d)
+		if err != nil {
+			return nil, fmt.Errorf("invalid distributor URL %q: %v", d, err)
+		}
+		distribs = append(distribs, newFetcher(u))
+	}
+	return distribs, nil
 }

--- a/serverless/integration/integration_test.go
+++ b/serverless/integration/integration_test.go
@@ -59,7 +59,7 @@ func RunIntegration(t *testing.T, s log.Storage, f client.Fetcher, lh *rfc6962.H
 		glog.Exitf("Unable to create new verifier: %q", err)
 	}
 
-	lst, err := client.NewLogStateTracker(ctx, f, lh, nil, v, integrationOrigin)
+	lst, err := client.NewLogStateTracker(ctx, f, lh, nil, v, integrationOrigin, client.YOLOConsensus(f))
 	if err != nil {
 		t.Fatalf("Failed to create new log state tracker: %q", err)
 	}

--- a/serverless/integration/integration_test.go
+++ b/serverless/integration/integration_test.go
@@ -59,7 +59,7 @@ func RunIntegration(t *testing.T, s log.Storage, f client.Fetcher, lh *rfc6962.H
 		glog.Exitf("Unable to create new verifier: %q", err)
 	}
 
-	lst, err := client.NewLogStateTracker(ctx, f, lh, nil, v, integrationOrigin, client.YOLOConsensus(f))
+	lst, err := client.NewLogStateTracker(ctx, f, lh, nil, v, integrationOrigin, client.UnilateralConsensus(f))
 	if err != nil {
 		t.Fatalf("Failed to create new log state tracker: %q", err)
 	}


### PR DESCRIPTION
This adds basic support in the serverless client for the experimental witness/distributor.

Example usage:

```bash
$ export SERVERLESS_LOG_PUBLIC_KEY=github.com/AlCutter/serverless-test/log+28035191+AVtQ/9lW+g90rQY3+pODJvMQ8X/tTvh/EuvCDLSmUk4S
$ go run ./serverless/cmd/client/ \
  --log_url=https://raw.githubusercontent.com/AlCutter/serverless-test/master/log \
  --log_id=serverless-test \
  --origin=github.com/AlCutter/serverless-test/log \
  --distributor_url=https://raw.githubusercontent.com/AlCutter/serverless-test/master/distributor/ \
  --witness_sigs_required=2 \
  --witness_public_key=${HOME}/trillian/serverless-test/witnesskeys/can_i_get.pub \
  --witness_public_key=${HOME}/trillian/serverless-test/witnesskeys/wolsey_bank_alfred.pub \
  --v=2 \
  --logtostderr \
  update
I0908 12:39:56.010538 3362835 client.go:342] Found witness "can-I-get-a-witness"
I0908 12:39:56.010648 3362835 client.go:342] Found witness "wolsey-bank-alfred"
I0908 12:39:56.010663 3362835 client.go:345] Found 2 witnesses
I0908 12:39:56.010720 3362835 client.go:237] Original checkpoint:
github.com/AlCutter/serverless-test/log
35
TjSypKrdZ2V67JEoHNXJmOOIno+rCfmKH1X0m7gl4JA=

— github.com/AlCutter/serverless-test/log KANRkbZqNkJO7h3RL/x0/Lb4wlgHUePQQjMyBDPljzmPK/RVA9LyNEVrX2nhOU99RYN2ViS5Ly+UPXD7nm+6dsu5ngQ=
— wolsey-bank-alfred AzbssEyqPgeE95wwJuwznmCvYQbSWF33UeR8IMKFQAjaqG/gWnUxU9fllvt2VTl4COo3ieVGRTP2PAbHk6AYufApqgo=
— can-I-get-a-witness uXoeVhdm3ykFFfwJyFw6irqNqKTO4wRoXyZBMTVgh3lRUZngabgIXfV7ETgNLcDGQBw+R2bh0R932IbmrWuS3nYiwA8=
I0908 12:39:56.200797 3362835 consensus.go:71] considering 1 cps
I0908 12:39:56.200852 3362835 client.go:245] Log hasn't grown, nothing to update.
```

