### PR TITLE
Replaced the last untrusted Checkpoint parsing with defensive code

### DIFF
--- a/serverless/client/client.go
+++ b/serverless/client/client.go
@@ -346,9 +346,11 @@ func NewLogStateTracker(ctx context.Context, f Fetcher, h hashers.LogHasher, che
 	}
 	if len(checkpointRaw) > 0 {
 		ret.LatestConsistentRaw = checkpointRaw
-		if _, err := ret.LatestConsistent.Unmarshal(checkpointRaw); err != nil {
+		cp, _, _, err := log.ParseCheckpoint(checkpointRaw, origin, nV)
+		if err != nil {
 			return ret, err
 		}
+		ret.LatestConsistent = *cp
 		return ret, nil
 	}
 	return ret, ret.Update(ctx)


### PR DESCRIPTION
This will also check the signatures and the origin. Checking this at construction makes it easier to reason about the invariants of the LatestConsistent checkpoint - it should always be signed by CpSigVerifier and have the expected Origin string.