### PR TITLE
[serverless] Don't map ports to host, just to other containers

### DIFF
--- a/serverless/deploy/docker/witness/docker-compose.yaml
+++ b/serverless/deploy/docker/witness/docker-compose.yaml
@@ -21,8 +21,8 @@ services:
       - "--config_file=/witness-config/${WITNESS_CONFIG_FILE:-witness.config}"
       - "--logtostderr"
     restart: always
-    ports:
-      - "8100:8100"
+    expose:
+      - "8100"
   feeder:
     depends_on:
       - witness


### PR DESCRIPTION
This allows the running of multiple instances of the feeder/witness/distribute combo on the same machine without needing to change ports.