### PR TITLE
Use the prebuilt docker images instead of building manually

### DIFF
--- a/sumdbaudit/witness/docker-compose.yaml
+++ b/sumdbaudit/witness/docker-compose.yaml
@@ -1,9 +1,7 @@
 version: '3.2'
 services:
   witness:
-    build:
-      context: ../..
-      dockerfile: ./witness/golang/cmd/witness/Dockerfile
+    image: gcr.io/trillian-opensource-ci/witness:latest
     volumes:
         - type: volume
           source: data
@@ -26,9 +24,7 @@ services:
   feeder:
     depends_on:
       - witness
-    build:
-      context: ../..
-      dockerfile: ./sumdbaudit/witness/cmd/feeder/Dockerfile
+    image: gcr.io/trillian-opensource-ci/sumdb-feeder:latest
     command:
       - "--w=http://witness:8100"
       - "--wk=${WITNESS_PUBLIC_KEY}"


### PR DESCRIPTION
This makes deploying a witness a 20s job instead of about an hour on a Raspberry Pi.