### PR TITLE
Improved docker reliability for sumdb feeder

### DIFF
--- a/sumdbaudit/witness/docker-compose.yaml
+++ b/sumdbaudit/witness/docker-compose.yaml
@@ -28,7 +28,9 @@ services:
     command:
       - "--w=http://witness:8100"
       - "--wk=${WITNESS_PUBLIC_KEY}"
+      - "--poll=1m"
       - "--alsologtostderr"
       - "--v=1"
+    restart: always
 volumes:
   data:


### PR DESCRIPTION
Restart when it stops, and change poll interval from 10s to 1m as the publicly visible checkpoint doesn't change that regularly.
