### PR TITLE
Improve witness status code responses

### DIFF
--- a/witness/golang/client/http/witness_client.go
+++ b/witness/golang/client/http/witness_client.go
@@ -97,7 +97,7 @@ func (w Witness) Update(ctx context.Context, logID string, cp []byte, proof [][]
 	}
 	if resp.StatusCode != 200 {
 		if resp.StatusCode == 409 {
-			return body, ErrCheckpointTooOld
+			return body, fmt.Errorf("%w: %s", ErrCheckpointTooOld, resp.Status)
 		}
 		return nil, fmt.Errorf("bad status response (%s): %q", resp.Status, body)
 	}

--- a/witness/golang/cmd/witness/internal/witness/witness.go
+++ b/witness/golang/cmd/witness/internal/witness/witness.go
@@ -133,7 +133,7 @@ func (w *Witness) GetCheckpoint(logID string) ([]byte, error) {
 // version of nextRaw if the update was applied.
 //
 // If an error occurs, this method will generally return an error with a status code:
-// - codes.NodeFound if the log is unknown
+// - codes.NotFound if the log is unknown
 // - codes.InvalidArgument for general bad requests
 // - codes.AlreadyExists if the checkpoint is smaller than the one the witness knows
 // - codes.FailedPrecondition if the checkpoint is inconsistent with the one the witness knows


### PR DESCRIPTION
- tweaked the returned `status.Code` for some conditions
- added a bit of logging/passing HTTP status text through into `error`s
- fixed bug where CP wasn't being written as comments suggested