### PR TITLE
Fix up the ECDSA verifier string format

### DIFF
--- a/feeder/cmd/rekor_feeder/example_config.yaml
+++ b/feeder/cmd/rekor_feeder/example_config.yaml
@@ -1,7 +1,7 @@
 Logs:
   - Origin: Rekor
-    PublicKeyType: sigstore_ecdsa
-    PublicKey: rekor.sigstore.dev MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2G2Y+2tabdTV5BcGiBIx0a9fAFwrkBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw==
+    PublicKeyType: ecdsa
+    PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
     URL: https://rekor.sigstore.dev
 
 Witness:

--- a/internal/note/note_verifier.go
+++ b/internal/note/note_verifier.go
@@ -80,9 +80,9 @@ func (v *verifier) Verify(msg, sig []byte) bool {
 //   <key_name>+<key_hash>+<key_bytes>
 // Where
 //   <key_name> is a human readable identifier for the key, containing no whitespace or "+" symbols
-//   <key_hash> is a 32bit hash of the key bytes
 //   <key_bytes> is base64 encoded blob starting with a 0x02 (algECDSAWithSHA256) byte and followed
 //       by the DER encoded public key in SPKI format.
+//   <key_hash> is a 32bit hash of the key DER
 // e.g.:
 //   "rekor.sigstore.dev+12345678+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
 func NewECDSAVerifier(key string) (sdb_note.Verifier, error) {

--- a/internal/note/note_verifier_test.go
+++ b/internal/note/note_verifier_test.go
@@ -23,7 +23,7 @@ import (
 // These come from the the current SigStore Rekór key, which is an ECDSA key:
 const (
 	sigStoreKeyMaterial = "AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc="
-	sigStoreKeyHash = "c0d23d6a"
+	sigStoreKeyHash     = "c0d23d6a"
 	sigStoreKey         = "rekor.sigstore.dev" + "+" + sigStoreKeyHash + "+" + sigStoreKeyMaterial
 )
 
@@ -92,7 +92,7 @@ func TestNewECDSAVerifier(t *testing.T) {
 			wantErr: true,
 		}, {
 			name:    "incorrect keyhash",
-			pubK: "rekor.sigstore.dev" + "+" + "00000000" + "+" + sigStoreKeyMaterial,
+			pubK:    "rekor.sigstore.dev" + "+" + "00000000" + "+" + sigStoreKeyMaterial,
 			wantErr: true,
 		},
 	} {

--- a/internal/note/note_verifier_test.go
+++ b/internal/note/note_verifier_test.go
@@ -22,8 +22,9 @@ import (
 
 // These come from the the current SigStore Rekór key:
 const (
-	sigStoreKeyMaterial = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2G2Y+2tabdTV5BcGiBIx0a9fAFwrkBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw=="
-	sigStoreKey         = "rekor.sigstore.dev " + sigStoreKeyMaterial
+	sigStoreKeyMaterial = "AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc="
+	sigStoreKeyHash = "c0d23d6a"
+	sigStoreKey         = "rekor.sigstore.dev" + "+" + sigStoreKeyHash + "+" + sigStoreKeyMaterial
 )
 
 func TestNewVerifier(t *testing.T) {
@@ -42,11 +43,11 @@ func TestNewVerifier(t *testing.T) {
 			wantErr: true,
 		}, {
 			name:  "sigstore ECDSA works",
-			kType: SigstoreECDSA,
+			kType: ECDSA,
 			k:     sigStoreKey,
 		}, {
 			name:    "sigstore ECDSA mismatch",
-			kType:   SigstoreECDSA,
+			kType:   ECDSA,
 			k:       "PeterNeumann+c74f20a3+ARpc2QcUPDhMQegwxbzhKqiBfsVkmqq/LDE4izWy10TW",
 			wantErr: true,
 		}, {
@@ -77,7 +78,7 @@ func TestSigstoreVerifier(t *testing.T) {
 			note: []byte("Rekor\n798034\nf+7CoKgXKE/tNys9TTXcr/ad6U/K3xvznmzew9y6SP0=\n\n— rekor.sigstore.dev wNI9ajBEAiARInWIWyCdyG27CO6LPnPekyw20qO0YJfoaPaowGp/XgIgc+qEHS3+GKVClgqq20uDLet7MCoTURUCRdxwWBHHufk=\n"),
 		}, {
 			name:    "invalid name",
-			pubK:    "bananas.sigstore.dev " + sigStoreKeyMaterial,
+			pubK:    "bananas.sigstore.dev" + "+" + sigStoreKeyHash + "+" + sigStoreKeyMaterial,
 			note:    []byte("Rekor\n798034\nf+7CoKgXKE/tNys9TTXcr/ad6U/K3xvznmzew9y6SP0=\n\n— rekor.sigstore.dev wNI9ajBEAiARInWIWyCdyG27CO6LPnPekyw20qO0YJfoaPaowGp/XgIgc+qEHS3+GKVClgqq20uDLet7MCoTURUCRdxwWBHHufk=\n"),
 			wantErr: true,
 		}, {
@@ -87,13 +88,15 @@ func TestSigstoreVerifier(t *testing.T) {
 			wantErr: true,
 		},
 	} {
-		v, err := NewSigstoreECDSAVerifier(test.pubK)
-		if err != nil {
-			t.Fatalf("Failed to create new ECDSA verifier: %v", err)
-		}
-		_, err = note.Open(test.note, note.VerifierList(v))
-		if gotErr := err != nil; gotErr != test.wantErr {
-			t.Fatalf("Got err %v, but want error %v", err, test.wantErr)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			v, err := NewECDSAVerifier(test.pubK)
+			if err != nil {
+				t.Fatalf("Failed to create new ECDSA verifier from %q: %v", test.pubK, err)
+			}
+			_, err = note.Open(test.note, note.VerifierList(v))
+			if gotErr := err != nil; gotErr != test.wantErr {
+				t.Fatalf("Got err %v, but want error %v", err, test.wantErr)
+			}
+		})
 	}
 }


### PR DESCRIPTION
- Make the verifier string format be like standard note ones
- Rename from SigStoreECDSA -> ECDSA since this is now agreed to be the definition of note's algoID 2