### PR TITLE
Docker compose file for Pixel BT log witness

### DIFF
--- a/feeder/cmd/pixel_bt_feeder/README.md
+++ b/feeder/cmd/pixel_bt_feeder/README.md
@@ -19,3 +19,19 @@ to fetch checkpoints and proofs to feed to the [generic witness](/witness/golang
 
 The feeder reads its config from a YAML config file, an [example](./example_config.yaml) is
 provided for reference.
+
+## Standalone
+
+A docker-compose script is provided to easily bring up a witness that witnesses only the
+Pixel BT log. See https://go.dev/play/p/ZKrAbQovsZK for getting started, but the overview is:
+ 1. Generate signing key material.
+ 2. Update the [configuration file](./standalone.conf/feeder.yaml) to add the public key
+ 3. Use `docker-compose` to start the feeder and witness
+
+After 5 minutes or so, the witnessed checkpoint should be visible at
+http://localhost:8123/witness/v0/logs/d0a1f19e973cd5cc3d4f26446ea418d33faefffb43ea1e3eadfe133287f71ff8/checkpoint.
+If this doesn't appear, inspect the logs from the containers with:
+ * `docker logs pixel_bt_feeder_feeder_1`
+ * `docker logs pixel_bt_feeder_witness_1`
+
+can be

--- a/feeder/cmd/pixel_bt_feeder/README.md
+++ b/feeder/cmd/pixel_bt_feeder/README.md
@@ -33,5 +33,3 @@ http://localhost:8123/witness/v0/logs/d0a1f19e973cd5cc3d4f26446ea418d33faefffb43
 If this doesn't appear, inspect the logs from the containers with:
  * `docker logs pixel_bt_feeder_feeder_1`
  * `docker logs pixel_bt_feeder_witness_1`
-
-can be

--- a/feeder/cmd/pixel_bt_feeder/standalone.conf/feeder.yaml
+++ b/feeder/cmd/pixel_bt_feeder/standalone.conf/feeder.yaml
@@ -1,0 +1,10 @@
+Log:
+  Origin: DEFAULT
+  PublicKeyType: ecdsa
+  PublicKey: Pixel-Transparency-Log-2021+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=
+
+  URL: https://developers.google.com/android/binary_transparency/
+
+Witness:
+  URL: http://witness:8123
+  PublicKey: ReplaceThisTokenWithYourWitnessPublicKey+db81a74c+Ad+741CbyNmvkmUf19B+tv6VB7yy37NlSxIa9jyqr3tb

--- a/feeder/cmd/pixel_bt_feeder/standalone.conf/feeder.yaml
+++ b/feeder/cmd/pixel_bt_feeder/standalone.conf/feeder.yaml
@@ -2,7 +2,6 @@ Log:
   Origin: DEFAULT
   PublicKeyType: ecdsa
   PublicKey: Pixel-Transparency-Log-2021+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=
-
   URL: https://developers.google.com/android/binary_transparency/
 
 Witness:

--- a/feeder/cmd/pixel_bt_feeder/standalone.conf/pixelwitness.yaml
+++ b/feeder/cmd/pixel_bt_feeder/standalone.conf/pixelwitness.yaml
@@ -1,0 +1,6 @@
+Logs:
+  - Origin: DEFAULT
+    PubKeyType: ecdsa
+    PubKey: Pixel-Transparency-Log-2021+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=
+    HashStrategy: default
+    UseCompact: false

--- a/feeder/cmd/pixel_bt_feeder/standalonewitness.docker-compose.yaml
+++ b/feeder/cmd/pixel_bt_feeder/standalonewitness.docker-compose.yaml
@@ -1,0 +1,53 @@
+# This compose script brings up a standalone Pixel BT witness that
+# polls the log every 5  minutes, and exposes the cosigned checkpoints
+# via a REST API on port 8123.
+# When running, the witnessed checkpoint will be at:
+# http://localhost:8123/witness/v0/logs/d0a1f19e973cd5cc3d4f26446ea418d33faefffb43ea1e3eadfe133287f71ff8/checkpoint
+#
+# See https://go.dev/play/p/ZKrAbQovsZK for an example of generating
+# the key material for the witness signing.
+#
+# This compose script is not intended for configuring a witness
+# that can witness other logs. See the `/witness/golang/` directory
+# in this repo for greater flexibility.
+
+version: '3.2'
+services:
+  witness:
+    image: gcr.io/trillian-opensource-ci/witness:latest
+    volumes:
+        - type: volume
+          source: data
+          target: /data
+          volume:
+            nocopy: true
+        - type: bind
+          source: ./standalone.conf
+          target: /witness-config
+          read_only: true
+    command:
+      - "--listen=:8123"
+      - "--db_file=/data/witness.sqlite"
+      - "--private_key=${WITNESS_PRIVATE_KEY}"
+      - "--config_file=/witness-config/pixelwitness.yaml"
+      - "--logtostderr"
+    restart: always
+    ports:
+      - "8123:8123"
+  feeder:
+    depends_on:
+      - witness
+    image: gcr.io/trillian-opensource-ci/pixel-bt-feeder:latest
+    command:
+      - "--config_file=/feeder-config/feeder.yaml"
+      - "--interval=5m"
+      - "--alsologtostderr"
+      - "--v=1"
+    restart: always
+    volumes:
+      - type: bind
+        source: ./standalone.conf
+        target: /feeder-config
+        read_only: true
+volumes:
+  data:

--- a/feeder/cmd/pixel_bt_feeder/standalonewitness.docker-compose.yaml
+++ b/feeder/cmd/pixel_bt_feeder/standalonewitness.docker-compose.yaml
@@ -1,5 +1,5 @@
 # This compose script brings up a standalone Pixel BT witness that
-# polls the log every 5  minutes, and exposes the cosigned checkpoints
+# polls the log every 5 minutes, and exposes the cosigned checkpoints
 # via a REST API on port 8123.
 # When running, the witnessed checkpoint will be at:
 # http://localhost:8123/witness/v0/logs/d0a1f19e973cd5cc3d4f26446ea418d33faefffb43ea1e3eadfe133287f71ff8/checkpoint


### PR DESCRIPTION
This allows a witness for the Pixel Binary Transparency log to be brought up easily. To do so, key material must be generated (example code is linked in the compose file), then provided in the feeder.yaml and via environment variables to docker-compose.