### PR TITLE
[Witness] Remove pubkey from feeders

### DIFF
--- a/feeder/cmd/pixel_bt_feeder/example_config.yaml
+++ b/feeder/cmd/pixel_bt_feeder/example_config.yaml
@@ -2,9 +2,7 @@ Log:
   Origin: DEFAULT
   PublicKeyType: ecdsa
   PublicKey: Pixel-Transparency-Log-2021+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=
-
   URL: https://developers.google.com/android/binary_transparency/
 
 Witness:
   URL: http://localhost:8100
-  PublicKey: can-I-get-a-witness+b97a1e56+AZkpOlwZwR+wwasAENZwIa98ufmWmzlq0Tx0XN7voU6X

--- a/feeder/cmd/pixel_bt_feeder/main.go
+++ b/feeder/cmd/pixel_bt_feeder/main.go
@@ -72,8 +72,7 @@ func main() {
 		glog.Exitf("Failed to parse witness URL %q: %v", cfg.Witness.URL, err)
 	}
 	witness := wit_http.Witness{
-		URL:      u,
-		Verifier: mustCreateVerifier(i_note.Note, cfg.Witness.PublicKey),
+		URL: u,
 	}
 
 	ctx := context.Background()

--- a/feeder/cmd/rekor_feeder/example_config.yaml
+++ b/feeder/cmd/rekor_feeder/example_config.yaml
@@ -6,4 +6,3 @@ Logs:
 
 Witness:
   URL: http://localhost:8100
-  PublicKey: can-I-get-a-witness+b97a1e56+AZkpOlwZwR+wwasAENZwIa98ufmWmzlq0Tx0XN7voU6X

--- a/feeder/cmd/rekor_feeder/main.go
+++ b/feeder/cmd/rekor_feeder/main.go
@@ -67,8 +67,7 @@ func main() {
 		glog.Exitf("Failed to parse witness URL %q: %v", cfg.Witness.URL, err)
 	}
 	witness := wit_http.Witness{
-		URL:      u,
-		Verifier: mustCreateVerifier(i_note.Note, cfg.Witness.PublicKey),
+		URL: u,
 	}
 
 	wg := &sync.WaitGroup{}

--- a/internal/feeder/feeder_test.go
+++ b/internal/feeder/feeder_test.go
@@ -54,8 +54,7 @@ func TestFeedOnce(t *testing.T) {
 		}, {
 			desc:     "works - TOFU feed",
 			submitCP: testdata.Checkpoint(t, 2),
-			witness: &fakeWitness{
-			},
+			witness:  &fakeWitness{},
 		}, {
 			desc:     "works - submitCP == latest",
 			submitCP: testdata.Checkpoint(t, 1),

--- a/internal/feeder/feeder_test.go
+++ b/internal/feeder/feeder_test.go
@@ -28,16 +28,8 @@ import (
 	"golang.org/x/mod/sumdb/note"
 )
 
-const (
-	testWitnessSecretKey = "PRIVATE+KEY+test-witness+d28ecb0d+AbextYkHs2Be69xhwhvaUvjxijEqtQQ9NWNC05YWx7Jr"
-	testWitnessPublicKey = "test-witness+d28ecb0d+AV2DM8GnnoXPS77FKY/KwsZdfien9eSmb35f6qUv2TrH"
-)
-
 func TestFeedOnce(t *testing.T) {
 	ctx := context.Background()
-	logSigV := testdata.LogSigVerifier(t)
-	witSig := mustCreateSigner(t, testWitnessSecretKey)
-	witSigV := mustCreateVerifier(t, testWitnessPublicKey)
 	for _, test := range []struct {
 		desc     string
 		submitCP []byte
@@ -48,20 +40,14 @@ func TestFeedOnce(t *testing.T) {
 			desc:     "works",
 			submitCP: testdata.Checkpoint(t, 2),
 			witness: &fakeWitness{
-				logSigV:  logSigV,
-				witSig:   witSig,
-				witSigV:  witSigV,
-				latestCP: mustCosignCP(t, testdata.Checkpoint(t, 1), logSigV, witSig),
+				latestCP: testdata.Checkpoint(t, 1),
 			},
 		}, {
 			desc:     "works after a few failures",
 			submitCP: testdata.Checkpoint(t, 2),
 			witness: &slowWitness{
 				fakeWitness: &fakeWitness{
-					logSigV:  logSigV,
-					witSig:   witSig,
-					witSigV:  witSigV,
-					latestCP: mustCosignCP(t, testdata.Checkpoint(t, 1), logSigV, witSig),
+					latestCP: testdata.Checkpoint(t, 1),
 				},
 				times: 3,
 			},
@@ -69,39 +55,20 @@ func TestFeedOnce(t *testing.T) {
 			desc:     "works - TOFU feed",
 			submitCP: testdata.Checkpoint(t, 2),
 			witness: &fakeWitness{
-				logSigV: logSigV,
-				witSig:  witSig,
-				witSigV: witSigV,
 			},
 		}, {
 			desc:     "works - submitCP == latest",
 			submitCP: testdata.Checkpoint(t, 1),
 			witness: &fakeWitness{
-				logSigV:  logSigV,
-				witSig:   witSig,
-				witSigV:  witSigV,
-				latestCP: mustCosignCP(t, testdata.Checkpoint(t, 1), logSigV, witSig),
+				latestCP: testdata.Checkpoint(t, 1),
 			},
-		}, {
-			desc:     "no new sigs added",
-			submitCP: mustCosignCP(t, testdata.Checkpoint(t, 1), logSigV, witSig),
-			witness: &fakeWitness{
-				logSigV:  logSigV,
-				witSig:   witSig,
-				witSigV:  witSigV,
-				latestCP: mustCosignCP(t, testdata.Checkpoint(t, 1), logSigV, witSig),
-			},
-			wantErr: true,
 		}, {
 			desc:    "submitting stale CP",
 			wantErr: true,
 			// This checkpoint is older than the witness' latestCP below:
 			submitCP: testdata.Checkpoint(t, 1),
 			witness: &fakeWitness{
-				logSigV:  logSigV,
-				witSig:   witSig,
-				witSigV:  witSigV,
-				latestCP: mustCosignCP(t, testdata.Checkpoint(t, 2), logSigV, witSig),
+				latestCP: testdata.Checkpoint(t, 2),
 			},
 		},
 	} {
@@ -157,15 +124,8 @@ func (sw *slowWitness) GetLatestCheckpoint(ctx context.Context, logID string) ([
 }
 
 type fakeWitness struct {
-	logSigV      note.Verifier
-	witSig       note.Signer
-	witSigV      note.Verifier
 	latestCP     []byte
 	rejectUpdate bool
-}
-
-func (fw *fakeWitness) SigVerifier() note.Verifier {
-	return fw.witSigV
 }
 
 func (fw *fakeWitness) GetLatestCheckpoint(_ context.Context, logID string) ([]byte, error) {
@@ -180,11 +140,7 @@ func (fw *fakeWitness) Update(_ context.Context, logID string, newCP []byte, pro
 		return nil, errors.New("computer says 'no'")
 	}
 
-	csCP, err := cosignCP(newCP, fw.logSigV, fw.witSig)
-	if err != nil {
-		return nil, err
-	}
-	fw.latestCP = csCP
+	fw.latestCP = newCP
 
 	return fw.latestCP, nil
 }
@@ -196,43 +152,4 @@ func mustOpenCheckpoint(t *testing.T, cp []byte, origin string, v note.Verifier)
 		t.Fatalf("Failed to open checkpoint: %v", err)
 	}
 	return *c
-}
-
-func cosignCP(cp []byte, v note.Verifier, s note.Signer) ([]byte, error) {
-	n, err := note.Open(cp, note.VerifierList(v))
-	if err != nil {
-		return nil, fmt.Errorf("failed to open note: %v", err)
-	}
-
-	r, err := note.Sign(n, s)
-	if err != nil {
-		return nil, fmt.Errorf("failed to cosign note: %v", err)
-	}
-	return r, nil
-}
-
-func mustCosignCP(t *testing.T, cp []byte, v note.Verifier, s note.Signer) []byte {
-	t.Helper()
-	r, err := cosignCP(cp, v, s)
-	if err != nil {
-		t.Fatalf("Failed to cosign CP: %v", err)
-	}
-	return r
-}
-
-func mustCreateSigner(t *testing.T, secK string) note.Signer {
-	t.Helper()
-	s, err := note.NewSigner(secK)
-	if err != nil {
-		t.Fatalf("failed to create signer: %v", err)
-	}
-	return s
-}
-func mustCreateVerifier(t *testing.T, pubK string) note.Verifier {
-	t.Helper()
-	v, err := note.NewVerifier(pubK)
-	if err != nil {
-		t.Fatalf("failed to create verifier: %v", err)
-	}
-	return v
 }

--- a/serverless/cmd/feeder/example_config.yaml
+++ b/serverless/cmd/feeder/example_config.yaml
@@ -5,4 +5,3 @@ Logs:
 
 Witness:
   URL: http://localhost:8765
-  PublicKey: test-witness+d28ecb0d+AV2DM8GnnoXPS77FKY/KwsZdfien9eSmb35f6qUv2TrH

--- a/serverless/cmd/feeder/main.go
+++ b/serverless/cmd/feeder/main.go
@@ -68,8 +68,7 @@ func main() {
 		glog.Exitf("Failed to parse witness URL %q: %v", cfg.Witness.URL, err)
 	}
 	witness := wit_http.Witness{
-		URL:      u,
-		Verifier: mustCreateVerifier(cfg.Witness.PublicKey),
+		URL: u,
 	}
 
 	wg := &sync.WaitGroup{}


### PR DESCRIPTION
Having the public key around in feeders is a remnant from when the feeder/verifier/distributor roles were bundled together, but since the feeder's only job is to send checkpoints _into_ the witness it's unnecessary.

Removing it simplifies code & config.