### PR TITLE
Removed the witness public key from the config files

### DIFF
--- a/serverless/cmd/distribute/example_config.yaml
+++ b/serverless/cmd/distribute/example_config.yaml
@@ -5,4 +5,3 @@ Logs:
 
 Witness:
   URL: http://localhost:8100
-  PublicKey: mhutchinson.witness+384b3dbc+AfWg+7+qmcFoMuIM0ZGe4ZsIuc6gEg3EL0cKkNVolCA+

--- a/serverless/cmd/distribute/github/main.go
+++ b/serverless/cmd/distribute/github/main.go
@@ -57,6 +57,7 @@ var (
 	distributorBranch = flag.String("distributor_branch", "master", "The branch that PRs will be proposed against on the distributor_repo.")
 	forkRepo          = flag.String("fork_repo", "", "The repo owner/fragment from the feeder (forked distributor) repo URL.")
 	distributorPath   = flag.String("distributor_path", "", "Path from the root of the repo where the distributor files can be found.")
+	witSigV           = flag.String("witness_vkey", "", "Witness public key.")
 	configPath        = flag.String("config_file", "", "Path to the config file for the serverless/cmd/feeder command.")
 	interval          = flag.Duration("interval", time.Duration(0), "Interval between checkpoints. Default of 0 causes the tool to be a one-shot.")
 )
@@ -103,6 +104,7 @@ func mustConfigure(ctx context.Context) *dist_gh.DistributeOptions {
 	checkNotEmpty("Missing required --fork_repo flag", *forkRepo)
 	checkNotEmpty("Missing required --distributor_path flag", *distributorPath)
 	checkNotEmpty("Missing required --config_file flag", *configPath)
+	checkNotEmpty("Missing required --witness_vkey flag", *witSigV)
 
 	// Check env vars
 	githubAuthToken := os.Getenv("GITHUB_AUTH_TOKEN")
@@ -131,7 +133,7 @@ func mustConfigure(ctx context.Context) *dist_gh.DistributeOptions {
 	if err != nil {
 		glog.Exitf("Failed to parse witness URL %q: %v", cfg.Witness.URL, err)
 	}
-	wSigV, err := note.NewVerifier(cfg.Witness.PublicKey)
+	wSigV, err := note.NewVerifier(*witSigV)
 	if err != nil {
 		glog.Exitf("Invalid witness public key for url %q: %v", cfg.Witness.URL, err)
 	}

--- a/serverless/config/example_witness_config.yaml
+++ b/serverless/config/example_witness_config.yaml
@@ -1,3 +1,2 @@
 Witness:
-  PublicKey: mhutchinson.witness+384b3dbc+AfWg+7+qmcFoMuIM0ZGe4ZsIuc6gEg3EL0cKkNVolCA+
   URL: 5koi7kqnnoms3z3axlkdjh7cp6o6v2we3zcsl5zk5tk3c27zgxh45hqd.onion

--- a/serverless/config/witness.go
+++ b/serverless/config/witness.go
@@ -15,15 +15,12 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 )
 
 // Log describes a witness in a config file.
 type Witness struct {
-	// PublicKey used to verify checkpoints are signed by this witness.
-	PublicKey string `yaml:"PublicKey"`
 	// URL is the URL of the root of the witness.
 	// This is optional if direct witness communication is not required.
 	URL string `yaml:"URL"`
@@ -31,9 +28,6 @@ type Witness struct {
 
 // Validate checks that the witness configuration is valid.
 func (w Witness) Validate() error {
-	if w.PublicKey == "" {
-		return errors.New("missing field: PublicKey")
-	}
 	if w.URL != "" {
 		if _, err := url.Parse(w.URL); err != nil {
 			return fmt.Errorf("unparseable URL: %v", err)


### PR DESCRIPTION
Anywhere it is needed, it can be provided as a flag. This makes it far simpler to deploy with docker.
