### PR TITLE
[Witness] Extract feeder implementations from their main files

### DIFF
--- a/feeder/cmd/pixel_bt_feeder/main.go
+++ b/feeder/cmd/pixel_bt_feeder/main.go
@@ -20,28 +20,16 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"net/url"
-	"os"
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/google/trillian-examples/feeder/cmd/pixel_bt_feeder/internal"
 	"github.com/google/trillian-examples/formats/log"
-	"github.com/google/trillian-examples/internal/feeder"
 	"github.com/google/trillian-examples/serverless/config"
-	"golang.org/x/mod/sumdb/note"
-	"golang.org/x/mod/sumdb/tlog"
 
-	i_note "github.com/google/trillian-examples/internal/note"
+	"github.com/google/trillian-examples/internal/feeder/pixelbt"
 	wit_http "github.com/google/trillian-examples/witness/golang/client/http"
 	yaml "gopkg.in/yaml.v2"
-)
-
-const (
-	// tileHeight is the tlog tile height.
-	// From: https://developers.devsite.corp.google.com/android/binary_transparency/tile
-	tileHeight = 1
 )
 
 var (
@@ -76,127 +64,9 @@ func main() {
 	}
 
 	ctx := context.Background()
-	if err := feedLog(ctx, cfg.Log, witness, *timeout, *interval); err != nil {
+	if err := pixelbt.FeedLog(ctx, cfg.Log, witness, *timeout, *interval); err != nil {
 		glog.Errorf("feedLog: %v", err)
 	}
-}
-
-func feedLog(ctx context.Context, l config.Log, w wit_http.Witness, timeout time.Duration, interval time.Duration) error {
-	lURL, err := url.Parse(l.URL)
-	if err != nil {
-		return fmt.Errorf("invalid LogURL %q: %v", l.URL, err)
-	}
-	logSigV := mustCreateVerifier(l.PublicKeyType, l.PublicKey)
-
-	fetchCP := func(ctx context.Context) ([]byte, error) {
-		cpTxt, err := fetch(ctx, lURL, "checkpoint.txt")
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch checkpoint.txt: %v", err)
-		}
-		n, err := internal.ConvertToNote(string(cpTxt), logSigV.Name(), logSigV.KeyHash())
-		glog.V(1).Infof("note : %q", n)
-		return n, err
-	}
-	fetchProof := func(ctx context.Context, from, to log.Checkpoint) ([][]byte, error) {
-		if from.Size == 0 {
-			return [][]byte{}, nil
-		}
-		var h [32]byte
-		copy(h[:], to.Hash)
-		tree := tlog.Tree{
-			N:    int64(to.Size),
-			Hash: h,
-		}
-		tr := tileReader{fetch: func(p string) ([]byte, error) {
-			return fetch(ctx, lURL, p)
-		}}
-
-		proof, err := tlog.ProveTree(int64(to.Size), int64(from.Size), tlog.TileHashReader(tree, tr))
-		if err != nil {
-			return nil, fmt.Errorf("ProveTree: %v", err)
-		}
-		r := make([][]byte, 0, len(proof))
-		for _, h := range proof {
-			h := h
-			r = append(r, h[:])
-		}
-		glog.V(1).Infof("Fetched proof from %d -> %d: %x", from.Size, to.Size, r)
-		return r, nil
-	}
-
-	opts := feeder.FeedOpts{
-		LogID:           l.ID,
-		LogOrigin:       l.Origin,
-		FetchCheckpoint: fetchCP,
-		FetchProof:      fetchProof,
-		LogSigVerifier:  logSigV,
-		Witness:         w,
-	}
-	if interval > 0 {
-		return feeder.Run(ctx, interval, opts)
-	}
-	_, err = feeder.FeedOnce(ctx, opts)
-	return err
-}
-
-type tileReader struct {
-	fetch func(p string) ([]byte, error)
-}
-
-func (tr tileReader) Height() int { return tileHeight }
-
-func (tr tileReader) SaveTiles([]tlog.Tile, [][]byte) {}
-
-func (tr tileReader) ReadTiles(tiles []tlog.Tile) ([][]byte, error) {
-	r := make([][]byte, 0, len(tiles))
-	for _, t := range tiles {
-		path := fmt.Sprintf("tile/%d/%d/%03d", t.H, t.L, t.N)
-		if t.W < 1<<t.H {
-			path += fmt.Sprintf(".p/%d", t.W)
-		}
-		tile, err := tr.fetch(path)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch %q: %v", path, err)
-		}
-		r = append(r, tile)
-	}
-	return r, nil
-}
-
-func fetch(ctx context.Context, base *url.URL, path string) ([]byte, error) {
-	u, err := base.Parse(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse URL: %v", err)
-	}
-	glog.Infof("GET %s", u.String())
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %v", err)
-	}
-	req = req.WithContext(ctx)
-
-	rsp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make request to %q: %v", u.String(), err)
-	}
-	defer rsp.Body.Close()
-
-	if rsp.StatusCode == 404 {
-		return nil, os.ErrNotExist
-	}
-	if rsp.StatusCode != 200 {
-		return nil, fmt.Errorf("unexpected status fetching %q: %s", u.String(), rsp.Status)
-	}
-
-	return ioutil.ReadAll(rsp.Body)
-}
-
-func mustCreateVerifier(t, pub string) note.Verifier {
-	v, err := i_note.NewVerifier(t, pub)
-	if err != nil {
-		glog.Exitf("Failed to create signature verifier from %q: %v", pub, err)
-	}
-	return v
 }
 
 func readConfig(f string) (*Config, error) {

--- a/feeder/cmd/rekor_feeder/main.go
+++ b/feeder/cmd/rekor_feeder/main.go
@@ -17,24 +17,18 @@ package main
 
 import (
 	"context"
-	"encoding/hex"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"net/url"
-	"os"
 	"sync"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/formats/log"
-	"github.com/google/trillian-examples/internal/feeder"
+	"github.com/google/trillian-examples/internal/feeder/rekor"
 	"github.com/google/trillian-examples/serverless/config"
-	"golang.org/x/mod/sumdb/note"
 
-	i_note "github.com/google/trillian-examples/internal/note"
 	wit_http "github.com/google/trillian-examples/witness/golang/client/http"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -76,7 +70,7 @@ func main() {
 		wg.Add(1)
 		go func(l config.Log, w wit_http.Witness) {
 			defer wg.Done()
-			if err := feedLog(ctx, l, witness, *timeout, *interval); err != nil {
+			if err := rekor.FeedLog(ctx, l, witness, *timeout, *interval); err != nil {
 				glog.Errorf("feedLog: %v", err)
 			}
 		}(l, witness)
@@ -84,108 +78,6 @@ func main() {
 	wg.Wait()
 }
 
-// logInfo is a partial representation of the JSON object returned by Rekór's
-// api/v1/log request.
-type logInfo struct {
-	// SignedTreeHead contains a Rekór checkpoint.
-	SignedTreeHead string `json:"signedTreeHead"`
-}
-
-// proof is a partial representation of the JSON struct returned by the Rekór
-// api/v1/log/proof request.
-type proof struct {
-	Hashes []string `json:"hashes"`
-}
-
-func feedLog(ctx context.Context, l config.Log, w wit_http.Witness, timeout time.Duration, interval time.Duration) error {
-	lURL, err := url.Parse(l.URL)
-	if err != nil {
-		return fmt.Errorf("invalid LogURL %q: %v", l.URL, err)
-	}
-
-	fetchCP := func(ctx context.Context) ([]byte, error) {
-		li := logInfo{}
-		if err := getJSON(ctx, lURL, "api/v1/log", &li); err != nil {
-			return nil, fmt.Errorf("failed to fetch log info: %v", err)
-		}
-		return []byte(li.SignedTreeHead), nil
-	}
-	fetchProof := func(ctx context.Context, from, to log.Checkpoint) ([][]byte, error) {
-		if from.Size == 0 {
-			return [][]byte{}, nil
-		}
-		cp := proof{}
-		if err := getJSON(ctx, lURL, fmt.Sprintf("api/v1/log/proof?firstSize=%d&lastSize=%d", from.Size, to.Size), &cp); err != nil {
-			return nil, fmt.Errorf("failed to fetch log info: %v", err)
-		}
-		var err error
-		p := make([][]byte, len(cp.Hashes))
-		for i := range cp.Hashes {
-			p[i], err = hex.DecodeString(cp.Hashes[i])
-			if err != nil {
-				return nil, fmt.Errorf("invalid proof element at %d: %v", i, err)
-			}
-		}
-		return p, nil
-	}
-
-	opts := feeder.FeedOpts{
-		LogID:           l.ID,
-		LogOrigin:       l.Origin,
-		FetchCheckpoint: fetchCP,
-		FetchProof:      fetchProof,
-		LogSigVerifier:  mustCreateVerifier(l.PublicKeyType, l.PublicKey),
-		Witness:         w,
-	}
-	if interval > 0 {
-		return feeder.Run(ctx, interval, opts)
-	}
-	_, err = feeder.FeedOnce(ctx, opts)
-	return err
-}
-
-func getJSON(ctx context.Context, base *url.URL, path string, s interface{}) error {
-	u, err := base.Parse(path)
-	if err != nil {
-		return fmt.Errorf("failed to parse URL: %v", err)
-	}
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %v", err)
-	}
-	req = req.WithContext(ctx)
-
-	rsp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to make request to %q: %v", u.String(), err)
-	}
-	defer rsp.Body.Close()
-
-	if rsp.StatusCode == 404 {
-		return os.ErrNotExist
-	}
-	if rsp.StatusCode != 200 {
-		return fmt.Errorf("unexpected status fetching %q: %s", u.String(), rsp.Status)
-	}
-
-	raw, err := ioutil.ReadAll(rsp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read body from %q: %v", u.String(), err)
-	}
-	if err := json.Unmarshal(raw, s); err != nil {
-		glog.Infof("Got body:\n%s", string(raw))
-		return fmt.Errorf("failed to unmarshal JSON: %v", err)
-	}
-	return nil
-}
-
-func mustCreateVerifier(t, pub string) note.Verifier {
-	v, err := i_note.NewVerifier(t, pub)
-	if err != nil {
-		glog.Exitf("Failed to create signature verifier from %q: %v", pub, err)
-	}
-	return v
-}
 func readConfig(f string) (*Config, error) {
 	c, err := ioutil.ReadFile(f)
 	if err != nil {

--- a/internal/feeder/pixelbt/convert.go
+++ b/internal/feeder/pixelbt/convert.go
@@ -25,7 +25,7 @@ import (
 	"unicode/utf8"
 )
 
-// convertToNote converts a the PixelBT checkpoint to a valid Note.
+// convertToNote converts a PixelBT checkpoint to a valid Note.
 //
 // Hopefully we won't need this for too long, and PixelBT will update their checkpoint format to make it
 // fully compatible.

--- a/internal/feeder/pixelbt/convert.go
+++ b/internal/feeder/pixelbt/convert.go
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package internal holds some private helper functions for the Pixel BT feeder.
-package internal
+package pixelbt
 
 import (
 	"bytes"
@@ -26,11 +25,11 @@ import (
 	"unicode/utf8"
 )
 
-// ConvertToNote converts a the PixelBT checkpoint to a valid Note.
+// convertToNote converts a the PixelBT checkpoint to a valid Note.
 //
 // Hopefully we won't need this for too long, and PixelBT will update their checkpoint format to make it
 // fully compatible.
-func ConvertToNote(pixelCP, keyName string, keyHash uint32) ([]byte, error) {
+func convertToNote(pixelCP, keyName string, keyHash uint32) ([]byte, error) {
 	split := strings.LastIndex(pixelCP, "\n\n")
 	if split < 0 {
 		return nil, fmt.Errorf("invalid Pixel CP %q", pixelCP)

--- a/internal/feeder/pixelbt/convert_test.go
+++ b/internal/feeder/pixelbt/convert_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package pixelbt
 
 import (
 	"bytes"
@@ -64,7 +64,7 @@ func TestConvertToNote(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			got, err := ConvertToNote(test.cpTxt, test.keyName, test.keyHash)
+			got, err := convertToNote(test.cpTxt, test.keyName, test.keyHash)
 			if gotErr := err != nil; gotErr != test.wantErr {
 				t.Fatalf("ToNote = %v, want no error", err)
 			}

--- a/internal/feeder/pixelbt/pixel_feeder.go
+++ b/internal/feeder/pixelbt/pixel_feeder.go
@@ -1,0 +1,156 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pixelbt is an implementation of a witness feeder for the Pixel BT log.
+package pixelbt
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/formats/log"
+	"github.com/google/trillian-examples/internal/feeder"
+	"github.com/google/trillian-examples/serverless/config"
+	"golang.org/x/mod/sumdb/tlog"
+
+	i_note "github.com/google/trillian-examples/internal/note"
+	wit_http "github.com/google/trillian-examples/witness/golang/client/http"
+)
+
+const (
+	// tileHeight is the tlog tile height.
+	// From: https://developers.devsite.corp.google.com/android/binary_transparency/tile
+	tileHeight = 1
+)
+
+// FeedLog retrieves checkpoints and proofs from the source Pixel BT log, and sends them to the witness.
+// This method blocks until the context is done.
+func FeedLog(ctx context.Context, l config.Log, w wit_http.Witness, timeout time.Duration, interval time.Duration) error {
+	lURL, err := url.Parse(l.URL)
+	if err != nil {
+		return fmt.Errorf("invalid LogURL %q: %v", l.URL, err)
+	}
+	logSigV, err := i_note.NewVerifier(l.PublicKeyType, l.PublicKey)
+	if err != nil {
+		return err
+	}
+
+	fetchCP := func(ctx context.Context) ([]byte, error) {
+		cpTxt, err := fetch(ctx, lURL, "checkpoint.txt")
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch checkpoint.txt: %v", err)
+		}
+		n, err := convertToNote(string(cpTxt), logSigV.Name(), logSigV.KeyHash())
+		glog.V(1).Infof("note : %q", n)
+		return n, err
+	}
+	fetchProof := func(ctx context.Context, from, to log.Checkpoint) ([][]byte, error) {
+		if from.Size == 0 {
+			return [][]byte{}, nil
+		}
+		var h [32]byte
+		copy(h[:], to.Hash)
+		tree := tlog.Tree{
+			N:    int64(to.Size),
+			Hash: h,
+		}
+		tr := tileReader{fetch: func(p string) ([]byte, error) {
+			return fetch(ctx, lURL, p)
+		}}
+
+		proof, err := tlog.ProveTree(int64(to.Size), int64(from.Size), tlog.TileHashReader(tree, tr))
+		if err != nil {
+			return nil, fmt.Errorf("ProveTree: %v", err)
+		}
+		r := make([][]byte, 0, len(proof))
+		for _, h := range proof {
+			h := h
+			r = append(r, h[:])
+		}
+		glog.V(1).Infof("Fetched proof from %d -> %d: %x", from.Size, to.Size, r)
+		return r, nil
+	}
+
+	opts := feeder.FeedOpts{
+		LogID:           l.ID,
+		LogOrigin:       l.Origin,
+		FetchCheckpoint: fetchCP,
+		FetchProof:      fetchProof,
+		LogSigVerifier:  logSigV,
+		Witness:         w,
+	}
+	if interval > 0 {
+		return feeder.Run(ctx, interval, opts)
+	}
+	_, err = feeder.FeedOnce(ctx, opts)
+	return err
+}
+
+type tileReader struct {
+	fetch func(p string) ([]byte, error)
+}
+
+func (tr tileReader) Height() int { return tileHeight }
+
+func (tr tileReader) SaveTiles([]tlog.Tile, [][]byte) {}
+
+func (tr tileReader) ReadTiles(tiles []tlog.Tile) ([][]byte, error) {
+	r := make([][]byte, 0, len(tiles))
+	for _, t := range tiles {
+		path := fmt.Sprintf("tile/%d/%d/%03d", t.H, t.L, t.N)
+		if t.W < 1<<t.H {
+			path += fmt.Sprintf(".p/%d", t.W)
+		}
+		tile, err := tr.fetch(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch %q: %v", path, err)
+		}
+		r = append(r, tile)
+	}
+	return r, nil
+}
+
+func fetch(ctx context.Context, base *url.URL, path string) ([]byte, error) {
+	u, err := base.Parse(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %v", err)
+	}
+	glog.Infof("GET %s", u.String())
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+	req = req.WithContext(ctx)
+
+	rsp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request to %q: %v", u.String(), err)
+	}
+	defer rsp.Body.Close()
+
+	if rsp.StatusCode == 404 {
+		return nil, os.ErrNotExist
+	}
+	if rsp.StatusCode != 200 {
+		return nil, fmt.Errorf("unexpected status fetching %q: %s", u.String(), rsp.Status)
+	}
+
+	return ioutil.ReadAll(rsp.Body)
+}

--- a/internal/feeder/rekor/rekor_feeder.go
+++ b/internal/feeder/rekor/rekor_feeder.go
@@ -1,0 +1,138 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rekor is an implementation of a witness feeder for the Sigstore log: Rekór.
+package rekor
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/formats/log"
+	"github.com/google/trillian-examples/internal/feeder"
+	"github.com/google/trillian-examples/serverless/config"
+
+	i_note "github.com/google/trillian-examples/internal/note"
+	wit_http "github.com/google/trillian-examples/witness/golang/client/http"
+)
+
+// logInfo is a partial representation of the JSON object returned by Rekór's
+// api/v1/log request.
+type logInfo struct {
+	// SignedTreeHead contains a Rekór checkpoint.
+	SignedTreeHead string `json:"signedTreeHead"`
+}
+
+// proof is a partial representation of the JSON struct returned by the Rekór
+// api/v1/log/proof request.
+type proof struct {
+	Hashes []string `json:"hashes"`
+}
+
+// FeedLog feeds checkpoints from the source log to the witness.
+// If interval is non-zero, this function will return when the context is done, otherwise it will perform
+// one feed cycle and return.
+func FeedLog(ctx context.Context, l config.Log, w wit_http.Witness, timeout time.Duration, interval time.Duration) error {
+	lURL, err := url.Parse(l.URL)
+	if err != nil {
+		return fmt.Errorf("invalid LogURL %q: %v", l.URL, err)
+	}
+	logSigV, err := i_note.NewVerifier(l.PublicKeyType, l.PublicKey)
+	if err != nil {
+		return err
+	}
+
+	fetchCP := func(ctx context.Context) ([]byte, error) {
+		li := logInfo{}
+		if err := getJSON(ctx, lURL, "api/v1/log", &li); err != nil {
+			return nil, fmt.Errorf("failed to fetch log info: %v", err)
+		}
+		return []byte(li.SignedTreeHead), nil
+	}
+	fetchProof := func(ctx context.Context, from, to log.Checkpoint) ([][]byte, error) {
+		if from.Size == 0 {
+			return [][]byte{}, nil
+		}
+		cp := proof{}
+		if err := getJSON(ctx, lURL, fmt.Sprintf("api/v1/log/proof?firstSize=%d&lastSize=%d", from.Size, to.Size), &cp); err != nil {
+			return nil, fmt.Errorf("failed to fetch log info: %v", err)
+		}
+		var err error
+		p := make([][]byte, len(cp.Hashes))
+		for i := range cp.Hashes {
+			p[i], err = hex.DecodeString(cp.Hashes[i])
+			if err != nil {
+				return nil, fmt.Errorf("invalid proof element at %d: %v", i, err)
+			}
+		}
+		return p, nil
+	}
+
+	opts := feeder.FeedOpts{
+		LogID:           l.ID,
+		LogOrigin:       l.Origin,
+		FetchCheckpoint: fetchCP,
+		FetchProof:      fetchProof,
+		LogSigVerifier:  logSigV,
+		Witness:         w,
+	}
+	if interval > 0 {
+		return feeder.Run(ctx, interval, opts)
+	}
+	_, err = feeder.FeedOnce(ctx, opts)
+	return err
+}
+
+func getJSON(ctx context.Context, base *url.URL, path string, s interface{}) error {
+	u, err := base.Parse(path)
+	if err != nil {
+		return fmt.Errorf("failed to parse URL: %v", err)
+	}
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %v", err)
+	}
+	req = req.WithContext(ctx)
+
+	rsp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to make request to %q: %v", u.String(), err)
+	}
+	defer rsp.Body.Close()
+
+	if rsp.StatusCode == 404 {
+		return os.ErrNotExist
+	}
+	if rsp.StatusCode != 200 {
+		return fmt.Errorf("unexpected status fetching %q: %s", u.String(), rsp.Status)
+	}
+
+	raw, err := ioutil.ReadAll(rsp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read body from %q: %v", u.String(), err)
+	}
+	if err := json.Unmarshal(raw, s); err != nil {
+		glog.Infof("Got body:\n%s", string(raw))
+		return fmt.Errorf("failed to unmarshal JSON: %v", err)
+	}
+	return nil
+}

--- a/internal/feeder/serverless/serverless_feeder.go
+++ b/internal/feeder/serverless/serverless_feeder.go
@@ -1,0 +1,121 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package serverless is an implementation of a witness feeder for serverless logs.
+package serverless
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/google/trillian-examples/formats/log"
+	"github.com/google/trillian-examples/internal/feeder"
+	"github.com/google/trillian-examples/serverless/client"
+	"github.com/google/trillian-examples/serverless/config"
+	"github.com/transparency-dev/merkle/rfc6962"
+
+	i_note "github.com/google/trillian-examples/internal/note"
+	wit_http "github.com/google/trillian-examples/witness/golang/client/http"
+)
+
+// FeedLog periodically feeds checkpoints from the log to the witness.
+// This function returns once the provided context is done.
+func FeedLog(ctx context.Context, l config.Log, w wit_http.Witness, timeout time.Duration, interval time.Duration) error {
+	lURL, err := url.Parse(l.URL)
+	if err != nil {
+		return fmt.Errorf("invalid LogURL %q: %v", l.URL, err)
+	}
+	logSigV, err := i_note.NewVerifier(l.PublicKeyType, l.PublicKey)
+	if err != nil {
+		return err
+	}
+	f := newFetcher(lURL)
+	h := rfc6962.DefaultHasher
+
+	fetchCP := func(ctx context.Context) ([]byte, error) {
+		return f(ctx, "checkpoint")
+	}
+	fetchProof := func(ctx context.Context, from, to log.Checkpoint) ([][]byte, error) {
+		if from.Size == 0 {
+			return [][]byte{}, nil
+		}
+		pb, err := client.NewProofBuilder(ctx, to, h.HashChildren, f)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create proof builder for %q: %v", l.Origin, err)
+		}
+
+		conP, err := pb.ConsistencyProof(ctx, from.Size, to.Size)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create proof for %q(%d -> %d): %v", l.Origin, from.Size, to.Size, err)
+		}
+		return conP, nil
+	}
+
+	opts := feeder.FeedOpts{
+		LogID:           l.ID,
+		LogOrigin:       l.Origin,
+		FetchCheckpoint: fetchCP,
+		FetchProof:      fetchProof,
+		LogSigVerifier:  logSigV,
+		Witness:         w,
+	}
+	if interval > 0 {
+		return feeder.Run(context.Background(), interval, opts)
+	}
+	_, err = feeder.FeedOnce(context.Background(), opts)
+	return err
+}
+
+// TODO(al): factor this stuff out and share between tools:
+
+// newFetcher creates a Fetcher for the log at the given root location.
+func newFetcher(root *url.URL) client.Fetcher {
+	get := getByScheme[root.Scheme]
+	if get == nil {
+		panic(fmt.Errorf("unsupported URL scheme %s", root.Scheme))
+	}
+
+	return func(ctx context.Context, p string) ([]byte, error) {
+		u, err := root.Parse(p)
+		if err != nil {
+			return nil, err
+		}
+		return get(ctx, u)
+	}
+}
+
+var getByScheme = map[string]func(context.Context, *url.URL) ([]byte, error){
+	"http":  readHTTP,
+	"https": readHTTP,
+	"file": func(_ context.Context, u *url.URL) ([]byte, error) {
+		return ioutil.ReadFile(u.Path)
+	},
+}
+
+func readHTTP(ctx context.Context, u *url.URL) ([]byte, error) {
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return ioutil.ReadAll(resp.Body)
+}

--- a/internal/feeder/sumdb/sumdb_feeder.go
+++ b/internal/feeder/sumdb/sumdb_feeder.go
@@ -1,0 +1,206 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sumdb implements a feeder for the Go SumDB log.
+package sumdb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/formats/log"
+	"github.com/google/trillian-examples/internal/feeder"
+	"github.com/google/trillian-examples/serverless/config"
+	"github.com/google/trillian-examples/sumdbaudit/client"
+	"github.com/google/trillian-examples/witness/golang/client/http"
+	"github.com/transparency-dev/merkle/compact"
+	"github.com/transparency-dev/merkle/rfc6962"
+	"golang.org/x/mod/sumdb/tlog"
+
+	i_note "github.com/google/trillian-examples/internal/note"
+)
+
+const (
+	tileHeight    = 8
+	leavesPerTile = 1 << tileHeight
+)
+
+var (
+	rf = &compact.RangeFactory{
+		Hash: rfc6962.DefaultHasher.HashChildren,
+	}
+)
+
+func FeedLog(ctx context.Context, l config.Log, w http.Witness, interval time.Duration) error {
+	sdb := client.NewSumDB(tileHeight, l.PublicKey)
+	logSigV, err := i_note.NewVerifier(l.PublicKeyType, l.PublicKey)
+	if err != nil {
+		return err
+	}
+
+	fetchProof := func(ctx context.Context, from, to log.Checkpoint) ([][]byte, error) {
+		broker := newTileBroker(to.Size, sdb.TileHashes)
+
+		required := compact.RangeNodes(from.Size, to.Size)
+		proof := make([][]byte, 0, len(required))
+		for _, n := range required {
+			i, r := convertToSumDBTiles(n)
+			t, err := broker.tile(i)
+			if err != nil {
+				return nil, fmt.Errorf("failed to lookup %s: %v", i, err)
+			}
+			h := t.hash(r)
+			proof = append(proof, h)
+		}
+		return proof, nil
+	}
+
+	fetchCheckpoint := func(_ context.Context) ([]byte, error) {
+		sdbcp, err := sdb.LatestCheckpoint()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get latest checkpoint: %v", err)
+		}
+		return sdbcp.Raw, nil
+
+	}
+
+	opts := feeder.FeedOpts{
+		LogID:           l.ID,
+		LogOrigin:       l.Origin,
+		FetchCheckpoint: fetchCheckpoint,
+		FetchProof:      fetchProof,
+		LogSigVerifier:  logSigV,
+		Witness:         w,
+	}
+
+	return feeder.Run(ctx, interval, opts)
+}
+
+// convertToSumDBTiles takes a NodeID pointing to a node within the overall log,
+// and returns the tile coordinate that it will be found in, along with the nodeID
+// that references the node within that tile.
+func convertToSumDBTiles(n compact.NodeID) (tileIndex, compact.NodeID) {
+	sdbLevel := n.Level / tileHeight
+	rLevel := uint(n.Level % tileHeight)
+
+	// The last leaf that n commits to.
+	lastLeaf := (1<<n.Level)*(n.Index+1) - 1
+	// How many proper leaves are committed to by a tile at sdbLevel.
+	tileLeaves := 1 << ((1 + sdbLevel) * tileHeight)
+
+	sdbOffset := lastLeaf / uint64(tileLeaves)
+	rLeaves := lastLeaf % uint64(tileLeaves)
+	rIndex := rLeaves / (1 << n.Level)
+
+	return tileIndex{
+		level:  int(sdbLevel),
+		offset: int(sdbOffset),
+	}, compact.NewNodeID(rLevel, rIndex)
+}
+
+// tileIndex is the location of a tile.
+// We could have used compact.NodeID, but that would overload its meaning;
+// with this usage tileIndex points to a tile, and NodeID points to a node.
+type tileIndex struct {
+	level, offset int
+}
+
+func (i tileIndex) String() string {
+	return fmt.Sprintf("T(%d,%d)", i.level, i.offset)
+}
+
+type tile struct {
+	leaves [][]byte
+}
+
+func newTile(hs []tlog.Hash) tile {
+	leaves := make([][]byte, len(hs))
+	for i, h := range hs {
+		h := h
+		leaves[i] = h[:]
+	}
+	return tile{
+		leaves: leaves,
+	}
+}
+
+// hash returns the hash of the subtree within this tile identified by n.
+// Note that the coordinate system starts with the bottom left of the tile
+// being (0,0), no matter where this tile appears within the overall log.
+func (t tile) hash(n compact.NodeID) []byte {
+	r := rf.NewEmptyRange(0)
+
+	left := n.Index << uint64(n.Level)
+	right := (n.Index + 1) << uint64(n.Level)
+
+	if len(t.leaves) < int(right) {
+		panic(fmt.Sprintf("index %d out of range of %d leaves", right, len(t.leaves)))
+	}
+	for _, l := range t.leaves[left:right] {
+		r.Append(l[:], nil)
+	}
+	root, err := r.GetRootHash(nil)
+	if err != nil {
+		panic(err)
+	}
+	return root
+}
+
+// tileBroker takes requests for tiles and returns the appropriate tile for the tree size.
+// This will cache results for the lifetime of the broker, and it will ensure that requests
+// for incomplete tiles are requested as partial tiles.
+type tileBroker struct {
+	pts    map[tileIndex]int
+	ts     map[tileIndex]tile
+	lookup func(level, offset, partial int) ([]tlog.Hash, error)
+}
+
+func newTileBroker(size uint64, lookup func(level, offset, partial int) ([]tlog.Hash, error)) tileBroker {
+	pts := make(map[tileIndex]int)
+	l := 0
+	t := size / leavesPerTile
+	o := size % leavesPerTile
+	for {
+		i := tileIndex{l, int(t)}
+		pts[i] = int(o)
+		if t == 0 {
+			break
+		}
+		o = t % leavesPerTile
+		t = t / leavesPerTile
+		l++
+	}
+	return tileBroker{
+		pts:    pts,
+		ts:     make(map[tileIndex]tile),
+		lookup: lookup,
+	}
+}
+
+func (tb *tileBroker) tile(i tileIndex) (tile, error) {
+	if t, ok := tb.ts[i]; ok {
+		return t, nil
+	}
+	partial := tb.pts[i]
+	glog.V(2).Infof("Looking up %s (partial=%d) from remote", i, partial)
+	hs, err := tb.lookup(i.level, i.offset, partial)
+	if err != nil {
+		return tile{}, fmt.Errorf("lookup failed: %v", err)
+	}
+	t := newTile(hs)
+	tb.ts[i] = t
+	return t, nil
+}

--- a/internal/feeder/sumdb/sumdb_feeder_test.go
+++ b/internal/feeder/sumdb/sumdb_feeder_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package sumdb
 
 import (
 	"bytes"

--- a/serverless/cmd/feeder/main.go
+++ b/serverless/cmd/feeder/main.go
@@ -23,18 +23,14 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"net/url"
 	"sync"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/formats/log"
-	"github.com/google/trillian-examples/internal/feeder"
-	"github.com/google/trillian-examples/serverless/client"
+	"github.com/google/trillian-examples/internal/feeder/serverless"
 	"github.com/google/trillian-examples/serverless/config"
-	"github.com/transparency-dev/merkle/rfc6962"
-	"golang.org/x/mod/sumdb/note"
 
 	wit_http "github.com/google/trillian-examples/witness/golang/client/http"
 	yaml "gopkg.in/yaml.v2"
@@ -71,67 +67,18 @@ func main() {
 		URL: u,
 	}
 
+	ctx := context.Background()
 	wg := &sync.WaitGroup{}
 	for _, l := range cfg.Logs {
 		wg.Add(1)
 		go func(l config.Log, w wit_http.Witness) {
 			defer wg.Done()
-			if err := feedLog(l, witness, *timeout, *interval); err != nil {
+			if err := serverless.FeedLog(ctx, l, witness, *timeout, *interval); err != nil {
 				glog.Errorf("feedLog: %v", err)
 			}
 		}(l, witness)
 	}
 	wg.Wait()
-}
-
-func feedLog(l config.Log, w wit_http.Witness, timeout time.Duration, interval time.Duration) error {
-	lURL, err := url.Parse(l.URL)
-	if err != nil {
-		return fmt.Errorf("invalid LogURL %q: %v", l.URL, err)
-	}
-	f := newFetcher(lURL)
-	h := rfc6962.DefaultHasher
-
-	fetchCP := func(ctx context.Context) ([]byte, error) {
-		return f(ctx, "checkpoint")
-	}
-	fetchProof := func(ctx context.Context, from, to log.Checkpoint) ([][]byte, error) {
-		if from.Size == 0 {
-			return [][]byte{}, nil
-		}
-		pb, err := client.NewProofBuilder(ctx, to, h.HashChildren, f)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create proof builder for %q: %v", l.Origin, err)
-		}
-
-		conP, err := pb.ConsistencyProof(ctx, from.Size, to.Size)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create proof for %q(%d -> %d): %v", l.Origin, from.Size, to.Size, err)
-		}
-		return conP, nil
-	}
-
-	opts := feeder.FeedOpts{
-		LogID:           l.ID,
-		LogOrigin:       l.Origin,
-		FetchCheckpoint: fetchCP,
-		FetchProof:      fetchProof,
-		LogSigVerifier:  mustCreateVerifier(l.PublicKey),
-		Witness:         w,
-	}
-	if interval > 0 {
-		return feeder.Run(context.Background(), interval, opts)
-	}
-	_, err = feeder.FeedOnce(context.Background(), opts)
-	return err
-}
-
-func mustCreateVerifier(pub string) note.Verifier {
-	v, err := note.NewVerifier(pub)
-	if err != nil {
-		glog.Exitf("Failed to create signature verifier from %q: %v", pub, err)
-	}
-	return v
 }
 
 func readConfig(f string) (*Config, error) {
@@ -149,43 +96,4 @@ func readConfig(f string) (*Config, error) {
 		}
 	}
 	return &cfg, nil
-}
-
-// TODO(al): factor this stuff out and share between tools:
-
-// newFetcher creates a Fetcher for the log at the given root location.
-func newFetcher(root *url.URL) client.Fetcher {
-	get := getByScheme[root.Scheme]
-	if get == nil {
-		panic(fmt.Errorf("unsupported URL scheme %s", root.Scheme))
-	}
-
-	return func(ctx context.Context, p string) ([]byte, error) {
-		u, err := root.Parse(p)
-		if err != nil {
-			return nil, err
-		}
-		return get(ctx, u)
-	}
-}
-
-var getByScheme = map[string]func(context.Context, *url.URL) ([]byte, error){
-	"http":  readHTTP,
-	"https": readHTTP,
-	"file": func(_ context.Context, u *url.URL) ([]byte, error) {
-		return ioutil.ReadFile(u.Path)
-	},
-}
-
-func readHTTP(ctx context.Context, u *url.URL) ([]byte, error) {
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
 }

--- a/sumdbaudit/witness/cmd/feeder/main.go
+++ b/sumdbaudit/witness/cmd/feeder/main.go
@@ -18,19 +18,15 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"net/url"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/formats/log"
-	"github.com/google/trillian-examples/internal/feeder"
-	"github.com/google/trillian-examples/sumdbaudit/client"
+	"github.com/google/trillian-examples/internal/feeder/sumdb"
+	"github.com/google/trillian-examples/serverless/config"
 	"github.com/google/trillian-examples/witness/golang/client/http"
-	"github.com/transparency-dev/merkle/compact"
-	"github.com/transparency-dev/merkle/rfc6962"
 	"golang.org/x/mod/sumdb/note"
-	"golang.org/x/mod/sumdb/tlog"
 )
 
 var (
@@ -40,29 +36,19 @@ var (
 	witnessKey   = flag.String("wk", "", "The public key of the witness")
 	logID        = flag.String("lid", "", "The ID of the log within the witness")
 	pollInterval = flag.Duration("poll", 10*time.Second, "How quickly to poll the sumdb to get updates")
-
-	rf = &compact.RangeFactory{
-		Hash: rfc6962.DefaultHasher.HashChildren,
-	}
-)
-
-const (
-	tileHeight    = 8
-	leavesPerTile = 1 << tileHeight
 )
 
 func main() {
 	flag.Parse()
 	ctx := context.Background()
-	sdb := client.NewSumDB(tileHeight, *vkey)
-	var w http.Witness
-	if wURL, err := url.Parse(*witness); err != nil {
+	wURL, err := url.Parse(*witness)
+	if err != nil {
 		glog.Exitf("Failed to parse witness URL: %v", err)
-	} else {
-		w = http.Witness{
-			URL:      wURL,
-			Verifier: mustCreateVerifier(*witnessKey),
-		}
+	}
+
+	w := http.Witness{
+		URL:      wURL,
+		Verifier: mustCreateVerifier(*witnessKey),
 	}
 
 	lid := *logID
@@ -70,159 +56,14 @@ func main() {
 		lid = log.ID(*origin, []byte(*vkey))
 	}
 
-	fetchCheckpoint := func(_ context.Context) ([]byte, error) {
-		sdbcp, err := sdb.LatestCheckpoint()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get latest checkpoint: %v", err)
-		}
-		return sdbcp.Raw, nil
-
+	log := config.Log{
+		Origin:    *origin,
+		PublicKey: *vkey,
+		ID:        lid,
 	}
-	fetchProof := func(ctx context.Context, from, to log.Checkpoint) ([][]byte, error) {
-		broker := newTileBroker(to.Size, sdb.TileHashes)
-
-		required := compact.RangeNodes(from.Size, to.Size)
-		proof := make([][]byte, 0, len(required))
-		for _, n := range required {
-			i, r := convertToSumDBTiles(n)
-			t, err := broker.tile(i)
-			if err != nil {
-				return nil, fmt.Errorf("failed to lookup %s: %v", i, err)
-			}
-			h := t.hash(r)
-			proof = append(proof, h)
-		}
-		return proof, nil
-	}
-
-	opts := feeder.FeedOpts{
-		LogID:           lid,
-		LogOrigin:       *origin,
-		FetchCheckpoint: fetchCheckpoint,
-		FetchProof:      fetchProof,
-		LogSigVerifier:  mustCreateVerifier(*vkey),
-		Witness:         w,
-	}
-
-	if err := feeder.Run(ctx, *pollInterval, opts); err != nil {
+	if err := sumdb.FeedLog(ctx, log, w, *pollInterval); err != nil {
 		glog.Exitf("Feeder: %v", err)
 	}
-}
-
-// convertToSumDBTiles takes a NodeID pointing to a node within the overall log,
-// and returns the tile coordinate that it will be found in, along with the nodeID
-// that references the node within that tile.
-func convertToSumDBTiles(n compact.NodeID) (tileIndex, compact.NodeID) {
-	sdbLevel := n.Level / tileHeight
-	rLevel := uint(n.Level % tileHeight)
-
-	// The last leaf that n commits to.
-	lastLeaf := (1<<n.Level)*(n.Index+1) - 1
-	// How many proper leaves are committed to by a tile at sdbLevel.
-	tileLeaves := 1 << ((1 + sdbLevel) * tileHeight)
-
-	sdbOffset := lastLeaf / uint64(tileLeaves)
-	rLeaves := lastLeaf % uint64(tileLeaves)
-	rIndex := rLeaves / (1 << n.Level)
-
-	return tileIndex{
-		level:  int(sdbLevel),
-		offset: int(sdbOffset),
-	}, compact.NewNodeID(rLevel, rIndex)
-}
-
-// tileIndex is the location of a tile.
-// We could have used compact.NodeID, but that would overload its meaning;
-// with this usage tileIndex points to a tile, and NodeID points to a node.
-type tileIndex struct {
-	level, offset int
-}
-
-func (i tileIndex) String() string {
-	return fmt.Sprintf("T(%d,%d)", i.level, i.offset)
-}
-
-type tile struct {
-	leaves [][]byte
-}
-
-func newTile(hs []tlog.Hash) tile {
-	leaves := make([][]byte, len(hs))
-	for i, h := range hs {
-		h := h
-		leaves[i] = h[:]
-	}
-	return tile{
-		leaves: leaves,
-	}
-}
-
-// hash returns the hash of the subtree within this tile identified by n.
-// Note that the coordinate system starts with the bottom left of the tile
-// being (0,0), no matter where this tile appears within the overall log.
-func (t tile) hash(n compact.NodeID) []byte {
-	r := rf.NewEmptyRange(0)
-
-	left := n.Index << uint64(n.Level)
-	right := (n.Index + 1) << uint64(n.Level)
-
-	if len(t.leaves) < int(right) {
-		panic(fmt.Sprintf("index %d out of range of %d leaves", right, len(t.leaves)))
-	}
-	for _, l := range t.leaves[left:right] {
-		r.Append(l[:], nil)
-	}
-	root, err := r.GetRootHash(nil)
-	if err != nil {
-		panic(err)
-	}
-	return root
-}
-
-// tileBroker takes requests for tiles and returns the appropriate tile for the tree size.
-// This will cache results for the lifetime of the broker, and it will ensure that requests
-// for incomplete tiles are requested as partial tiles.
-type tileBroker struct {
-	pts    map[tileIndex]int
-	ts     map[tileIndex]tile
-	lookup func(level, offset, partial int) ([]tlog.Hash, error)
-}
-
-func newTileBroker(size uint64, lookup func(level, offset, partial int) ([]tlog.Hash, error)) tileBroker {
-	pts := make(map[tileIndex]int)
-	l := 0
-	t := size / leavesPerTile
-	o := size % leavesPerTile
-	for {
-		i := tileIndex{l, int(t)}
-		pts[i] = int(o)
-		if t == 0 {
-			break
-		}
-		o = t % leavesPerTile
-		t = t / leavesPerTile
-		l++
-	}
-	return tileBroker{
-		pts:    pts,
-		ts:     make(map[tileIndex]tile),
-		lookup: lookup,
-	}
-}
-
-func (tb *tileBroker) tile(i tileIndex) (tile, error) {
-	if t, ok := tb.ts[i]; ok {
-		return t, nil
-	}
-	partial := tb.pts[i]
-	glog.V(2).Infof("Looking up %s (partial=%d) from remote", i, partial)
-	hs, err := tb.lookup(i.level, i.offset, partial)
-	if err != nil {
-		return tile{}, fmt.Errorf("lookup failed: %v", err)
-	}
-	t := newTile(hs)
-	tb.ts[i] = t
-	return t, nil
 }
 
 func mustCreateVerifier(pub string) note.Verifier {


### PR DESCRIPTION
This allows alternative main files to be created for these feeders, e.g. TamaGo unikernels.

The delta appears large, but is almost entirely mechanical moving of existing code.