### PR TITLE
[Witness] Fix DB related issues

### DIFF
--- a/witness/golang/cmd/witness/impl/witness.go
+++ b/witness/golang/cmd/witness/impl/witness.go
@@ -100,6 +100,9 @@ func Main(ctx context.Context, opts ServerOpts) error {
 	if err != nil {
 		return fmt.Errorf("failed to connect to DB: %w", err)
 	}
+	// Avoid "database locked" issues with multiple concurrent updates.
+	db.SetMaxOpenConns(1)
+
 	// Load log configuration into the map.
 	logMap, err := buildLogMap(opts.Config)
 	if err != nil {

--- a/witness/golang/cmd/witness/internal/witness/witness.go
+++ b/witness/golang/cmd/witness/internal/witness/witness.go
@@ -155,6 +155,7 @@ func (w *Witness) Update(ctx context.Context, logID string, nextRaw []byte, proo
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create db tx: %v", err)
 	}
+	// Defer a rollback to clean up the TX if something fails.
 	defer tx.Rollback()
 
 	// Get the latest checkpoint (if one exists) and compact range.


### PR DESCRIPTION
Fixes a couple of issues with the witness' storage implementation:
1. The call to `Exec` to update checkpoints can silently fail, ensure we catch those errors
2. Errors caught by the fix to (1) were seen for concurrent update RPCs (where updates are for distinct logs), resulting in a `database locked` error. Avoid this situation entirely by limiting the number of concurrent connections.

Also simplify the SQL used for the update.
