### PR TITLE
Updated Pixel BT public key

### DIFF
--- a/witness/golang/omniwitness/distributor_configs/witness.yaml
+++ b/witness/golang/omniwitness/distributor_configs/witness.yaml
@@ -11,7 +11,7 @@ Logs:
     URL: https://rekor.sigstore.dev
   - Origin: DEFAULT
     PublicKeyType: ecdsa
-    PublicKey: Pixel-Transparency-Log-2021+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=
+    PublicKey: pixel6_transparency_log+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=
     URL: https://developers.google.com/android/binary_transparency/
 
 Witness:

--- a/witness/golang/omniwitness/feeder_configs/pixel.yaml
+++ b/witness/golang/omniwitness/feeder_configs/pixel.yaml
@@ -1,7 +1,7 @@
 Log:
   Origin: DEFAULT
   PublicKeyType: ecdsa
-  PublicKey: Pixel-Transparency-Log-2021+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=
+  PublicKey: pixel6_transparency_log+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=
   URL: https://developers.google.com/android/binary_transparency/
 
 Witness:

--- a/witness/golang/omniwitness/witness_configs/witness.yaml
+++ b/witness/golang/omniwitness/witness_configs/witness.yaml
@@ -14,7 +14,7 @@ Logs:
     UseCompact: false
   - Origin: DEFAULT
     PublicKeyType: ecdsa
-    PublicKey: Pixel-Transparency-Log-2021+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=
+    PublicKey: pixel6_transparency_log+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=
     HashStrategy: default
     UseCompact: false
 


### PR DESCRIPTION
This was updated in the last week or so. Witness operators will need to update their config files to this new version and redeploy. I recommend also updating the docker images to more recent versions too.
