### PR TITLE
Improve feeder interfaces and timeout handling

### DIFF
--- a/feeder/cmd/pixel_bt_feeder/main.go
+++ b/feeder/cmd/pixel_bt_feeder/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"net/url"
 	"time"
 
@@ -63,8 +64,11 @@ func main() {
 		URL: u,
 	}
 
+	c := &http.Client{
+		Timeout: *timeout,
+	}
 	ctx := context.Background()
-	if err := pixelbt.FeedLog(ctx, cfg.Log, witness, *timeout, *interval); err != nil {
+	if err := pixelbt.FeedLog(ctx, cfg.Log, witness, c, *interval); err != nil {
 		glog.Errorf("feedLog: %v", err)
 	}
 }

--- a/feeder/cmd/rekor_feeder/main.go
+++ b/feeder/cmd/rekor_feeder/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"net/url"
 	"sync"
 	"time"
@@ -70,7 +71,11 @@ func main() {
 		wg.Add(1)
 		go func(l config.Log, w wit_http.Witness) {
 			defer wg.Done()
-			if err := rekor.FeedLog(ctx, l, witness, *timeout, *interval); err != nil {
+
+			c := &http.Client{
+				Timeout: *timeout,
+			}
+			if err := rekor.FeedLog(ctx, l, witness, c, *interval); err != nil {
 				glog.Errorf("feedLog: %v", err)
 			}
 		}(l, witness)

--- a/internal/feeder/serverless/serverless_feeder.go
+++ b/internal/feeder/serverless/serverless_feeder.go
@@ -30,12 +30,11 @@ import (
 	"github.com/transparency-dev/merkle/rfc6962"
 
 	i_note "github.com/google/trillian-examples/internal/note"
-	wit_http "github.com/google/trillian-examples/witness/golang/client/http"
 )
 
 // FeedLog periodically feeds checkpoints from the log to the witness.
 // This function returns once the provided context is done.
-func FeedLog(ctx context.Context, l config.Log, w wit_http.Witness, timeout time.Duration, interval time.Duration) error {
+func FeedLog(ctx context.Context, l config.Log, w feeder.Witness, c *http.Client, interval time.Duration) error {
 	lURL, err := url.Parse(l.URL)
 	if err != nil {
 		return fmt.Errorf("invalid LogURL %q: %v", l.URL, err)
@@ -44,7 +43,7 @@ func FeedLog(ctx context.Context, l config.Log, w wit_http.Witness, timeout time
 	if err != nil {
 		return err
 	}
-	f := newFetcher(lURL)
+	f := newFetcher(c, lURL)
 	h := rfc6962.DefaultHasher
 
 	fetchCP := func(ctx context.Context) ([]byte, error) {
@@ -84,9 +83,30 @@ func FeedLog(ctx context.Context, l config.Log, w wit_http.Witness, timeout time
 // TODO(al): factor this stuff out and share between tools:
 
 // newFetcher creates a Fetcher for the log at the given root location.
-func newFetcher(root *url.URL) client.Fetcher {
-	get := getByScheme[root.Scheme]
-	if get == nil {
+// If the scheme is http/https then the client provided will be used.
+func newFetcher(c *http.Client, root *url.URL) client.Fetcher {
+	var get func(context.Context, *url.URL) ([]byte, error)
+	switch root.Scheme {
+	case "http":
+		fallthrough
+	case "https":
+		get = func(ctx context.Context, u *url.URL) ([]byte, error) {
+			req, err := http.NewRequest("GET", u.String(), nil)
+			if err != nil {
+				return nil, err
+			}
+			resp, err := c.Do(req.WithContext(ctx))
+			if err != nil {
+				return nil, err
+			}
+			defer resp.Body.Close()
+			return ioutil.ReadAll(resp.Body)
+		}
+	case "file":
+		get = func(_ context.Context, u *url.URL) ([]byte, error) {
+			return ioutil.ReadFile(u.Path)
+		}
+	default:
 		panic(fmt.Errorf("unsupported URL scheme %s", root.Scheme))
 	}
 
@@ -97,25 +117,4 @@ func newFetcher(root *url.URL) client.Fetcher {
 		}
 		return get(ctx, u)
 	}
-}
-
-var getByScheme = map[string]func(context.Context, *url.URL) ([]byte, error){
-	"http":  readHTTP,
-	"https": readHTTP,
-	"file": func(_ context.Context, u *url.URL) ([]byte, error) {
-		return ioutil.ReadFile(u.Path)
-	},
-}
-
-func readHTTP(ctx context.Context, u *url.URL) ([]byte, error) {
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
 }

--- a/internal/feeder/serverless/serverless_feeder.go
+++ b/internal/feeder/serverless/serverless_feeder.go
@@ -81,6 +81,8 @@ func FeedLog(ctx context.Context, l config.Log, w feeder.Witness, c *http.Client
 }
 
 // TODO(al): factor this stuff out and share between tools:
+// Consider moving client.Fetcher to somewhere more general, and then
+// replacing http.Client with this Fetcher in all feeder impls.
 
 // newFetcher creates a Fetcher for the log at the given root location.
 // If the scheme is http/https then the client provided will be used.

--- a/internal/feeder/sumdb/sumdb_feeder.go
+++ b/internal/feeder/sumdb/sumdb_feeder.go
@@ -18,6 +18,7 @@ package sumdb
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/golang/glog"
@@ -25,7 +26,6 @@ import (
 	"github.com/google/trillian-examples/internal/feeder"
 	"github.com/google/trillian-examples/serverless/config"
 	"github.com/google/trillian-examples/sumdbaudit/client"
-	"github.com/google/trillian-examples/witness/golang/client/http"
 	"github.com/transparency-dev/merkle/compact"
 	"github.com/transparency-dev/merkle/rfc6962"
 	"golang.org/x/mod/sumdb/tlog"
@@ -44,8 +44,8 @@ var (
 	}
 )
 
-func FeedLog(ctx context.Context, l config.Log, w http.Witness, interval time.Duration) error {
-	sdb := client.NewSumDB(tileHeight, l.PublicKey)
+func FeedLog(ctx context.Context, l config.Log, w feeder.Witness, c *http.Client, interval time.Duration) error {
+	sdb := client.NewSumDB(tileHeight, l.PublicKey, c)
 	logSigV, err := i_note.NewVerifier(l.PublicKeyType, l.PublicKey)
 	if err != nil {
 		return err

--- a/serverless/cmd/feeder/main.go
+++ b/serverless/cmd/feeder/main.go
@@ -23,6 +23,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"net/url"
 	"sync"
 	"time"
@@ -73,7 +74,11 @@ func main() {
 		wg.Add(1)
 		go func(l config.Log, w wit_http.Witness) {
 			defer wg.Done()
-			if err := serverless.FeedLog(ctx, l, witness, *timeout, *interval); err != nil {
+
+			c := &http.Client{
+				Timeout: *timeout,
+			}
+			if err := serverless.FeedLog(ctx, l, witness, c, *interval); err != nil {
 				glog.Errorf("feedLog: %v", err)
 			}
 		}(l, witness)

--- a/sumdbaudit/cli/clone/clone.go
+++ b/sumdbaudit/cli/clone/clone.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"context"
+	"net/http"
+	"time"
 
 	"flag"
 
@@ -26,10 +28,11 @@ import (
 )
 
 var (
-	height = flag.Int("h", 8, "tile height")
-	vkey   = flag.String("k", "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8", "key")
-	extraV = flag.Bool("x", false, "performs additional checks on each tile hashes")
-	force  = flag.Bool("f", false, "forces the auditor to run even if no new data is available")
+	height  = flag.Int("h", 8, "tile height")
+	vkey    = flag.String("k", "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8", "key")
+	extraV  = flag.Bool("x", false, "performs additional checks on each tile hashes")
+	force   = flag.Bool("f", false, "forces the auditor to run even if no new data is available")
+	timeout = flag.Duration("timeout", 10*time.Second, "Maximum time to wait for http connections to complete.")
 )
 
 // Clones the leaves of the SumDB into the local database and verifies the result.
@@ -49,7 +52,9 @@ func main() {
 		glog.Exitf("failed to init DB: %v", err)
 	}
 
-	sumDB := client.NewSumDB(*height, *vkey)
+	sumDB := client.NewSumDB(*height, *vkey, &http.Client{
+		Timeout: *timeout,
+	})
 	checkpoint, err := sumDB.LatestCheckpoint()
 	if err != nil {
 		glog.Exitf("failed to get latest checkpoint: %s", err)

--- a/sumdbaudit/cli/mirror/mirror.go
+++ b/sumdbaudit/cli/mirror/mirror.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"flag"
+	"net/http"
 	"time"
 
 	"github.com/golang/glog"
@@ -28,6 +29,7 @@ var (
 	height   = flag.Int("h", 8, "tile height")
 	vkey     = flag.String("k", "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8", "key")
 	unpack   = flag.Bool("unpack", false, "if provided then the leafMetadata table will be populated by parsing the raw leaf data")
+	timeout  = flag.Duration("timeout", 10*time.Second, "Maximum time to wait for http connections to complete.")
 	interval = flag.Duration("interval", 5*time.Minute, "how long to wait between runs")
 )
 
@@ -45,7 +47,9 @@ func main() {
 	if err != nil {
 		glog.Exitf("Failed to init DB: %v", err)
 	}
-	sumDB := client.NewSumDB(*height, *vkey)
+	sumDB := client.NewSumDB(*height, *vkey, &http.Client{
+		Timeout: *timeout,
+	})
 	s := audit.NewService(db, sumDB, *height)
 
 	for {

--- a/sumdbaudit/cli/witness/witness.go
+++ b/sumdbaudit/cli/witness/witness.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/sumdbaudit/audit"
@@ -30,8 +31,9 @@ import (
 )
 
 var (
-	height = flag.Int("h", 8, "tile height")
-	vkey   = flag.String("k", "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8", "key")
+	height  = flag.Int("h", 8, "tile height")
+	vkey    = flag.String("k", "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8", "key")
+	timeout = flag.Duration("timeout", 10*time.Second, "Maximum time to wait for http connections to complete.")
 
 	listenAddr = flag.String("listen", ":8000", "address:port to listen for requests on")
 )
@@ -92,7 +94,9 @@ func main() {
 		glog.Exitf("Failed to open DB: %v", err)
 	}
 
-	sumDB := client.NewSumDB(*height, *vkey)
+	sumDB := client.NewSumDB(*height, *vkey, &http.Client{
+		Timeout: *timeout,
+	})
 	auditor := audit.NewService(db, sumDB, *height)
 	server := &server{a: auditor}
 

--- a/sumdbaudit/witness/cmd/feeder/main.go
+++ b/sumdbaudit/witness/cmd/feeder/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	"flag"
+	"net/http"
 	"net/url"
 	"time"
 
@@ -25,7 +26,7 @@ import (
 	"github.com/google/trillian-examples/formats/log"
 	"github.com/google/trillian-examples/internal/feeder/sumdb"
 	"github.com/google/trillian-examples/serverless/config"
-	"github.com/google/trillian-examples/witness/golang/client/http"
+	wclient "github.com/google/trillian-examples/witness/golang/client/http"
 	"golang.org/x/mod/sumdb/note"
 )
 
@@ -46,7 +47,7 @@ func main() {
 		glog.Exitf("Failed to parse witness URL: %v", err)
 	}
 
-	w := http.Witness{
+	w := wclient.Witness{
 		URL:      wURL,
 		Verifier: mustCreateVerifier(*witnessKey),
 	}
@@ -61,7 +62,7 @@ func main() {
 		PublicKey: *vkey,
 		ID:        lid,
 	}
-	if err := sumdb.FeedLog(ctx, log, w, *pollInterval); err != nil {
+	if err := sumdb.FeedLog(ctx, log, w, http.DefaultClient, *pollInterval); err != nil {
 		glog.Exitf("Feeder: %v", err)
 	}
 }


### PR DESCRIPTION
All feeders now take a http client used for all http connections. Furthermore, they all take the interface definition for a witness instead of the http client implementation. This allows different implementations to be passed in

All clients configure the http client with a timeout. Previously, it doesn't look like the timeout was actually being used in many cases.
