### PR TITLE
Updated tamago to latest version

### DIFF
--- a/binary_transparency/firmware/devices/usbarmory/bootloader/boot.go
+++ b/binary_transparency/firmware/devices/usbarmory/bootloader/boot.go
@@ -25,7 +25,7 @@ func exec(kernel uint32, params uint32)
 func svc()
 
 func boot(kernel uint32, params uint32) {
-	arm.ExceptionHandler(func(n int) {
+	arm.SystemExceptionHandler = func(n int) {
 		if n != arm.SUPERVISOR {
 			panic("unhandled exception")
 		}
@@ -38,12 +38,12 @@ func boot(kernel uint32, params uint32) {
 		// RNGB driver doesn't play well with previous initializations
 		rngb.Reset()
 
-		imx6.ARM.InterruptsDisable()
-		imx6.ARM.CacheFlushData()
-		imx6.ARM.CacheDisable()
+		imx6.ARM.DisableInterrupts()
+		imx6.ARM.FlushDataCache()
+		imx6.ARM.DisableCache()
 
 		exec(kernel, params)
-	})
+	}
 
 	svc()
 }

--- a/binary_transparency/firmware/devices/usbarmory/bootloader/elf.go
+++ b/binary_transparency/firmware/devices/usbarmory/bootloader/elf.go
@@ -44,7 +44,7 @@ func loadELF(mem uint32, kernel []byte) (addr uint32) {
 		}
 
 		offset := uint32(prg.Paddr) - mem
-		dma.Write(mem, b, int(offset))
+		dma.Write(mem, int(offset), b)
 	}
 
 	return uint32(f.Entry)

--- a/binary_transparency/firmware/devices/usbarmory/bootloader/main.go
+++ b/binary_transparency/firmware/devices/usbarmory/bootloader/main.go
@@ -129,8 +129,8 @@ func main() {
 	if conf.elf {
 		boot(loadELF(mem, conf.kernel), 0)
 	} else {
-		dma.Write(mem, conf.kernel, kernelOffset)
-		dma.Write(mem, conf.params, paramsOffset)
+		dma.Write(mem, kernelOffset, conf.kernel)
+		dma.Write(mem, paramsOffset, conf.params)
 
 		boot(mem+kernelOffset, mem+paramsOffset)
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.2
 	github.com/dsoprea/go-ext4 v0.0.0-20190528173430-c13b09fc0ff8
 	github.com/dsoprea/go-logging v0.0.0-20200710184922-b02d349568dd // indirect
-	github.com/f-secure-foundry/tamago v0.0.0-20201201222556-c7d3ba598c56
+	github.com/f-secure-foundry/tamago v0.0.0-20220307101044-d73fcdd7f11b
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -246,6 +246,8 @@ github.com/envoyproxy/protoc-gen-validate v0.3.0-java/go.mod h1:iSmxcyjqTsJpI2R4
 github.com/etcd-io/gofail v0.0.0-20190801230047-ad7f989257ca/go.mod h1:49H/RkXP8pKaZy4h0d+NW16rSLhyVBt4o6VLJbmOqDE=
 github.com/f-secure-foundry/tamago v0.0.0-20201201222556-c7d3ba598c56 h1:HH3Y8V0tIqE/ZgzqwvZ8BF868LdhjlJkFjXdnArk6DU=
 github.com/f-secure-foundry/tamago v0.0.0-20201201222556-c7d3ba598c56/go.mod h1:+xmhdYxGfaNhWUZ/F1mbwFu38H73slg/k/oPjOL7tc8=
+github.com/f-secure-foundry/tamago v0.0.0-20220307101044-d73fcdd7f11b h1:lQprQ63VwWseLwyyC1jqFfEbawf3sKTlyBendLxdjq8=
+github.com/f-secure-foundry/tamago v0.0.0-20220307101044-d73fcdd7f11b/go.mod h1:PeqYMgpP/R3MESqPnF2rvmD6Mu8G4JSSf9srGeQkz2M=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=


### PR DESCRIPTION
Fixed breaking changes from various refactorings. A newer version of tamago is needed to get the imx-usbnet package working for the unikernel witness in #601.
