### PR TITLE
serverless/client: Don't panic when tile is unreachable

### DIFF
--- a/serverless/client/client.go
+++ b/serverless/client/client.go
@@ -254,12 +254,12 @@ func (n *nodeCache) GetNode(ctx context.Context, id compact.NodeID) ([]byte, err
 		n.tiles[tKey] = *tile
 	}
 	nodeKey := int(api.TileNodeKey(nodeLevel, nodeIndex))
-	if nodeKey > len(t.Nodes) {
-		return nil, fmt.Errorf("node %v (tile coords [%d,%d]/[%d,%d]) unreachable", id, tileLevel, tileIndex, nodeLevel, nodeIndex)
+	if l := len(t.Nodes); nodeKey >= l {
+		return nil, fmt.Errorf("node %v (tile coords [%d,%d]/[%d,%d], key %d) outside populated tile nodes (%d)", id, tileLevel, tileIndex, nodeLevel, nodeIndex, nodeKey, l)
 	}
 	node := t.Nodes[nodeKey]
 	if node == nil {
-		return nil, fmt.Errorf("node %v (tile coords [%d,%d]/[%d,%d]) unknown", id, tileLevel, tileIndex, nodeLevel, nodeIndex)
+		return nil, fmt.Errorf("node %v (tile coords [%d,%d]/[%d,%d], key %d) unknown", id, tileLevel, tileIndex, nodeLevel, nodeIndex, nodeKey)
 	}
 	return node, nil
 }

--- a/serverless/client/client.go
+++ b/serverless/client/client.go
@@ -253,7 +253,11 @@ func (n *nodeCache) GetNode(ctx context.Context, id compact.NodeID) ([]byte, err
 		t = *tile
 		n.tiles[tKey] = *tile
 	}
-	node := t.Nodes[api.TileNodeKey(nodeLevel, nodeIndex)]
+	nodeKey := int(api.TileNodeKey(nodeLevel, nodeIndex))
+	if nodeKey > len(t.Nodes) {
+		return nil, fmt.Errorf("node %v (tile coords [%d,%d]/[%d,%d]) unreachable", id, tileLevel, tileIndex, nodeLevel, nodeIndex)
+	}
+	node := t.Nodes[nodeKey]
 	if node == nil {
 		return nil, fmt.Errorf("node %v (tile coords [%d,%d]/[%d,%d]) unknown", id, tileLevel, tileIndex, nodeLevel, nodeIndex)
 	}


### PR DESCRIPTION
Happens if we specify a non-existing "to-size" in a consistency proof

Signed-off-by: Morten Linderud <morten@linderud.pw>