### PR TITLE
sumdbconfig

### DIFF
--- a/clone/cmd/sumdbclone/sumdbclone.go
+++ b/clone/cmd/sumdbclone/sumdbclone.go
@@ -36,6 +36,7 @@ import (
 
 var (
 	vkey           = flag.String("vkey", "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8", "The verification key for the log checkpoints")
+	url            = flag.String("url", "https://sum.golang.org", "The base URL for the sumdb HTTP API.")
 	mysqlURI       = flag.String("mysql_uri", "", "URL of a MySQL database to clone the log into. The DB should contain only one log.")
 	writeBatchSize = flag.Uint("write_batch_size", 1024, "The number of leaves to write in each DB transaction.")
 	workers        = flag.Uint("workers", 4, "The number of worker threads to run in parallel to fetch entries.")
@@ -59,7 +60,7 @@ func main() {
 		glog.Exitf("Failed to connect to database: %q", err)
 	}
 
-	client := sdbclient.NewSumDB(tileHeight, *vkey, &http.Client{
+	client := sdbclient.NewSumDB(tileHeight, *vkey, *url, &http.Client{
 		Timeout: *timeout,
 	})
 	targetCp, err := client.LatestCheckpoint()

--- a/internal/feeder/sumdb/sumdb_feeder.go
+++ b/internal/feeder/sumdb/sumdb_feeder.go
@@ -45,7 +45,7 @@ var (
 )
 
 func FeedLog(ctx context.Context, l config.Log, w feeder.Witness, c *http.Client, interval time.Duration) error {
-	sdb := client.NewSumDB(tileHeight, l.PublicKey, c)
+	sdb := client.NewSumDB(tileHeight, l.PublicKey, l.URL, c)
 	logSigV, err := i_note.NewVerifier(l.PublicKeyType, l.PublicKey)
 	if err != nil {
 		return err

--- a/sumdbaudit/cli/clone/clone.go
+++ b/sumdbaudit/cli/clone/clone.go
@@ -30,6 +30,7 @@ import (
 var (
 	height  = flag.Int("h", 8, "tile height")
 	vkey    = flag.String("k", "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8", "key")
+	url     = flag.String("url", "https://sum.golang.org", "Base URL for the sumdb HTTP API.")
 	extraV  = flag.Bool("x", false, "performs additional checks on each tile hashes")
 	force   = flag.Bool("f", false, "forces the auditor to run even if no new data is available")
 	timeout = flag.Duration("timeout", 10*time.Second, "Maximum time to wait for http connections to complete.")
@@ -52,7 +53,7 @@ func main() {
 		glog.Exitf("failed to init DB: %v", err)
 	}
 
-	sumDB := client.NewSumDB(*height, *vkey, &http.Client{
+	sumDB := client.NewSumDB(*height, *vkey, *url, &http.Client{
 		Timeout: *timeout,
 	})
 	checkpoint, err := sumDB.LatestCheckpoint()

--- a/sumdbaudit/cli/mirror/mirror.go
+++ b/sumdbaudit/cli/mirror/mirror.go
@@ -28,6 +28,7 @@ import (
 var (
 	height   = flag.Int("h", 8, "tile height")
 	vkey     = flag.String("k", "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8", "key")
+	url      = flag.String("url", "https://sum.golang.org", "Base URL for the sumdb HTTP API.")
 	unpack   = flag.Bool("unpack", false, "if provided then the leafMetadata table will be populated by parsing the raw leaf data")
 	timeout  = flag.Duration("timeout", 10*time.Second, "Maximum time to wait for http connections to complete.")
 	interval = flag.Duration("interval", 5*time.Minute, "how long to wait between runs")
@@ -47,7 +48,7 @@ func main() {
 	if err != nil {
 		glog.Exitf("Failed to init DB: %v", err)
 	}
-	sumDB := client.NewSumDB(*height, *vkey, &http.Client{
+	sumDB := client.NewSumDB(*height, *vkey, *url, &http.Client{
 		Timeout: *timeout,
 	})
 	s := audit.NewService(db, sumDB, *height)

--- a/sumdbaudit/cli/witness/witness.go
+++ b/sumdbaudit/cli/witness/witness.go
@@ -33,6 +33,7 @@ import (
 var (
 	height  = flag.Int("h", 8, "tile height")
 	vkey    = flag.String("k", "sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8", "key")
+	url     = flag.String("url", "https://sum.golang.org", "Base URL for the sumdb HTTP API.")
 	timeout = flag.Duration("timeout", 10*time.Second, "Maximum time to wait for http connections to complete.")
 
 	listenAddr = flag.String("listen", ":8000", "address:port to listen for requests on")
@@ -94,7 +95,7 @@ func main() {
 		glog.Exitf("Failed to open DB: %v", err)
 	}
 
-	sumDB := client.NewSumDB(*height, *vkey, &http.Client{
+	sumDB := client.NewSumDB(*height, *vkey, *url, &http.Client{
 		Timeout: *timeout,
 	})
 	auditor := audit.NewService(db, sumDB, *height)

--- a/sumdbaudit/client/sumdb.go
+++ b/sumdbaudit/client/sumdb.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"strings"
 
 	"golang.org/x/mod/sumdb/note"
 	"golang.org/x/mod/sumdb/tlog"
@@ -55,19 +54,13 @@ type SumDBClient struct {
 }
 
 // NewSumDB creates a new client that fetches tiles of the given height.
-func NewSumDB(height int, vkey string, c *http.Client) *SumDBClient {
-	name := vkey
-	if i := strings.Index(name, "+"); i >= 0 {
-		name = name[:i]
-	}
-	target := "https://" + name
-
+func NewSumDB(height int, vkey, url string, c *http.Client) *SumDBClient {
 	return &SumDBClient{
 		height: height,
 		vkey:   vkey,
 		fetcher: &HTTPFetcher{
 			c:       c,
-			baseURL: target,
+			baseURL: url,
 		},
 	}
 }

--- a/witness/golang/omniwitness/configs.go
+++ b/witness/golang/omniwitness/configs.go
@@ -29,6 +29,10 @@ var (
 	//go:embed feeder_configs/serverless.yaml
 	ConfigFeederServerless []byte
 
+	// ConfigFeederSumDB is the config for the feeder for SumDB.
+	//go:embed feeder_configs/sumdb.yaml
+	ConfigFeederSumDB []byte
+
 	// ConfigWitness is the config for the witness used in the omniwitness.
 	//go:embed witness_configs/witness.yaml
 	ConfigWitness []byte

--- a/witness/golang/omniwitness/feeder_configs/sumdb.yaml
+++ b/witness/golang/omniwitness/feeder_configs/sumdb.yaml
@@ -1,0 +1,7 @@
+Logs:
+  - Origin: go.sum database tree
+    PublicKey: sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8
+    URL: https://sum.golang.org
+
+Witness:
+  URL: http://witness:8100


### PR DESCRIPTION
 Make SumDB Feeder configured similarly to the others

This feeder was implemented before the others, and at the time it seemed like a good idea to have it take the URL from the key name. This now takes the URL explicitly, which makes it consistent with the others. The config for this feeder in the omniwitness now lives in a config file.
