### PR TITLE
Use the context passed in

### DIFF
--- a/internal/feeder/serverless/serverless_feeder.go
+++ b/internal/feeder/serverless/serverless_feeder.go
@@ -74,9 +74,9 @@ func FeedLog(ctx context.Context, l config.Log, w feeder.Witness, c *http.Client
 		Witness:         w,
 	}
 	if interval > 0 {
-		return feeder.Run(context.Background(), interval, opts)
+		return feeder.Run(ctx, interval, opts)
 	}
-	_, err = feeder.FeedOnce(context.Background(), opts)
+	_, err = feeder.FeedOnce(ctx, opts)
 	return err
 }
 


### PR DESCRIPTION
This will cause this feeder to bail when the context becomes cancelled. I'm surprised there isn't a lint check for calling one of the methods like context.Background when there is already a ctx in scope.
