### PR TITLE
Don't hard-fail if someone gets an incoming directory created for an unknown log

### DIFF
--- a/serverless/deploy/github/distributor/combine_witness_signatures/combine_witness_signatures.go
+++ b/serverless/deploy/github/distributor/combine_witness_signatures/combine_witness_signatures.go
@@ -65,7 +65,10 @@ func main() {
 
 		o, ok := opts[logID]
 		if !ok {
-			glog.Exitf("Found incoming directory for unknown log %q", logID)
+			// TODO(mhutchinson): it would be better to not allow these to be automerged,
+			// but not blocking everything else should this happen is a big win.
+			glog.Errorf("Found incoming directory for unknown log %q. This log will be skipped.", logID)
+			continue
 		}
 
 		// Read state


### PR DESCRIPTION
This is happening at the moment because of the Pixel BT changing ID. This shouldn't happen again, but in general, the principle that a configuration error in one log shouldn't block all of the others seems good.
