### PR TITLE
Unikernel omniwitness can now distribute

### DIFF
--- a/witness/golang/omniwitness/internal/omniwitness/omniwitness.go
+++ b/witness/golang/omniwitness/internal/omniwitness/omniwitness.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/google/trillian-examples/serverless/config"
 	wimpl "github.com/google/trillian-examples/witness/golang/cmd/witness/impl"
 	ihttp "github.com/google/trillian-examples/witness/golang/internal/http"
@@ -38,17 +39,21 @@ import (
 	"google.golang.org/grpc/status"
 	"gopkg.in/yaml.v3"
 
+	dist_gh "github.com/google/trillian-examples/internal/distribute/github"
 	"github.com/google/trillian-examples/internal/feeder"
 	"github.com/google/trillian-examples/internal/feeder/pixelbt"
 	"github.com/google/trillian-examples/internal/feeder/rekor"
 	"github.com/google/trillian-examples/internal/feeder/serverless"
 	"github.com/google/trillian-examples/internal/feeder/sumdb"
+	"github.com/google/trillian-examples/internal/github"
+	i_note "github.com/google/trillian-examples/internal/note"
 )
 
 const (
 	// Interval between attempts to feed checkpoints
 	// TODO(mhutchinson): Make this configurable
-	feedInterval = 5 * time.Minute
+	feedInterval       = 5 * time.Minute
+	distributeInterval = 5 * time.Minute
 )
 
 // singleLogFeederConfig encapsulates the feeder config for a feeder that can only
@@ -67,11 +72,23 @@ type multiLogFeederConfig struct {
 	Logs []config.Log `yaml:"Logs"`
 }
 
+// OperatorConfig allows the bare minimum operator-specific configuration.
+// This should only contain configuration details that are custom per-operator.
+type OperatorConfig struct {
+	WitnessSigner   note.Signer
+	WitnessVerifier note.Verifier
+
+	GithubUser  string
+	GithubEmail string
+	GithubToken string
+}
+
 // Main runs the omniwitness, with the witness listening using the listener, and all
 // outbound HTTP calls using the client provided.
-func Main(ctx context.Context, signer note.Signer, httpListener net.Listener, httpClient *http.Client) error {
-	// This error group will be used to run all top level processes
-	g := errgroup.Group{}
+func Main(ctx context.Context, operatorConfig OperatorConfig, httpListener net.Listener, httpClient *http.Client) error {
+	// This error group will be used to run all top level processes.
+	// If any process dies, then all of them will be stopped via context cancellation.
+	g, ctx := errgroup.WithContext(ctx)
 
 	type logFeeder func(context.Context, config.Log, feeder.Witness, *http.Client, time.Duration) error
 	feeders := make(map[config.Log]logFeeder)
@@ -121,7 +138,7 @@ func Main(ctx context.Context, signer note.Signer, httpListener net.Listener, ht
 	}
 	witness, err := witness.New(witness.Opts{
 		Persistence: inmemory.NewPersistence(),
-		Signer:      signer,
+		Signer:      operatorConfig.WitnessSigner,
 		KnownLogs:   knownLogs,
 	})
 	if err != nil {
@@ -135,11 +152,28 @@ func Main(ctx context.Context, signer note.Signer, httpListener net.Listener, ht
 		c, f := c, f
 		// Continually feed this log in its own goroutine, hooked up to the global waitgroup.
 		g.Go(func() error {
+			glog.Infof("Feeder %q goroutine started", c.Origin)
+			defer glog.Infof("Feeder %q goroutine done", c.Origin)
 			return f(ctx, c, bw, httpClient, feedInterval)
 		})
 	}
 
-	// TODO(mhutchinson): Start the distributors too if auth details are present.
+	if len(operatorConfig.GithubUser) > 0 {
+		var distLogs = []dist_gh.Log{}
+		for config := range feeders {
+			// TODO(mhutchinson): This verifier could be created inside the distributor.
+			logSigV, err := i_note.NewVerifier(config.PublicKeyType, config.PublicKey)
+			if err != nil {
+				return err
+			}
+			distLogs = append(distLogs, dist_gh.Log{
+				Config: config,
+				SigV:   logSigV,
+			})
+		}
+
+		runDistributors(ctx, g, distLogs, bw, operatorConfig)
+	}
 
 	r := mux.NewRouter()
 	s := ihttp.NewServer(witness)
@@ -148,11 +182,91 @@ func Main(ctx context.Context, signer note.Signer, httpListener net.Listener, ht
 		Handler: r,
 	}
 	g.Go(func() error {
-		defer srv.Shutdown(ctx)
+		glog.Info("HTTP server goroutine started")
+		defer glog.Info("HTTP server goroutine done")
 		return srv.Serve(httpListener)
+	})
+	g.Go(func() error {
+		// This goroutine brings down the HTTP server when ctx is done.
+		glog.Info("HTTP server-shutdown goroutine started")
+		defer glog.Info("HTTP server-shutdown goroutine done")
+		<-ctx.Done()
+		return srv.Shutdown(ctx)
 	})
 
 	return g.Wait()
+}
+
+func runDistributors(ctx context.Context, g *errgroup.Group, logs []dist_gh.Log, witness dist_gh.Witness, operatorConfig OperatorConfig) {
+	distribute := func(opts *dist_gh.DistributeOptions) error {
+		if err := dist_gh.DistributeOnce(ctx, opts); err != nil {
+			glog.Errorf("DistributeOnce: %v", err)
+		}
+		for {
+			select {
+			case <-time.After(distributeInterval):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			if err := dist_gh.DistributeOnce(ctx, opts); err != nil {
+				glog.Errorf("DistributeOnce: %v", err)
+			}
+		}
+	}
+
+	g.Go(func() error {
+		dr, err := github.NewRepoID("mhutchinson/mhutchinson-distributor")
+		if err != nil {
+			return fmt.Errorf("NewRepoID: %v", err)
+		}
+		glog.Infof("Distributor %q goroutine started", dr)
+		defer glog.Infof("Distributor %q goroutine done", dr)
+
+		fork, err := github.NewRepoID(fmt.Sprintf("%s/mhutchinson-distributor", operatorConfig.GithubUser))
+		if err != nil {
+			return fmt.Errorf("NewRepoID: %v", err)
+		}
+		repo, err := github.NewRepository(ctx, dr, "main", fork, operatorConfig.GithubUser, operatorConfig.GithubEmail, operatorConfig.GithubToken)
+		if err != nil {
+			return fmt.Errorf("NewRepository: %v", err)
+		}
+		opts := &dist_gh.DistributeOptions{
+			Repo:            repo,
+			DistributorPath: "distributor",
+			Logs:            logs,
+			WitSigV:         operatorConfig.WitnessVerifier,
+			Witness:         witness,
+		}
+
+		return distribute(opts)
+	})
+
+	g.Go(func() error {
+		dr, err := github.NewRepoID("WolseyBankWitness/rediffusion")
+		if err != nil {
+			return fmt.Errorf("NewRepoID: %v", err)
+		}
+		glog.Infof("Distributor %q goroutine started", dr)
+		defer glog.Infof("Distributor %q goroutine done", dr)
+
+		fork, err := github.NewRepoID(fmt.Sprintf("%s/rediffusion", operatorConfig.GithubUser))
+		if err != nil {
+			return fmt.Errorf("NewRepoID: %v", err)
+		}
+		repo, err := github.NewRepository(ctx, dr, "main", fork, operatorConfig.GithubUser, operatorConfig.GithubEmail, operatorConfig.GithubToken)
+		if err != nil {
+			return fmt.Errorf("NewRepository: %v", err)
+		}
+		opts := &dist_gh.DistributeOptions{
+			Repo:            repo,
+			DistributorPath: ".",
+			Logs:            logs,
+			WitSigV:         operatorConfig.WitnessVerifier,
+			Witness:         witness,
+		}
+
+		return distribute(opts)
+	})
 }
 
 // witnessAdapter binds the internal witness implementation to the feeder interface.

--- a/witness/golang/omniwitness/usbarmory/main.go
+++ b/witness/golang/omniwitness/usbarmory/main.go
@@ -42,7 +42,6 @@ const (
 	// TODO(mhutchinson): these need to be read from file instead of constants
 	publicKey  = "TrustMe+68958214+AQ4Ys/PsXqfhPkNK7Y7RyYUMOJvfl65PzJOEiq9VFPjF"
 	signingKey = "PRIVATE+KEY+TrustMe+68958214+AZKby3TDZizdARF975ZyLJwGbHTivd+EqbfYTN5qr2cI"
-	_          = publicKey // public key is here so it doesn't get lost, we don't need it right now.
 )
 
 func main() {
@@ -64,7 +63,15 @@ func main() {
 	if err != nil {
 		glog.Exitf("Failed to init signer: %v", err)
 	}
-	if err := omniwitness.Main(ctx, signer, httpListener, httpClient); err != nil {
+	verifier, err := note.NewVerifier(publicKey)
+	if err != nil {
+		glog.Exitf("Failed to init verifier: %v", err)
+	}
+	opConfig := omniwitness.OperatorConfig{
+		WitnessSigner:   signer,
+		WitnessVerifier: verifier,
+	}
+	if err := omniwitness.Main(ctx, opConfig, httpListener, httpClient); err != nil {
 		glog.Exitf("Main failed: %v", err)
 	}
 }


### PR DESCRIPTION
If the github authentication details are provided then the distributors
will be started.

This also adds  goroutine start/stop info logging, which can be
useful in case there are any goroutines that exit early, and any that
don't automatically exit when the context is cancelled.
