### PR TITLE
Build the monolithic omniwitness as Docker image

### DIFF
--- a/cloudbuild_docker.yaml
+++ b/cloudbuild_docker.yaml
@@ -149,6 +149,20 @@ steps:
     waitFor:
       - show-target-build-platforms
     id: 'build-pixel-feeder-image'
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [
+      'buildx',
+      'build',
+      '--platform', '$_DOCKER_BUILDX_PLATFORMS',
+      '-t', 'gcr.io/$PROJECT_ID/omniwitness-monolith:latest',
+      '--cache-from', 'gcr.io/$PROJECT_ID/omniwitness-monolith:latest',
+      '-f', './witness/golang/omniwitness/monolith/Dockerfile',
+      '--push',
+      '.'
+    ]
+    waitFor:
+      - show-target-build-platforms
+    id: 'build-omniwitness-monolith-image'
 
 substitutions:
   _DOCKER_BUILDX_PLATFORMS: 'linux/amd64,linux/arm/v7'

--- a/witness/golang/omniwitness/monolith/Dockerfile
+++ b/witness/golang/omniwitness/monolith/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:buster AS builder
+
+ARG GOFLAGS=""
+ENV GOFLAGS=$GOFLAGS
+ENV GO111MODULE=on
+
+# Move to working directory /build
+WORKDIR /build
+
+# Copy and download dependency using go mod
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+# Copy the code into the container
+COPY . .
+
+# Build the application
+RUN go build -o omniwitness ./witness/golang/omniwitness/monolith
+
+# Build release image
+FROM golang:buster
+
+COPY --from=builder /build/omniwitness /bin/omniwitness
+ENTRYPOINT ["/bin/omniwitness"]


### PR DESCRIPTION
This may replace the docker-compose version of the omniwitness, at least as our primary recommendation of how to run this. The primary benefit is that it's much simpler; there's only one executable to launch and the only config it takes are those that are user-specific. All of the details of the logs and github distributors are baked into the binary. This should make it far easier to ensure everyone is running the same configuration of the omniwitness as logs are added, etc.

There is explicitly no plan to prevent users running these components flexibly, this is simply a case of having the omniwitness very opinionated to encourage simple adoption.
