### PR TITLE
Remove unused Cloud Build substitution added from https://github.com/google/trillian-examples/pull/598.

### DIFF
--- a/cloudbuild_docker.yaml
+++ b/cloudbuild_docker.yaml
@@ -153,4 +153,3 @@ steps:
 substitutions:
   _DOCKER_BUILDX_PLATFORMS: 'linux/amd64,linux/arm/v7'
   _BUCKET: 'transparency_log'
-  _ENTRIES_DIR: 'log_entries'


### PR DESCRIPTION
The Cloud Build workflow currently fails with the following error:

```
Your build failed to run: generic::invalid_argument: generic::invalid_argument: invalid value for 'build.substitutions': key in the template "ENTRIES_DIR" is not a valid built-in substitution
```