### PR TITLE
Use faster and bigger machines for cloud build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 timeout: 1200s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_32
   volumes:
   - name: go-modules
     path: /go

--- a/cloudbuild_docker.yaml
+++ b/cloudbuild_docker.yaml
@@ -3,7 +3,7 @@
 # This builds the images multi-arch so they run on x64 and Raspberry Pi.
 timeout: 3600s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_32
   volumes:
   - name: go-modules
     path: /go


### PR DESCRIPTION
We're getting timeouts building the docker images. Hopefully this will help. And doing it in both cloudbuild files keeps them consistent.
