### PR TITLE
Set up the docker build using the same setup as the others

### DIFF
--- a/witness/golang/omniwitness/monolith/Dockerfile
+++ b/witness/golang/omniwitness/monolith/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:buster AS builder
+FROM golang:1.17-alpine AS builder
+RUN apk add --no-cache gcc musl-dev
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS


### PR DESCRIPTION
The previous dockerfile wouldn't build in GCB. This is failing for weird reasons like TLS timeouts. Using the same base image and setup as the witness Dockerfile should make this work. At least, this works on my dev machinne.
