### PR TITLE
Override http.Client used by distributors

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -66,10 +66,7 @@ func NewRepository(ctx context.Context, c *http.Client, upstream RepoID, upstrea
 	}
 	var err error
 	repo.ghCli, err = authWithGithub(ctx, ghToken)
-	if err != nil {
-		return repo, err
-	}
-	return repo, nil
+	return repo, err
 }
 
 // authWithGithub returns a github client struct which uses the provided OAuth token.

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
@@ -54,7 +55,8 @@ func NewRepoID(or string) (RepoID, error) {
 
 // NewRepository creates a wrapper around a git repository which has a fork owned by
 // the user, and an upstream repository configured that PRs can be proposed against.
-func NewRepository(ctx context.Context, upstream RepoID, upstreamBranch string, fork RepoID, ghUser, ghEmail, ghToken string) (Repository, error) {
+func NewRepository(ctx context.Context, c *http.Client, upstream RepoID, upstreamBranch string, fork RepoID, ghUser, ghEmail, ghToken string) (Repository, error) {
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, c)
 	repo := Repository{
 		upstream:       upstream,
 		upstreamBranch: upstreamBranch,

--- a/serverless/cmd/distribute/github/main.go
+++ b/serverless/cmd/distribute/github/main.go
@@ -67,7 +67,7 @@ func main() {
 	flag.Parse()
 	ctx := context.Background()
 
-	opts := mustConfigure(ctx)
+	opts := mustConfigure(ctx, http.DefaultClient)
 
 	if err := dist_gh.DistributeOnce(ctx, opts); err != nil {
 		glog.Warningf("DistributeOnce: %v", err)
@@ -94,7 +94,7 @@ func usageExit(m string) {
 
 // mustConfigure creates an options struct from flags and env vars.
 // It will terminate execution on any error.
-func mustConfigure(ctx context.Context) *dist_gh.DistributeOptions {
+func mustConfigure(ctx context.Context, c *http.Client) *dist_gh.DistributeOptions {
 	checkNotEmpty := func(m, v string) {
 		if v == "" {
 			usageExit(m)
@@ -153,7 +153,7 @@ func mustConfigure(ctx context.Context) *dist_gh.DistributeOptions {
 		logs = append(logs, log)
 	}
 
-	repo, err := github.NewRepository(ctx, dr, *distributorBranch, fr, gitUsername, gitEmail, githubAuthToken)
+	repo, err := github.NewRepository(ctx, c, dr, *distributorBranch, fr, gitUsername, gitEmail, githubAuthToken)
 	if err != nil {
 		glog.Exitf("Failed to set up repository: %v", err)
 	}

--- a/witness/golang/omniwitness/internal/omniwitness/omniwitness.go
+++ b/witness/golang/omniwitness/internal/omniwitness/omniwitness.go
@@ -172,7 +172,7 @@ func Main(ctx context.Context, operatorConfig OperatorConfig, p persistence.LogS
 			})
 		}
 
-		runDistributors(ctx, g, distLogs, bw, operatorConfig)
+		runDistributors(ctx, httpClient, g, distLogs, bw, operatorConfig)
 	}
 
 	r := mux.NewRouter()
@@ -197,7 +197,7 @@ func Main(ctx context.Context, operatorConfig OperatorConfig, p persistence.LogS
 	return g.Wait()
 }
 
-func runDistributors(ctx context.Context, g *errgroup.Group, logs []dist_gh.Log, witness dist_gh.Witness, operatorConfig OperatorConfig) {
+func runDistributors(ctx context.Context, c *http.Client, g *errgroup.Group, logs []dist_gh.Log, witness dist_gh.Witness, operatorConfig OperatorConfig) {
 	distribute := func(opts *dist_gh.DistributeOptions) error {
 		if err := dist_gh.DistributeOnce(ctx, opts); err != nil {
 			glog.Errorf("DistributeOnce: %v", err)
@@ -223,7 +223,7 @@ func runDistributors(ctx context.Context, g *errgroup.Group, logs []dist_gh.Log,
 			Owner:    operatorConfig.GithubUser,
 			RepoName: repoName,
 		}
-		repo, err := github.NewRepository(ctx, dr, mainBranch, fork, operatorConfig.GithubUser, operatorConfig.GithubEmail, operatorConfig.GithubToken)
+		repo, err := github.NewRepository(ctx, c, dr, mainBranch, fork, operatorConfig.GithubUser, operatorConfig.GithubEmail, operatorConfig.GithubToken)
 		if err != nil {
 			return nil, fmt.Errorf("NewRepository: %v", err)
 		}


### PR DESCRIPTION
This was implicitly using the default client, which doesn't work on the USB Armory as it requires a custom client. This change sets the client via a context, which is the way the oauth2 libraries like to do it. This could also have been implemented by putting the client in the context at a higher level instead of passing it around, but the explicit argument passing is clearer and more consistent with how we've implemented the rest of this code.
