### PR TITLE
Upgrade lint to more recent version and fixed errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,8 +1,6 @@
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 90s
-  skip-dirs:
-    - (^|/)registers($|/)
 
 linters-settings:
   gocyclo:
@@ -31,3 +29,7 @@ linters:
     - varcheck
     # TODO(gbelvin): write license linter and commit to upstream.
     # ./scripts/check_license.sh is run by ./scripts/presubmit.sh
+
+issues:
+  # Don't turn off any checks by default. We can do this explicitly if needed.
+  exclude-use-default: false

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,16 +16,16 @@ linters-settings:
 linters:
   disable-all: true
   enable:
+    - deadcode
+    - depguard
     - gocyclo
     - gofmt
     - goimports
-    - golint
+    - govet
+    - ineffassign
     - megacheck
     - misspell
-    - govet
-    - depguard
-    - deadcode
-    - ineffassign
+    - revive
     - varcheck
     # TODO(gbelvin): write license linter and commit to upstream.
     # ./scripts/check_license.sh is run by ./scripts/presubmit.sh

--- a/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
+++ b/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package impl is the implementation of a util to flash firmware update packages created by the publisher tool onto devices.
+// Package impl is the implementation of a util to flash firmware update packages created by the publisher tool onto devices.
 //
 // Currently, the only device is a dummy device, which simply sorts the firmware+metadata on local disk.
 package impl
@@ -51,6 +51,7 @@ type FlashOpts struct {
 	DeviceStorage  string
 }
 
+// Main flashes the device according to the options provided.
 func Main(ctx context.Context, opts FlashOpts) error {
 	logURL, err := url.Parse(opts.LogURL)
 	if err != nil {

--- a/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
+++ b/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
@@ -55,6 +55,7 @@ type MonitorOpts struct {
 	StateFile      string
 }
 
+// Main runs the monitor until the context is canceled.
 func Main(ctx context.Context, opts MonitorOpts) error {
 	if len(opts.LogURL) == 0 {
 		return errors.New("log URL is required")

--- a/binary_transparency/firmware/cmd/ft_personality/impl/ft_personality.go
+++ b/binary_transparency/firmware/cmd/ft_personality/impl/ft_personality.go
@@ -46,6 +46,7 @@ type PersonalityOpts struct {
 	Signer         note.Signer
 }
 
+// Main runs the FT personality server until the context is canceled.
 func Main(ctx context.Context, opts PersonalityOpts) error {
 	if len(opts.CASFile) == 0 {
 		return errors.New("CAS file is required")

--- a/binary_transparency/firmware/cmd/ft_witness/internal/http/witness_test.go
+++ b/binary_transparency/firmware/cmd/ft_witness/internal/http/witness_test.go
@@ -50,7 +50,7 @@ func TestGetWitnessCheckpoint(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to sign checkpoint: %v", err)
 			}
-			witness, err := NewWitness(FakeStore{ns, true}, dummyURL, testVerifier, dummyPollInterval)
+			witness, err := NewWitness(&FakeStore{ns, true}, dummyURL, testVerifier, dummyPollInterval)
 			if err != nil {
 				t.Fatalf("error creating witness: %v", err)
 			}
@@ -92,7 +92,7 @@ func TestFailedWitnessCreation(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			_, err := NewWitness(FakeStore{[]byte{}, false}, dummyURL, testVerifier, dummyPollInterval)
+			_, err := NewWitness(&FakeStore{[]byte{}, false}, dummyURL, testVerifier, dummyPollInterval)
 			if err == nil {
 				t.Errorf("error witness creation happened smoothly: %v", err)
 			}
@@ -109,7 +109,7 @@ type FakeStore struct {
 	storeaccess bool
 }
 
-func (f FakeStore) StoreCP(wcp []byte) error {
+func (f *FakeStore) StoreCP(wcp []byte) error {
 	if !f.storeaccess {
 		return fmt.Errorf("unable to access store")
 	}
@@ -117,7 +117,7 @@ func (f FakeStore) StoreCP(wcp []byte) error {
 	return nil
 }
 
-func (f FakeStore) RetrieveCP() ([]byte, error) {
+func (f *FakeStore) RetrieveCP() ([]byte, error) {
 	if !f.storeaccess {
 		return nil, fmt.Errorf("unable to access store")
 	}

--- a/binary_transparency/firmware/cmd/ftmapserver/impl/ftmapserver.go
+++ b/binary_transparency/firmware/cmd/ftmapserver/impl/ftmapserver.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/mattn/go-sqlite3" // Load drivers for sqlite3
 )
 
+// MapReader is an interface that allows a map to be read from storage.
 type MapReader interface {
 	// LatestRevision gets the metadata for the last completed write.
 	LatestRevision() (rev int, logroot types.LogRootV1, count int64, err error)
@@ -53,6 +54,7 @@ type MapServerOpts struct {
 	MapDBAddr  string
 }
 
+// Main brings up an http server according to the given options.
 func Main(ctx context.Context, opts MapServerOpts) error {
 	if len(opts.MapDBAddr) == 0 {
 		return errors.New("map DB is required")

--- a/binary_transparency/firmware/devices/dummy/flash.go
+++ b/binary_transparency/firmware/devices/dummy/flash.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package dummy provides a fake device to demo flashing firmware.
 package dummy
 
 import (
@@ -40,7 +41,7 @@ type Device struct {
 
 var _ devices.Device = Device{}
 
-// NewFromFlags creates a new dummy device instance using data from flags.
+// New creates a new dummy device instance using data from flags.
 // TODO(al): figure out how/whether to remove the flag from in here.
 func New(storage string) (*Device, error) {
 	dStat, err := os.Stat(storage)

--- a/binary_transparency/firmware/internal/client/mapclient.go
+++ b/binary_transparency/firmware/internal/client/mapclient.go
@@ -32,10 +32,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// MapClient is a client that exposes the operations on a remote map.
 type MapClient struct {
 	mapURL *url.URL
 }
 
+// NewMapClient creates a MapClient for a map hosted at the given URL.
 func NewMapClient(mapURL string) (*MapClient, error) {
 	u, err := url.Parse(mapURL)
 	if err != nil {

--- a/binary_transparency/firmware/internal/ftmap/pipeline.go
+++ b/binary_transparency/firmware/internal/ftmap/pipeline.go
@@ -156,13 +156,13 @@ func (b *MapBuilder) getLogEnd(requiredEntries int64) (int64, []byte, error) {
 }
 
 const (
-	// Partition index for partition containing FirmwareMetadata
+	// FirmwareMetaPartition is the partition index for partition containing FirmwareMetadata
 	FirmwareMetaPartition = iota
-	// Partition index for partition containing MalwareStatement
+	// MalwareStatementPartition is the partition index for partition containing MalwareStatement
 	MalwareStatementPartition
-	// Partition index for partition containing anything not classified above
+	// UnclassifiedStatementPartition is the partition index for partition containing anything not classified above
 	UnclassifiedStatementPartition
-	// Add new partitions here
+	// MaxPartitions is the total number of supported partitions. Add new partitions here.
 	MaxPartitions
 )
 

--- a/clone/internal/cloner/clone.go
+++ b/clone/internal/cloner/clone.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// clone contains the core engine for quickly downloading leaves and adding
+// Package cloner contains the core engine for quickly downloading leaves and adding
 // them to the database.
 package cloner
 

--- a/clone/internal/download/batch.go
+++ b/clone/internal/download/batch.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// download contains a library for downloading data from logs.
+// Package download contains a library for downloading data from logs.
 package download
 
 import (

--- a/clone/internal/download/http.go
+++ b/clone/internal/download/http.go
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package download provides a fetcher to get data via http(s).
 package download
 
 import (

--- a/clone/internal/verify/verify.go
+++ b/clone/internal/verify/verify.go
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package verify supports verification that the downloaded contents match
+// the root hash commitment made in a log checkpoint.
 package verify
 
 import (

--- a/clone/logdb/database.go
+++ b/clone/logdb/database.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// logdb contains read/write access to the locally cloned data.
+// Package logdb contains read/write access to the locally cloned data.
 package logdb
 
 import (
@@ -45,7 +45,7 @@ func NewDatabase(connString string) (*Database, error) {
 	return db, db.init()
 }
 
-// NewDatabase creates a Database using the given database connection.
+// NewDatabaseDirect creates a Database using the given database connection.
 func NewDatabaseDirect(db *sql.DB) (*Database, error) {
 	ret := &Database{
 		db: db,

--- a/experimental/batchmap/ctmap/internal/pipeline/log.go
+++ b/experimental/batchmap/ctmap/internal/pipeline/log.go
@@ -126,6 +126,9 @@ func NodeHash(left, right []byte) []byte {
 	return h.Sum(nil)
 }
 
+// DomainCertIndexLog represents a key/value inside the map, and this value is a log.
+// The key is the domain, and the list of indices is an ordered sequence of leaf index
+// that contains certificates for this domain within the input log that was processed.
 type DomainCertIndexLog struct {
 	Domain  string
 	Indices []uint64

--- a/formats/checkpoints/combine_signatures.go
+++ b/formats/checkpoints/combine_signatures.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// checkpoints provides functionality for handling checkpoints.
+// Package checkpoints provides functionality for handling checkpoints.
 package checkpoints
 
 import (

--- a/helloworld/client.go
+++ b/helloworld/client.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Runs a simple client, designed to interact with a personality.
+// Package helloworld runs a simple client, designed to interact with a personality.
 package helloworld
 
 import (
@@ -46,7 +46,7 @@ type Personality interface {
 	UpdateChkpt(ctx context.Context, oldCPSize uint64) (personality.SignedCheckpoint, *trillian.Proof, error)
 }
 
-// A client is a verifier that maintains a checkpoint as state.
+// Client is a verifier that maintains a checkpoint as state.
 type Client struct {
 	v           merkle.LogVerifier
 	chkpt       *log.Checkpoint

--- a/helloworld/personality/personality.go
+++ b/helloworld/personality/personality.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// Runs a simple Trillian personality.
+
+// Package personality runs a simple Trillian personality.
 package personality
 
 import (
@@ -37,6 +37,7 @@ var (
 // SignedCheckpoint is a serialised form of a checkpoint+signatures.
 type SignedCheckpoint []byte
 
+// TrillianP is a personality backed by a trillian log.
 type TrillianP struct {
 	l      trillian.TrillianLogClient
 	treeID int64

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -11,7 +11,7 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-fre
 RUN apt-get update && apt-get -y install curl docker-compose lsof netcat unzip wget xxd
 
 RUN cd /usr/bin && curl -L -O https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && mv jq-linux64 /usr/bin/jq && chmod +x /usr/bin/jq
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.18.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.1
 RUN mkdir protoc && \
     (cd protoc && \
     wget "https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip" && \

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -25,4 +25,4 @@ RUN curl -sfL https://github.com/usbarmory/tamago-go/releases/download/tamago-go
 ENV TAMAGO=/usr/local/tamago-go/bin/go
 
 ENV GOPATH /go
-ENV PATH $GOPATH/bin:/testbase/protoc/bin:/usr/local/tamago-go/bin:/usr/local/go/bin:$PATH
+ENV PATH $GOPATH/bin:/testbase/protoc/bin:/usr/local/go/bin:/usr/local/tamago-go/bin:$PATH

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -11,7 +11,7 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-fre
 RUN apt-get update && apt-get -y install curl docker-compose lsof netcat unzip wget xxd
 
 RUN cd /usr/bin && curl -L -O https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && mv jq-linux64 /usr/bin/jq && chmod +x /usr/bin/jq
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.1
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.1
 RUN mkdir protoc && \
     (cd protoc && \
     wget "https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip" && \

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,5 +1,5 @@
 # This Dockerfile builds a base image for the CloudBuild integration testing.
-FROM golang:1.17-buster as testbase
+FROM golang:1.17.8-buster as testbase
 
 WORKDIR /testbase
 
@@ -21,7 +21,7 @@ RUN mkdir protoc && \
 # Tamago bits
 RUN apt-get -y install binutils-arm-none-eabi build-essential make u-boot-tools && \
     apt-get -y install -t buster-backports fuse fuse2fs
-RUN curl -sfL https://github.com/usbarmory/tamago-go/releases/download/tamago-go1.17/tamago-go1.17.linux-amd64.tar.gz | tar -xzf - -C /
+RUN curl -sfL https://github.com/usbarmory/tamago-go/releases/download/tamago-go1.17.8/tamago-go1.17.8.linux-amd64.tar.gz | tar -xzf - -C /
 ENV TAMAGO=/usr/local/tamago-go/bin/go
 
 ENV GOPATH /go

--- a/internal/distribute/github/distribute.go
+++ b/internal/distribute/github/distribute.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The github package provides support for pushing witnessed checkpoints to a
+// Package github provides support for pushing witnessed checkpoints to a
 // github actions based distributor.
 package github
 

--- a/internal/feeder/feeder.go
+++ b/internal/feeder/feeder.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// feeder provides support for building witness feeder implementations.
+// Package feeder provides support for building witness feeder implementations.
 package feeder
 
 import (

--- a/internal/feeder/sumdb/sumdb_feeder.go
+++ b/internal/feeder/sumdb/sumdb_feeder.go
@@ -44,6 +44,8 @@ var (
 	}
 )
 
+// FeedLog continually feeds checkpoints from the given log into the witness.
+// This method blocks until the context is done.
 func FeedLog(ctx context.Context, l config.Log, w feeder.Witness, c *http.Client, interval time.Duration) error {
 	sdb := client.NewSumDB(tileHeight, l.PublicKey, l.URL, c)
 	logSigV, err := i_note.NewVerifier(l.PublicKeyType, l.PublicKey)

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// github contains libraries for using github repositories that make serverless
-// operations easy to follow.
+// Package github contains libraries for using github repositories that
+// make serverless operations easy to follow.
 package github
 
 import (

--- a/internal/note/note_verifier.go
+++ b/internal/note/note_verifier.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package note provides note-compatible signature verifiers.
+// Package note provides note-compatible signature verifiers.
 package note
 
 import (
@@ -40,6 +40,7 @@ const (
 	algECDSAWithSHA256 = 2
 )
 
+// NewVerifier returns a verifier for the given key type and key.
 func NewVerifier(keyType, key string) (sdb_note.Verifier, error) {
 	switch keyType {
 	case ECDSA:

--- a/internal/note/note_verifier_test.go
+++ b/internal/note/note_verifier_test.go
@@ -36,34 +36,34 @@ const (
 func TestNewVerifier(t *testing.T) {
 	for _, test := range []struct {
 		name    string
-		kType   string
-		k       string
+		keyType string
+		key     string
 		wantErr bool
 	}{
 		{
 			name: "note works",
-			k:    "PeterNeumann+c74f20a3+ARpc2QcUPDhMQegwxbzhKqiBfsVkmqq/LDE4izWy10TW",
+			key:  "PeterNeumann+c74f20a3+ARpc2QcUPDhMQegwxbzhKqiBfsVkmqq/LDE4izWy10TW",
 		}, {
 			name:    "note mismatch",
-			k:       sigStoreKey,
+			key:     sigStoreKey,
 			wantErr: true,
 		}, {
-			name:  "ECDSA works",
-			kType: ECDSA,
-			k:     sigStoreKey,
+			name:    "ECDSA works",
+			keyType: ECDSA,
+			key:     sigStoreKey,
 		}, {
 			name:    "ECDSA mismatch",
-			kType:   ECDSA,
-			k:       "PeterNeumann+c74f20a3+ARpc2QcUPDhMQegwxbzhKqiBfsVkmqq/LDE4izWy10TW",
+			keyType: ECDSA,
+			key:     "PeterNeumann+c74f20a3+ARpc2QcUPDhMQegwxbzhKqiBfsVkmqq/LDE4izWy10TW",
 			wantErr: true,
 		}, {
 			name:    "unknown type fails",
-			kType:   "bananas",
+			keyType: "bananas",
 			wantErr: true,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := NewVerifier(test.kType, test.k)
+			_, err := NewVerifier(test.keyType, test.key)
 			if gotErr := err != nil; gotErr != test.wantErr {
 				t.Fatalf("NewVerifier: %v, wantErr %t", err, test.wantErr)
 			}

--- a/serverless/api/state.go
+++ b/serverless/api/state.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 )
 
-// CheckpointHeader is the first line of a marshaled log checkpoint.
+// CheckpointHeaderV0 is the first line of a marshaled log checkpoint.
 const CheckpointHeaderV0 = "Log Checkpoint v0"
 
 // Tile represents a subtree tile, containing inner nodes of a log tree.

--- a/serverless/config/log.go
+++ b/serverless/config/log.go
@@ -62,6 +62,7 @@ func (l Log) Validate() error {
 	return nil
 }
 
+// UnmarshalYAML populates the log from yaml using the unmarshal func provided.
 func (l *Log) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type rawLog Log
 	raw := rawLog{}

--- a/serverless/config/witness.go
+++ b/serverless/config/witness.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package config declares how witnesses are configured.
 package config
 
 import (
@@ -19,7 +20,7 @@ import (
 	"net/url"
 )
 
-// Log describes a witness in a config file.
+// Witness describes a witness in a config file.
 type Witness struct {
 	// URL is the URL of the root of the witness.
 	// This is optional if direct witness communication is not required.

--- a/sumdbaudit/client/sumdb.go
+++ b/sumdbaudit/client/sumdb.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// client contains a basic client for the SumDB log.
+// Package client contains a basic client for the SumDB log.
 package client
 
 import (

--- a/sumdbaudit/client/sumdb_test.go
+++ b/sumdbaudit/client/sumdb_test.go
@@ -67,7 +67,7 @@ func TestLeavesAtOffset(t *testing.T) {
 			t.Errorf("expected string terminating in newline, got: %x", l)
 		}
 		expStart := "golang.org/x/"
-		if got, want := fmt.Sprintf("%s", l[:len(expStart)]), expStart; got != want {
+		if got, want := string(l[:len(expStart)]), expStart; got != want {
 			t.Errorf("got prefix '%s', wanted '%s'", got, want)
 		}
 	}

--- a/witness/golang/client/http/witness_client.go
+++ b/witness/golang/client/http/witness_client.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// http is a simple client for interacting with witnesses over HTTP.
+// Package http is a simple client for interacting with witnesses over HTTP.
 package http
 
 import (
@@ -30,8 +30,10 @@ import (
 )
 
 // ErrCheckpointTooOld is returned if the checkpoint passed to Update needs to be updated.
-var ErrCheckpointTooOld error = errors.New("checkpoint too old")
+var ErrCheckpointTooOld = errors.New("checkpoint too old")
 
+// NewWitness returns a Witness accessed over http at the given URL
+// using the client provided.
 func NewWitness(url *url.URL, c *http.Client) Witness {
 	return Witness{
 		url:    url,

--- a/witness/golang/cmd/witness/impl/witness.go
+++ b/witness/golang/cmd/witness/impl/witness.go
@@ -51,7 +51,7 @@ type LogInfo struct {
 	UseCompact    bool   `yaml:"UseCompact"`
 }
 
-// The options for a server (specified in main.go).
+// ServerOpts are the options for a server (specified in main.go).
 type ServerOpts struct {
 	// Where to listen for requests.
 	ListenAddr string
@@ -91,6 +91,7 @@ func (config LogConfig) AsLogMap() (map[string]witness.LogInfo, error) {
 	return logMap, nil
 }
 
+// Main runs the witness until the context is canceled.
 func Main(ctx context.Context, opts ServerOpts) error {
 	if len(opts.DBFile) == 0 {
 		return errors.New("DBFile is required")

--- a/witness/golang/internal/persistence/testonly/persistence.go
+++ b/witness/golang/internal/persistence/testonly/persistence.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// TestGetLogs exposes a test that can be invoked by tests for specific implementations of persistence.
 func TestGetLogs(t *testing.T, lspFactory func() (persistence.LogStatePersistence, func() error)) {
 	lsp, close := lspFactory()
 	defer close()
@@ -48,6 +49,7 @@ func TestGetLogs(t *testing.T, lspFactory func() (persistence.LogStatePersistenc
 	}
 }
 
+// TestWriteOps exposes a test that can be invoked by tests for specific implementations of persistence.
 func TestWriteOps(t *testing.T, lspFactory func() (persistence.LogStatePersistence, func() error)) {
 	lsp, close := lspFactory()
 	defer close()

--- a/witness/golang/omniwitness/internal/omniwitness/omniwitness.go
+++ b/witness/golang/omniwitness/internal/omniwitness/omniwitness.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// omniwitness provides a single Main file that basically runs the omniwitness.
+// Package omniwitness provides a single Main file that runs the omniwitness.
 // Some components are left pluggable so this can be deployed on different
 // runtimes.
 package omniwitness

--- a/witness/golang/omniwitness/usbarmory/internal/storage/persistence.go
+++ b/witness/golang/omniwitness/usbarmory/internal/storage/persistence.go
@@ -61,7 +61,7 @@ type SlotPersistence struct {
 // slotMap defines the structure of the mapping config stored in slot zero.
 type slotMap map[string]uint
 
-// NewSlotPeristence creates a new SlotPersistence instance.
+// NewSlotPersistence creates a new SlotPersistence instance.
 // As per the Persistence interface, Init must be called before it's used to
 // read or write any data.
 func NewSlotPersistence(part *slots.Partition) *SlotPersistence {

--- a/witness/golang/omniwitness/usbarmory/internal/storage/testonly/memdev.go
+++ b/witness/golang/omniwitness/usbarmory/internal/storage/testonly/memdev.go
@@ -20,15 +20,20 @@ import (
 	"testing"
 )
 
+// MemBlockSize is the number of bytes in a single memory block.
 const MemBlockSize = 512
 
 //  MemDev is a simple in-memory block device.
 type MemDev [][MemBlockSize]byte
 
+// BlockSize returns the block size of the underlying storage system.
 func (md MemDev) BlockSize() uint {
 	return MemBlockSize
 }
 
+// ReadBlocks reads len(b) bytes into b from contiguous storage blocks starting
+// at the given block address.
+// b must be an integer multiple of the device's block size.
 func (md MemDev) ReadBlocks(lba uint, b []byte) error {
 	if lba >= uint(len(md)) {
 		return fmt.Errorf("lba (%d) >= device blocks (%d)", lba, len(md))
@@ -44,6 +49,9 @@ func (md MemDev) ReadBlocks(lba uint, b []byte) error {
 	return nil
 }
 
+// WriteBlocks writes len(b) bytes from b to contiguous storage blocks starting
+// at the given block address.
+// b must be an integer multiple of the device's block size.
 func (md MemDev) WriteBlocks(lba uint, b []byte) error {
 	if lba >= uint(len(md)) {
 		return fmt.Errorf("lba (%d) >= device blocks (%d)", lba, len(md))


### PR DESCRIPTION
This started off as trying to make the lint configuration consistent with other repos, and removing `skip` instruction that no longer matched anything. In doing so, it turned out that we were using an old version, and updating that caused a ream of lint warnings. So I've fixed them.

This also brought to light some weirdness where we install multiple versions of go (because we install tamago). I've made it so that:
 a) the same version of both go and tamago is installed
 b) tamago doesn't blat go in the path; invoking `go` will do normal go, not tamago