### PR TITLE
request only JSON formatted responses from Rekor

### DIFF
--- a/internal/feeder/rekor/rekor_feeder.go
+++ b/internal/feeder/rekor/rekor_feeder.go
@@ -111,6 +111,7 @@ func getJSON(ctx context.Context, c *http.Client, base *url.URL, path string, s 
 		return fmt.Errorf("failed to create request: %v", err)
 	}
 	req = req.WithContext(ctx)
+	req.Header.Set("Accept", "application/json")
 
 	rsp, err := c.Do(req)
 	if err != nil {


### PR DESCRIPTION
This should remove transient errors due to response content-type flipping back and forth between JSON and YAML.

@AlCutter 

Signed-off-by: Bob Callaway <bcallaway@google.com>