### PR TITLE
Better docs for common omniwitness deployments

### DIFF
--- a/witness/golang/omniwitness/README.md
+++ b/witness/golang/omniwitness/README.md
@@ -1,5 +1,67 @@
 # The OmniWitness
 
+The OmniWitness is a witness that will monitor all [known](./feeder_configs/) logs that use
+the [generic checkpoint format](https://github.com/transparency-dev/formats/tree/main/log).
+
+The OmniWitness is opinionated on which logs and distributors will be used. Deploying any
+of the OmniWitness implementations will perform the same witnessing and distribution, unless
+the operator changes any of the configuration files in the `*_configs` directories here.
+
+This directory contains a dockerized implementation for a micro-services style deployment;
+a container will be deployed for:
+  * The core witness
+  * Each of the feeder types (one for each of the config files in `./feeder_configs`)
+  * Each of the distributors ([mhutchinson-distributor](https://github.com/mhutchinson/mhutchinson-distributor) and [WolseyBankWitness](https://github.com/WolseyBankWitness/rediffusion))
+
+Instructions for deploying this are expanded below.
+
+In addition, there are two other equivalent implementations with different deployments:
+  * [monolith](./monolith): all in one process, can be ran bare or in Docker
+  * [usbarmory](./usbarmory): all in one unikernel, for specialized hardware
+
+## Common Configuration
+
+All deployments will need a keypair for signing/verifying witnessed checkpoints.
+Most deployments should push the witnessed checkpoints to the distributors.
+Instructions are provided for generating the material needed to do this.
+
+Each deployment of the omniwitness will take these credentials in a different
+way, so see the specific documentation for the deployment you are using.
+
+Take care to protect any private material!
+
+## Witness Key Generation
+
+It is strongly recommended to generate new key material for a witness. This key
+material should only be used to sign checkpoints that have been verified to be
+an append-only evolution of any previously signed version (or TOFU in the case
+of a brand new witness).
+
+A keypair can be generated using `note.GenerateKey`; example code is provided
+at https://play.golang.org/p/uWUKLNK6h9v. It is recommended to copy this code
+to your local machine and run from there in order to minimize the risk to the
+private key material.
+
+## Github Credentials
+
+This is optional, but recommended in order to push your checkpoints to as wide
+an audience as possible and strengthen the network.
+Checkpoints will be pushed to the distributors using GitHub pull requests.
+This means that GitHub credentials must be provided.
+It is strongly recommended to set up a secondary account for this purpose.
+
+Github setup:
+  * Create a personal access token with `repo` and `workflow` permissions at https://github.com/settings/tokens
+  * Fork both of the repositories:
+    * https://github.com/mhutchinson/mhutchinson-distributor
+    * https://github.com/WolseyBankWitness/rediffusion
+
+Raise PRs against the distributor repositories in order to register your new
+witness in their configuration files. Documentation on how to do this is found
+on the README at the root of these repositories.
+
+# OmniWitness: Dockerized
+
 This is a docker configuration that allows a witness to be deployed that will witness checkpoints from all known logs
 that have a valid note Checkpoint format (logs are explicitly listed in `./witness_configs/witness.yaml`).
 Features:
@@ -25,21 +87,9 @@ GIT_EMAIL=johndoe@example.com
 WITNESS_VERSION=latest
 ```
 
-`WITNESS_PRIVATE_KEY` and `WITNESS_PUBLIC_KEY` should be generated for this witness, and the private key kept secret.
-The keys can be generated using `note.GenerateKey`; example code is provided https://play.golang.org/p/uWUKLNK6h9v.
+`WITNESS_PRIVATE_KEY` and `WITNESS_PUBLIC_KEY` should be generated as documented above.
 
-If you wish to use the distributors to push to GitHub, then the other variables to set are those matching `GIT*`.
-Checkpoints will be pushed to the distributors using GitHub pull requests.
-This means that GitHub credentials must be provided.
-If you aren't comfortable doing this on your primary account, set up a secondary account for this purpose.
-
-Github setup:
-  * Create a personal access token with `repo` and `workflow` permissions at https://github.com/settings/tokens
-  * Fork both of the repositories:
-    * https://github.com/mhutchinson/mhutchinson-distributor
-    * https://github.com/WolseyBankWitness/rediffusion
-
-Once this is done, modify the `.env` file:
+If you wish to use the distributors to push to GitHub, follow the configuration steps above and then:
   * The token should be set as `GITHUB_AUTH_TOKEN`
   * `GIT_USERNAME` is the GitHub user account
   * `GIT_EMAIL` is the email address associated with this account
@@ -60,3 +110,4 @@ curl -i http://localhost:8100/witness/v0/logs/3e9617dce5730053cb82f0481b9d289cd3
 If you set up the distributors correctly, then you should see pull requests being raised against the GitHub distributors.
 
 If anything isn't working, the logs are the first place to look, e.g. `docker logs witness_sumdb.feeder_1`.
+

--- a/witness/golang/omniwitness/monolith/README.md
+++ b/witness/golang/omniwitness/monolith/README.md
@@ -1,0 +1,24 @@
+# OmniWitness: Monolith
+
+See the [parent directory](../) for an introduction to what the OmniWitness is, and for
+common configuration steps such as key generation and creating github credentials.
+
+This version uses a single `main` construct to invoke all of the sub-components needed to
+implement the OmniWitness. 
+
+## Running
+
+The configuration files referenced in the parent OmniWitness docs are compiled into the
+application during build. The remaining configuration is that specific to the operator,
+which is provided via flags (though see #662; this will change).
+
+```
+go run github.com/google/trillian-examples/witness/golang/omniwitness/monolith@master --alsologtostderr --v=1 \
+  --private_key PRIVATE+KEY+my.witness+67890abc+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
+  --public_key my.witness+67890abc+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
+  --gh_user my-github-user \
+  --gh_email foo@example.com \
+  --gh_token ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
+  --db_file ~/witness.db
+```
+


### PR DESCRIPTION
This introduces the concept better, and breaks out the common steps for generating required material. Each deployment then is a smaller doc with the specific instructions for that flavour.
