### PR TITLE
Update Pixel log signing ID name

### DIFF
--- a/witness/golang/omniwitness/distributor_configs/witness.yaml
+++ b/witness/golang/omniwitness/distributor_configs/witness.yaml
@@ -11,7 +11,7 @@ Logs:
     URL: https://rekor.sigstore.dev
   - Origin: DEFAULT
     PublicKeyType: ecdsa
-    PublicKey: pixel6_transparency_log+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=
+    PublicKey: pixel_transparency_log+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=
     URL: https://developers.google.com/android/binary_transparency/
   - Origin: lvfs
     PublicKey: lvfs+7908d142+ASnlGgOh+634tcE/2Lp3wV7k/cLoU6ncawmb/BLC1oMU

--- a/witness/golang/omniwitness/feeder_configs/pixel.yaml
+++ b/witness/golang/omniwitness/feeder_configs/pixel.yaml
@@ -1,7 +1,7 @@
 Log:
   Origin: DEFAULT
   PublicKeyType: ecdsa
-  PublicKey: pixel6_transparency_log+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=
+  PublicKey: pixel_transparency_log+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=
   URL: https://developers.google.com/android/binary_transparency/
 
 Witness:

--- a/witness/golang/omniwitness/witness_configs/witness.yaml
+++ b/witness/golang/omniwitness/witness_configs/witness.yaml
@@ -14,7 +14,7 @@ Logs:
     UseCompact: false
   - Origin: DEFAULT
     PublicKeyType: ecdsa
-    PublicKey: pixel6_transparency_log+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=
+    PublicKey: pixel_transparency_log+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=
     HashStrategy: default
     UseCompact: false
   - Origin: lvfs


### PR DESCRIPTION
The Pixel log key appears to have changed its name, update witness configs to match.