### PR TITLE
Fix Rekor feeder to handle sharded logs

### DIFF
--- a/feeder/cmd/rekor_feeder/example_config.yaml
+++ b/feeder/cmd/rekor_feeder/example_config.yaml
@@ -1,8 +1,14 @@
 Logs:
-  - Origin: Rekor
+  - Origin: rekor.sigstore.dev - 3904496407287907110
     PublicKeyType: ecdsa
     PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
     URL: https://rekor.sigstore.dev
+    ID: 3904496407287907110
+  - Origin: rekor.sigstore.dev - 2605736670972794746
+    PublicKeyType: ecdsa
+    PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
+    URL: https://rekor.sigstore.dev
+    ID: 2605736670972794746
 
 Witness:
   URL: http://localhost:8100

--- a/internal/feeder/rekor/rekor_feeder.go
+++ b/internal/feeder/rekor/rekor_feeder.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -76,6 +75,8 @@ func FeedLog(ctx context.Context, l config.Log, w feeder.Witness, c *http.Client
 	}
 
 	fetchCP := func(ctx context.Context) ([]byte, error) {
+		// Each Rekor feeder will request the same log info.
+		// TODO: Explore if it's feasible to request this once for all Rekor feeders.
 		li := logInfo{}
 		if err := getJSON(ctx, c, lURL, "api/v1/log", &li); err != nil {
 			return nil, fmt.Errorf("failed to fetch log info: %v", err)
@@ -90,7 +91,7 @@ func FeedLog(ctx context.Context, l config.Log, w feeder.Witness, c *http.Client
 				return []byte(shard.SignedTreeHead), nil
 			}
 		}
-		return nil, errors.New("failed to find shard that matched log ID from config")
+		return nil, fmt.Errorf("failed to find shard that matched log ID %s from config", l.ID)
 	}
 	fetchProof := func(ctx context.Context, from, to log.Checkpoint) ([][]byte, error) {
 		if from.Size == 0 {

--- a/internal/feeder/rekor/rekor_feeder.go
+++ b/internal/feeder/rekor/rekor_feeder.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -34,11 +35,25 @@ import (
 	i_note "github.com/google/trillian-examples/internal/note"
 )
 
-// logInfo is a partial representation of the JSON object returned by Rekór's
+// inactiveShardLogInfo is a presentation of the JSON object returned
+// by Rekor when there are inactive shards.
+type inactiveShardLogInfo struct {
+	RootHash string `json:"rootHash"`
+	// SignedTreeHead contains a Rekór checkpoint.
+	SignedTreeHead string `json:"signedTreeHead"`
+	TreeID         string `json:"treeID"`
+	TreeSize       int64  `json:"treeSize"`
+}
+
+// logInfo is a representation of the JSON object returned by Rekór's
 // api/v1/log request.
 type logInfo struct {
 	// SignedTreeHead contains a Rekór checkpoint.
-	SignedTreeHead string `json:"signedTreeHead"`
+	SignedTreeHead string                 `json:"signedTreeHead"`
+	RootHash       string                 `json:"rootHash"`
+	TreeID         string                 `json:"treeID"`
+	TreeSize       int64                  `json:"treeSize"`
+	InactiveShards []inactiveShardLogInfo `json:"inactiveShards"`
 }
 
 // proof is a partial representation of the JSON struct returned by the Rekór
@@ -65,14 +80,24 @@ func FeedLog(ctx context.Context, l config.Log, w feeder.Witness, c *http.Client
 		if err := getJSON(ctx, c, lURL, "api/v1/log", &li); err != nil {
 			return nil, fmt.Errorf("failed to fetch log info: %v", err)
 		}
-		return []byte(li.SignedTreeHead), nil
+		// Active shard
+		if li.TreeID == l.ID {
+			return []byte(li.SignedTreeHead), nil
+		}
+		// Search inactive shards
+		for _, shard := range li.InactiveShards {
+			if shard.TreeID == l.ID {
+				return []byte(shard.SignedTreeHead), nil
+			}
+		}
+		return nil, errors.New("failed to find shard that matched log ID from config")
 	}
 	fetchProof := func(ctx context.Context, from, to log.Checkpoint) ([][]byte, error) {
 		if from.Size == 0 {
 			return [][]byte{}, nil
 		}
 		cp := proof{}
-		if err := getJSON(ctx, c, lURL, fmt.Sprintf("api/v1/log/proof?firstSize=%d&lastSize=%d", from.Size, to.Size), &cp); err != nil {
+		if err := getJSON(ctx, c, lURL, fmt.Sprintf("api/v1/log/proof?firstSize=%d&lastSize=%d&treeID=%s", from.Size, to.Size, l.ID), &cp); err != nil {
 			return nil, fmt.Errorf("failed to fetch log info: %v", err)
 		}
 		var err error

--- a/witness/golang/omniwitness/distributor_configs/witness.yaml
+++ b/witness/golang/omniwitness/distributor_configs/witness.yaml
@@ -5,10 +5,16 @@ Logs:
   - Origin: Armory Drive Prod 2
     PublicKey: armory-drive-log+16541b8f+AYDPmG5pQp4Bgu0a1mr5uDZ196+t8lIVIfWQSPWmP+Jv
     URL: https://raw.githubusercontent.com/f-secure-foundry/armory-drive-log/master/log/
-  - Origin: Rekor
+  - Origin: rekor.sigstore.dev - 3904496407287907110
     PublicKeyType: ecdsa
     PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
     URL: https://rekor.sigstore.dev
+    ID: 3904496407287907110
+  - Origin: rekor.sigstore.dev - 2605736670972794746
+    PublicKeyType: ecdsa
+    PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
+    URL: https://rekor.sigstore.dev
+    ID: 2605736670972794746
   - Origin: DEFAULT
     PublicKeyType: ecdsa
     PublicKey: pixel_transparency_log+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=

--- a/witness/golang/omniwitness/feeder_configs/rekor.yaml
+++ b/witness/golang/omniwitness/feeder_configs/rekor.yaml
@@ -1,8 +1,14 @@
 Logs:
-  - Origin: Rekor
+  - Origin: rekor.sigstore.dev - 3904496407287907110
     PublicKeyType: ecdsa
     PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
     URL: https://rekor.sigstore.dev
+    ID: 3904496407287907110
+  - Origin: rekor.sigstore.dev - 2605736670972794746
+    PublicKeyType: ecdsa
+    PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
+    URL: https://rekor.sigstore.dev
+    ID: 2605736670972794746
 
 Witness:
   URL: http://witness:8100

--- a/witness/golang/omniwitness/witness_configs/witness.yaml
+++ b/witness/golang/omniwitness/witness_configs/witness.yaml
@@ -7,9 +7,16 @@ Logs:
     PublicKey: armory-drive-log+16541b8f+AYDPmG5pQp4Bgu0a1mr5uDZ196+t8lIVIfWQSPWmP+Jv
     HashStrategy: default
     UseCompact: false
-  - Origin: Rekor
+  - Origin: rekor.sigstore.dev - 3904496407287907110
     PublicKeyType: ecdsa
     PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
+    LogID: 3904496407287907110
+    HashStrategy: default
+    UseCompact: false
+  - Origin: rekor.sigstore.dev - 2605736670972794746
+    PublicKeyType: ecdsa
+    PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
+    LogID: 2605736670972794746
     HashStrategy: default
     UseCompact: false
   - Origin: DEFAULT


### PR DESCRIPTION
This updates the feeder to specify the shard ID when fetching a consistency proof, using the ID from the config.

I also needed to update fetching the latest checkpoint, searching for the checkpoint that matches the shard ID from the config.

Also added the new shard to the configs, and updated the Origin to match what's now returned by Rekor.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>