### PR TITLE
Optionally output log inclusion proof in JSON.

### DIFF
--- a/clone/cmd/serverlessclone/serverlessclone.go
+++ b/clone/cmd/serverlessclone/serverlessclone.go
@@ -82,7 +82,7 @@ func main() {
 	}
 	f := newFetcher(u)
 
-	targetCp, rawCp, err := client.FetchCheckpoint(ctx, f, v, *origin)
+	targetCp, rawCp, _, err := client.FetchCheckpoint(ctx, f, v, *origin)
 	if err != nil {
 		glog.Exitf("Failed to get latest checkpoint from log: %v", err)
 	}

--- a/serverless/client/witness/consensus.go
+++ b/serverless/client/witness/consensus.go
@@ -44,7 +44,7 @@ func CheckpointNConsensus(logID string, distributors []client.Fetcher, witnesses
 	//  - no distributor has a checkpoint.N file signed by N of the known witnesses.
 	//
 	// It's good enough for now, though.
-	return func(ctx context.Context, logSigV note.Verifier, origin string) (*fmt_log.Checkpoint, []byte, error) {
+	return func(ctx context.Context, logSigV note.Verifier, origin string) (*fmt_log.Checkpoint, []byte, *note.Note, error) {
 		type cp struct {
 			cp  *fmt_log.Checkpoint
 			n   *note.Note
@@ -84,9 +84,9 @@ func CheckpointNConsensus(logID string, distributors []client.Fetcher, witnesses
 			}
 		}
 		if bestCP.cp == nil {
-			return nil, nil, fmt.Errorf("unable to identify suitable checkpoint (fetch errs: %v)", fetchErrs)
+			return nil, nil, nil, fmt.Errorf("unable to identify suitable checkpoint (fetch errs: %v)", fetchErrs)
 		}
-		return bestCP.cp, bestCP.raw, nil
+		return bestCP.cp, bestCP.raw, bestCP.n, nil
 	}, nil
 }
 

--- a/serverless/client/witness/consensus_test.go
+++ b/serverless/client/witness/consensus_test.go
@@ -142,7 +142,7 @@ func TestCheckpointNConsensus(t *testing.T) {
 			if err != nil {
 				t.Fatalf("CheckpointNConsensus() = %v", err)
 			}
-			_, raw, err := f(context.Background(), logV, testOrigin)
+			_, raw, _, err := f(context.Background(), logV, testOrigin)
 			gotErr := err != nil
 			if gotErr != test.wantErr {
 				t.Errorf("Got err: %v, want err: %v", err, test.wantErr)


### PR DESCRIPTION
For some scenarios, it is useful to independently check a log inclusion proof. The serverless "client inclusion" command does provide the information necessary to verify the proof, such as the node index, the tree size, the tree root hash, and node hashes. But these are not provided in an easy-to-consume format. The hashes can be written to a file, but they are useless without the node index, tree size, and root hash. The index, tree size and root hash have to be scraped from the log output, which requires messy text parsing.

This change adds a new option to the "client inclusion" command to write all of this information to a file in JSON format. This gives us a self-contained proof file that can be used to verify log inclusion.