### PR TITLE
[Witness/Feeder] Configure Rekor treeID via URL

### DIFF
--- a/serverless/config/log.go
+++ b/serverless/config/log.go
@@ -28,7 +28,8 @@ import (
 // Log describes a verifiable log in a config file.
 type Log struct {
 	// ID is used to refer to the log in directory paths.
-	// ID is optional and will be defaulted to logfmt.ID() if not present.
+	// This field should not be manually set in configs, instead it will be
+	// derived automatically by logfmt.ID.
 	ID string `yaml:"ID"`
 	// PublicKey used to verify checkpoints from this log.
 	PublicKey string `yaml:"PublicKey"`
@@ -70,9 +71,11 @@ func (l *Log) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	if len(raw.ID) == 0 {
-		raw.ID = log.ID(raw.Origin, []byte(raw.PublicKey))
+	if len(raw.ID) > 0 {
+		return errors.New("the ID field should not be manually configured")
 	}
+	raw.ID = log.ID(raw.Origin, []byte(raw.PublicKey))
+
 	*l = Log(raw)
 	return nil
 }

--- a/serverless/config/log_test.go
+++ b/serverless/config/log_test.go
@@ -38,3 +38,15 @@ func TestExampleConfig(t *testing.T) {
 		t.Errorf("Validate: %v", err)
 	}
 }
+
+func TestConfigOverrideID(t *testing.T) {
+	bs, err := ioutil.ReadFile("example_log_config.yaml")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	bs = append(bs, []byte("\n\tID: wibble")...)
+	config := exampleLogConfig{}
+	if err := yaml.Unmarshal(bs, &config); err == nil {
+		t.Fatal("Unmarshal expected error, but got none")
+	}
+}

--- a/witness/golang/omniwitness/distributor_configs/witness.yaml
+++ b/witness/golang/omniwitness/distributor_configs/witness.yaml
@@ -8,13 +8,11 @@ Logs:
   - Origin: rekor.sigstore.dev - 3904496407287907110
     PublicKeyType: ecdsa
     PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
-    URL: https://rekor.sigstore.dev
-    ID: 3904496407287907110
+    URL: https://rekor.sigstore.dev?treeID=3904496407287907110
   - Origin: rekor.sigstore.dev - 2605736670972794746
     PublicKeyType: ecdsa
     PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
-    URL: https://rekor.sigstore.dev
-    ID: 2605736670972794746
+    URL: https://rekor.sigstore.dev?treeID=2605736670972794746
   - Origin: DEFAULT
     PublicKeyType: ecdsa
     PublicKey: pixel_transparency_log+72c878db+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFPN7lzVIk2BOd3Nk33VpqqVttGwV8uChH+RX/HVfBiypVQFyh8o8Ny6fSdxNMgkSf9/VynrgADBeys0r4Q9uPA=

--- a/witness/golang/omniwitness/feeder_configs/rekor.yaml
+++ b/witness/golang/omniwitness/feeder_configs/rekor.yaml
@@ -2,13 +2,11 @@ Logs:
   - Origin: rekor.sigstore.dev - 3904496407287907110
     PublicKeyType: ecdsa
     PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
-    URL: https://rekor.sigstore.dev
-    ID: 3904496407287907110
+    URL: https://rekor.sigstore.dev?treeID=3904496407287907110
   - Origin: rekor.sigstore.dev - 2605736670972794746
     PublicKeyType: ecdsa
     PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
-    URL: https://rekor.sigstore.dev
-    ID: 2605736670972794746
+    URL: https://rekor.sigstore.dev?treeID=2605736670972794746
 
 Witness:
   URL: http://witness:8100

--- a/witness/golang/omniwitness/witness_configs/witness.yaml
+++ b/witness/golang/omniwitness/witness_configs/witness.yaml
@@ -10,13 +10,11 @@ Logs:
   - Origin: rekor.sigstore.dev - 3904496407287907110
     PublicKeyType: ecdsa
     PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
-    LogID: 3904496407287907110
     HashStrategy: default
     UseCompact: false
   - Origin: rekor.sigstore.dev - 2605736670972794746
     PublicKeyType: ecdsa
     PublicKey: rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc=
-    LogID: 2605736670972794746
     HashStrategy: default
     UseCompact: false
   - Origin: DEFAULT


### PR DESCRIPTION
This PR moves the configuration of the Rekor `treeID` into the `LogURL` field rather than overloading `ID`.

The URL is a more natural place for this param (indeed, `treeID` ends up as a HTTP param on the request), and overriding `ID` has the unfortunate side effect of changing the directory name for the log in current distributor implementations away from the default derived hash value to a value which all distributor clients would need to configure.