### PR TITLE
Make checkpoint signatures available from checkpoint tracker.

### DIFF
--- a/clone/cmd/serverlessclone/serverlessclone.go
+++ b/clone/cmd/serverlessclone/serverlessclone.go
@@ -82,7 +82,7 @@ func main() {
 	}
 	f := newFetcher(u)
 
-	targetCp, rawCp, err := client.FetchCheckpoint(ctx, f, v, *origin)
+	targetCp, rawCp, _, err := client.FetchCheckpoint(ctx, f, v, *origin)
 	if err != nil {
 		glog.Exitf("Failed to get latest checkpoint from log: %v", err)
 	}

--- a/serverless/client/client.go
+++ b/serverless/client/client.go
@@ -50,27 +50,27 @@ type Fetcher func(ctx context.Context, path string) ([]byte, error)
 // signed by logSigV and satisfies some consensus algorithm.
 //
 // This is intended to provide a hook for adding a consensus view of a log, e.g. via witnessing.
-type ConsensusCheckpointFunc func(ctx context.Context, logSigV note.Verifier, origin string) (*log.Checkpoint, []byte, error)
+type ConsensusCheckpointFunc func(ctx context.Context, logSigV note.Verifier, origin string) (*log.Checkpoint, []byte, *note.Note, error)
 
 // UnilateralConsensus blindly trusts the source log, returning the checkpoint it provided.
 func UnilateralConsensus(f Fetcher) ConsensusCheckpointFunc {
-	return func(ctx context.Context, logSigV note.Verifier, origin string) (*log.Checkpoint, []byte, error) {
+	return func(ctx context.Context, logSigV note.Verifier, origin string) (*log.Checkpoint, []byte, *note.Note, error) {
 		return FetchCheckpoint(ctx, f, logSigV, origin)
 	}
 }
 
 // FetchCheckpoint retrieves and opens a checkpoint from the log.
 // Returns both the parsed structure and the raw serialised checkpoint.
-func FetchCheckpoint(ctx context.Context, f Fetcher, v note.Verifier, origin string) (*log.Checkpoint, []byte, error) {
+func FetchCheckpoint(ctx context.Context, f Fetcher, v note.Verifier, origin string) (*log.Checkpoint, []byte, *note.Note, error) {
 	cpRaw, err := f(ctx, layout.CheckpointPath)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	cp, _, _, err := log.ParseCheckpoint(cpRaw, origin, v)
+	cp, _, n, err := log.ParseCheckpoint(cpRaw, origin, v)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse Checkpoint: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to parse Checkpoint: %v", err)
 	}
-	return cp, cpRaw, nil
+	return cp, cpRaw, n, nil
 }
 
 // ProofBuilder knows how to build inclusion and consistency proofs from tiles.
@@ -321,7 +321,11 @@ type LogStateTracker struct {
 
 	// LatestConsistent is the deserialised form of LatestConsistentRaw
 	LatestConsistent log.Checkpoint
-	CpSigVerifier    note.Verifier
+
+	// The note with signatures and other metadata about the checkpoint
+	CheckpointNote *note.Note
+
+	CpSigVerifier note.Verifier
 }
 
 // NewLogStateTracker creates a newly initialised tracker.
@@ -333,6 +337,7 @@ func NewLogStateTracker(ctx context.Context, f Fetcher, h merkle.LogHasher, chec
 		Fetcher:             f,
 		Hasher:              h,
 		LatestConsistent:    log.Checkpoint{},
+		CheckpointNote:      nil,
 		CpSigVerifier:       nV,
 		Origin:              origin,
 	}
@@ -378,7 +383,7 @@ func (e ErrInconsistency) Error() string {
 // If the LatestConsistent checkpoint is 0 sized, no consistency proof will be returned
 // since it would be meaningless to do so.
 func (lst *LogStateTracker) Update(ctx context.Context) ([]byte, [][]byte, []byte, error) {
-	c, cRaw, err := lst.ConsensusCheckpoint(ctx, lst.CpSigVerifier, lst.Origin)
+	c, cRaw, cn, err := lst.ConsensusCheckpoint(ctx, lst.CpSigVerifier, lst.Origin)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -404,7 +409,7 @@ func (lst *LogStateTracker) Update(ctx context.Context) ([]byte, [][]byte, []byt
 		}
 	}
 	oldRaw := lst.LatestConsistentRaw
-	lst.LatestConsistentRaw, lst.LatestConsistent = cRaw, *c
+	lst.LatestConsistentRaw, lst.LatestConsistent, lst.CheckpointNote = cRaw, *c, cn
 	return oldRaw, p, lst.LatestConsistentRaw, nil
 }
 

--- a/serverless/client/witness/consensus.go
+++ b/serverless/client/witness/consensus.go
@@ -44,7 +44,7 @@ func CheckpointNConsensus(logID string, distributors []client.Fetcher, witnesses
 	//  - no distributor has a checkpoint.N file signed by N of the known witnesses.
 	//
 	// It's good enough for now, though.
-	return func(ctx context.Context, logSigV note.Verifier, origin string) (*fmt_log.Checkpoint, []byte, error) {
+	return func(ctx context.Context, logSigV note.Verifier, origin string) (*fmt_log.Checkpoint, []byte, *note.Note, error) {
 		type cp struct {
 			cp  *fmt_log.Checkpoint
 			n   *note.Note
@@ -84,9 +84,9 @@ func CheckpointNConsensus(logID string, distributors []client.Fetcher, witnesses
 			}
 		}
 		if bestCP.cp == nil {
-			return nil, nil, fmt.Errorf("unable to identify suitable checkpoint (fetch errs: %v)", fetchErrs)
+			return nil, nil, nil, fmt.Errorf("unable to identify suitable checkpoint (fetch errs: %v)", fetchErrs)
 		}
-		return bestCP.cp, bestCP.raw, nil
+		return bestCP.cp, bestCP.raw, bestCP.n, nil
 	}, nil
 }
 

--- a/serverless/client/witness/consensus_test.go
+++ b/serverless/client/witness/consensus_test.go
@@ -142,7 +142,7 @@ func TestCheckpointNConsensus(t *testing.T) {
 			if err != nil {
 				t.Fatalf("CheckpointNConsensus() = %v", err)
 			}
-			_, raw, err := f(context.Background(), logV, testOrigin)
+			_, raw, _, err := f(context.Background(), logV, testOrigin)
 			gotErr := err != nil
 			if gotErr != test.wantErr {
 				t.Errorf("Got err: %v, want err: %v", err, test.wantErr)

--- a/serverless/experimental/wasm/main.go
+++ b/serverless/experimental/wasm/main.go
@@ -89,7 +89,7 @@ func showCP(ctx context.Context, f client.Fetcher) {
 		case <-ctx.Done():
 			return
 		}
-		_, cp, err := client.FetchCheckpoint(ctx, f, logVer, origin)
+		_, cp, _, err := client.FetchCheckpoint(ctx, f, logVer, origin)
 		if err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
 				logMsg(err.Error())
@@ -245,7 +245,7 @@ monitorLoop:
 			return
 		}
 
-		cp, _, err := client.FetchCheckpoint(ctx, f, logVer, origin)
+		cp, _, _, err := client.FetchCheckpoint(ctx, f, logVer, origin)
 		if err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
 				monMsg(err.Error())

--- a/serverless/integration/integration_test.go
+++ b/serverless/integration/integration_test.go
@@ -42,7 +42,6 @@ const (
 	pubKey            = "astra+cad5a3d2+AZJqeuyE/GnknsCNh1eCtDtwdAwKBddOlS8M2eI1Jt4b"
 	privKey           = "PRIVATE+KEY+astra+cad5a3d2+ASgwwenlc0uuYcdy7kI44pQvuz1fw8cS5NqS8RkZBXoy"
 	integrationOrigin = "Serverless Integration Test Log"
-	keyName           = "astra"
 )
 
 func RunIntegration(t *testing.T, s log.Storage, f client.Fetcher, lh *rfc6962.Hasher, signer note.Signer) {
@@ -72,7 +71,7 @@ func RunIntegration(t *testing.T, s log.Storage, f client.Fetcher, lh *rfc6962.H
 		// Sequence some leaves:
 		leaves := sequenceNLeaves(ctx, t, s, lh, i*leavesPerLoop, leavesPerLoop)
 
-		var latestCpNote *note.Note = nil
+		var latestCpNote *note.Note
 		// Integrate those leaves
 		{
 			update, err := log.Integrate(ctx, checkpoint, s, lh)


### PR DESCRIPTION
This updates the transparency log checkpoint tracker to make the checkpoint's signature(s) available for client code that wants to verify the signature itself.