### PR TITLE
Remove GOMODULE111 in cloudbuild scripts

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,6 @@ options:
   - name: go-modules
     path: /go
   env:
-  - GO111MODULE=on
   - GOPROXY=https://proxy.golang.org
   - PROJECT_ROOT=github.com/google/trillian-examples
   - GOPATH=/go

--- a/cloudbuild_docker.yaml
+++ b/cloudbuild_docker.yaml
@@ -8,7 +8,6 @@ options:
   - name: go-modules
     path: /go
   env:
-  - GO111MODULE=on
   - GOPROXY=https://proxy.golang.org
   - PROJECT_ROOT=github.com/google/trillian-examples
   - GOPATH=/go


### PR DESCRIPTION
The default behavior in Go 1.16 is `GO111MODULE=on`. It is safe to remove this environment variable as this repo is using Go 1.19.