### PR TITLE
Made the monolith easier to discover, and better documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ The general-purpose components are:
   checkpoints issued by a verifiable log and produces co-signed checkpoints.
   This is an important role that enables the prevention or detection of certain
   types of log misbehavior (and in particular split-view attacks).
+    * [monolith](witness/golang/omniwitness/monolith) is the entry point for
+      users looking to deploy a preconfigured witness that witnesses all known
+      logs.
 
 These examples and components are not supported per-se, but the Trillian team 
 will likely try to help where possible.  You can contact them via the channels 

--- a/witness/README.md
+++ b/witness/README.md
@@ -32,8 +32,7 @@ making cosigned checkpoints available via some API (distributor).
 ## Generic Witness Implementation
 
 This repository provides a witness that works for any log that uses the
-[format defined in this
-repository](https://github.com/google/trillian-examples/tree/master/formats/log).
+[log checkpoint format](https://github.com/transparency-dev/formats/tree/main/log).
 Each log requires a custom feeder to provide the binding between the log and the
 witness. Such feeders are intentionally not provided here in order to maintain a
 logical separation, and to avoid this package acquiring vast numbers of code
@@ -77,10 +76,11 @@ defined above.  Currently it contains implementations in the following languages
 ## Feeders
 
 Specific feeders are listed below, however potential witness operators are advised to
-simply deploy the [Omniwitness](golang/omniwitness) which contains all of these
+simply deploy the [Omniwitness](golang/omniwitness/monolith) which contains all of these
 feeders, unless there is a compelling reason to limit the witnessed logs.
 
 * [Go SumDB](https://github.com/google/trillian-examples/tree/master/sumdbaudit/witness)
 * [Serverless](https://github.com/google/trillian-examples/tree/master/serverless/cmd/feeder)
 * [Pixel BT](https://github.com/google/trillian-examples/tree/master/feeder/cmd/pixel_bt_feeder)
 * [Rekor/SigStore](https://github.com/google/trillian-examples/tree/master/feeder/cmd/rekor_feeder)
+

--- a/witness/golang/README.md
+++ b/witness/golang/README.md
@@ -17,6 +17,12 @@ Once up and running, the witness provides three API endpoints (as defined in
 Running the witness
 --------------------
 
+Most users wanting to run a witness will simply deploy the [OmniWitness](omniwitness/monolith),
+which is preconfigured to witness all known logs using the checkpoint format.
+
+Witnessing a custom log
+-----------------------
+
 Running the witness is as simple as running `go run main.go` (where `main.go`
 can be found in the `cmd/witness` directory), with the following flags:
 - `listen`, which specifies the address and port to listen on.

--- a/witness/golang/omniwitness/README.md
+++ b/witness/golang/omniwitness/README.md
@@ -7,7 +7,9 @@ The OmniWitness is opinionated on which logs and distributors will be used. Depl
 of the OmniWitness implementations will perform the same witnessing and distribution, unless
 the operator changes any of the configuration files in the `*_configs` directories here.
 
-This directory contains a dockerized implementation for a micro-services style deployment;
+The recommended way to deploy the OmniWitness is using the [monolith](monolith), which is
+a single executable that bundles all of the components. Alternatively, this
+directory contains a dockerized implementation for a micro-services style deployment;
 a container will be deployed for:
   * The core witness
   * Each of the feeder types (one for each of the config files in `./feeder_configs`)

--- a/witness/golang/omniwitness/internal/omniwitness/omniwitness.go
+++ b/witness/golang/omniwitness/internal/omniwitness/omniwitness.go
@@ -173,6 +173,8 @@ func Main(ctx context.Context, operatorConfig OperatorConfig, p persistence.LogS
 		}
 
 		runDistributors(ctx, httpClient, g, distLogs, bw, operatorConfig)
+	} else {
+		glog.Info("No GitHub user specified; skipping deployment of distributors")
 	}
 
 	r := mux.NewRouter()

--- a/witness/golang/omniwitness/monolith/README.md
+++ b/witness/golang/omniwitness/monolith/README.md
@@ -12,6 +12,23 @@ The configuration files referenced in the parent OmniWitness docs are compiled i
 application during build. The remaining configuration is that specific to the operator,
 which is provided via flags (though see #662; this will change).
 
+The simplest possible configuration brings up the OmniWitness to follow all of the logs,
+but the witnessed checkpoints will not be distributed and can only be disovered via the
+witness HTTP endpoints (see parent directories for documentation on these):
+
+```
+go run github.com/google/trillian-examples/witness/golang/omniwitness/monolith@master --alsologtostderr --v=1 \
+  --private_key PRIVATE+KEY+my.witness+67890abc+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
+  --public_key my.witness+67890abc+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
+  --db_file ~/witness.db
+```
+
+A more advanced configuration for users that are committed to running the witness is to
+set up witnessed checkpoints to be distributed via the GitHub distributors, which will
+strengthen the ecosystem. Note that this requires more configuration of GitHub secrets,
+and your witness key adding to the configuration files for the distributors. This
+configuration is detailed in the parent directories.
+
 ```
 go run github.com/google/trillian-examples/witness/golang/omniwitness/monolith@master --alsologtostderr --v=1 \
   --private_key PRIVATE+KEY+my.witness+67890abc+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \


### PR DESCRIPTION
The monolith should be the default witness that most people should find themselves at; it is simple to deploy and follows all known logs. The other configurations (dockerized, bare witness) are still useful, but only to advanced users that know they don't want the monolith.
