### PR TITLE
Use alpine instead of buster for the release image of omniwitness monolith

### DIFF
--- a/witness/golang/omniwitness/monolith/Dockerfile
+++ b/witness/golang/omniwitness/monolith/Dockerfile
@@ -20,7 +20,7 @@ COPY . .
 RUN go build -o omniwitness ./witness/golang/omniwitness/monolith
 
 # Build release image
-FROM golang:buster
+FROM alpine
 
 COPY --from=builder /build/omniwitness /bin/omniwitness
 ENTRYPOINT ["/bin/omniwitness"]


### PR DESCRIPTION
This is consistent with the Dockerfiles of the subcomponents, and removes the omniwitness from being the only target in `cloudbuild_docker.yaml` that uses a non-alpine release base. This may resolve #717. In addition, it should make the release image a lot smaller.
