### PR TITLE
Witness bails with error if config has log configs with duplicate IDs

### DIFF
--- a/witness/golang/cmd/witness/impl/witness.go
+++ b/witness/golang/cmd/witness/impl/witness.go
@@ -86,6 +86,9 @@ func (config LogConfig) AsLogMap() (map[string]witness.LogInfo, error) {
 		if len(logID) == 0 {
 			logID = logfmt.ID(log.Origin, []byte(log.PublicKey))
 		}
+		if oldLog, found := logMap[logID]; found {
+			return nil, fmt.Errorf("colliding log configs found for key %x: %+v and %+v", logID, oldLog, logInfo)
+		}
 		logMap[logID] = logInfo
 	}
 	return logMap, nil


### PR DESCRIPTION
This currently fails because of the colliding Rekor configs. This PR should not be merged until https://github.com/transparency-dev/formats/issues/14 is addressed and the dependency here is updated.
