### PR TITLE
Breaking change: use new ID function for logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
-	github.com/transparency-dev/formats v0.0.0-20221130180841-34660baab089 // indirect
+	github.com/transparency-dev/formats v0.0.0-20230124125735-2da9e2580a26 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/net v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -267,6 +267,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/transparency-dev/formats v0.0.0-20221130180841-34660baab089 h1:0E7R/5vhZ+2zAwIWofJpdnY3eAONu+pRoVaDjCWDCWA=
 github.com/transparency-dev/formats v0.0.0-20221130180841-34660baab089/go.mod h1:fd1larYQvguClA6Lzz0QQZr1hk+xNW5Mdrs5ubO/q1M=
+github.com/transparency-dev/formats v0.0.0-20230124125735-2da9e2580a26 h1:CVoO2X5LdS4DMgC2UeRx9VzJvTV3BNuxldzvSkC9QlQ=
+github.com/transparency-dev/formats v0.0.0-20230124125735-2da9e2580a26/go.mod h1:fd1larYQvguClA6Lzz0QQZr1hk+xNW5Mdrs5ubO/q1M=
 github.com/transparency-dev/merkle v0.0.1 h1:T9/9gYB8uZl7VOJIhdwjALeRWlxUxSfDEysjfmx+L9E=
 github.com/transparency-dev/merkle v0.0.1/go.mod h1:B8FIw5LTq6DaULoHsVFRzYIUDkl8yuSwCdZnOZGKL/A=
 github.com/twitchyliquid64/golang-asm v0.0.0-20190126203739-365674df15fc h1:RTUQlKzoZZVG3umWNzOYeFecQLIh+dbxXvJp1zPQJTI=

--- a/serverless/deploy/github/distributor/combine_witness_signatures/go.mod
+++ b/serverless/deploy/github/distributor/combine_witness_signatures/go.mod
@@ -10,6 +10,6 @@ require (
 )
 
 require (
-	github.com/transparency-dev/formats v0.0.0-20221130180841-34660baab089 // indirect
+	github.com/transparency-dev/formats v0.0.0-20230124125735-2da9e2580a26 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 )

--- a/serverless/deploy/github/distributor/combine_witness_signatures/go.sum
+++ b/serverless/deploy/github/distributor/combine_witness_signatures/go.sum
@@ -682,6 +682,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/transparency-dev/formats v0.0.0-20221130180841-34660baab089 h1:0E7R/5vhZ+2zAwIWofJpdnY3eAONu+pRoVaDjCWDCWA=
 github.com/transparency-dev/formats v0.0.0-20221130180841-34660baab089/go.mod h1:fd1larYQvguClA6Lzz0QQZr1hk+xNW5Mdrs5ubO/q1M=
+github.com/transparency-dev/formats v0.0.0-20230124125735-2da9e2580a26 h1:CVoO2X5LdS4DMgC2UeRx9VzJvTV3BNuxldzvSkC9QlQ=
+github.com/transparency-dev/formats v0.0.0-20230124125735-2da9e2580a26/go.mod h1:fd1larYQvguClA6Lzz0QQZr1hk+xNW5Mdrs5ubO/q1M=
 github.com/transparency-dev/merkle v0.0.0-20220104141048-2fe6541b4c0d/go.mod h1:B8FIw5LTq6DaULoHsVFRzYIUDkl8yuSwCdZnOZGKL/A=
 github.com/twitchyliquid64/golang-asm v0.0.0-20190126203739-365674df15fc/go.mod h1:NoCfSFWosfqMqmmD7hApkirIK9ozpHjxRnRxs1l413A=
 github.com/u-root/u-root v7.0.0+incompatible/go.mod h1:RYkpo8pTHrNjW08opNd/U6p/RJE7K0D8fXO0d47+3YY=


### PR DESCRIPTION
All distributors and witnesses will need to redeploy in order to re-sync on IDs
