### PR TITLE
[Serverless/witness] Update example actions config

### DIFF
--- a/serverless/deploy/github/distributor/README.md
+++ b/serverless/deploy/github/distributor/README.md
@@ -85,7 +85,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
           ref: "refs/pull/${{ github.event.number }}/merge"
       - name: Combine witness signatures (dry run)
         id: combine_witness_signatures_dry_run


### PR DESCRIPTION
The distributor_pr action no longer needs the full history of the repo, so only check out the last commit. This can speed the action up quite a bit.