### PR TITLE
Enable all lint checks

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,22 +15,6 @@ linters-settings:
       - encoding/asn1
       - crypto/x509
 
-linters:
-  disable-all: true
-  enable:
-    - depguard
-    - gocyclo
-    - gofmt
-    - goimports
-    - govet
-    - ineffassign
-    - megacheck
-    - misspell
-    - revive
-    - unused
-    # TODO(gbelvin): write license linter and commit to upstream.
-    # ./scripts/check_license.sh is run by ./scripts/presubmit.sh
-
 issues:
   # Don't turn off any checks by default. We can do this explicitly if needed.
   exclude-use-default: false

--- a/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
+++ b/binary_transparency/firmware/cmd/flash_tool/impl/flash_tool.go
@@ -146,7 +146,11 @@ func readUpdateFile(path string) (api.UpdatePackage, error) {
 	if err != nil {
 		glog.Exitf("Failed to open update package file %q: %q", path, err)
 	}
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			glog.Errorf("f.Close(): %v", err)
+		}
+	}()
 
 	var up api.UpdatePackage
 	if err := json.NewDecoder(f).Decode(&up); err != nil {

--- a/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
+++ b/binary_transparency/firmware/cmd/ft_monitor/impl/ft_monitor.go
@@ -118,7 +118,9 @@ func Main(ctx context.Context, opts MonitorOpts) error {
 		if entry.Index == entry.Root.Size-1 {
 			// If we have processed all leaves in the current checkpoint, then persist this checkpoint
 			// so that we don't repeat work on startup.
-			os.WriteFile(opts.StateFile, entry.Root.Envelope, 0o755)
+			if err := os.WriteFile(opts.StateFile, entry.Root.Envelope, 0o755); err != nil {
+				glog.Errorf("os.WriteFile(): %v", err)
+			}
 		}
 	}
 }

--- a/binary_transparency/firmware/cmd/ft_personality/impl/ft_personality.go
+++ b/binary_transparency/firmware/cmd/ft_personality/impl/ft_personality.go
@@ -102,6 +102,8 @@ func Main(ctx context.Context, opts PersonalityOpts) error {
 	}()
 	<-ctx.Done()
 	glog.Info("Server shutting down")
-	hServer.Shutdown(ctx)
+	if err := hServer.Shutdown(ctx); err != nil {
+		glog.Errorf("server.Shutdown(): %v", err)
+	}
 	return <-e
 }

--- a/binary_transparency/firmware/cmd/ft_personality/internal/cas/sql_test.go
+++ b/binary_transparency/firmware/cmd/ft_personality/internal/cas/sql_test.go
@@ -45,7 +45,11 @@ func TestRoundTrip(t *testing.T) {
 			if err != nil {
 				t.Error("failed to open temporary in-memory DB", err)
 			}
-			defer db.Close()
+			defer func() {
+				if err := db.Close(); err != nil {
+					t.Errorf("db.Close(): %v", err)
+				}
+			}()
 
 			store, err := NewBinaryStorage(db)
 			if err != nil {
@@ -75,7 +79,11 @@ func TestUnknownHash(t *testing.T) {
 	if err != nil {
 		t.Error("failed to open temporary in-memory DB", err)
 	}
-	defer db.Close()
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("db.Close(): %v", err)
+		}
+	}()
 
 	store, err := NewBinaryStorage(db)
 	if err != nil {

--- a/binary_transparency/firmware/cmd/ft_personality/internal/http/server.go
+++ b/binary_transparency/firmware/cmd/ft_personality/internal/http/server.go
@@ -222,7 +222,9 @@ func (s *Server) getConsistency(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(js)
+	if _, err := w.Write(js); err != nil {
+		glog.Errorf("w.Write(): %v", err)
+	}
 }
 
 // getInclusionByHash returns an inclusion proof for the entry with the specified hash (if it exists).
@@ -264,7 +266,9 @@ func (s *Server) getInclusionByHash(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(js)
+	if _, err := w.Write(js); err != nil {
+		glog.Errorf("w.Write(): %v", err)
+	}
 }
 
 // getManifestEntryAndProof returns a tree leaf and corresponding inclusion proof.
@@ -308,7 +312,9 @@ func (s *Server) getManifestEntryAndProof(w http.ResponseWriter, r *http.Request
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(js)
+	if _, err := w.Write(js); err != nil {
+		glog.Errorf("w.Write(): %v", err)
+	}
 }
 
 // getRoot returns a recent tree root.
@@ -331,7 +337,9 @@ func (s *Server) getRoot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/plain")
-	w.Write(b)
+	if _, err := w.Write(b); err != nil {
+		glog.Errorf("w.Write(): %v", err)
+	}
 }
 
 // getFirmwareImage returns a firmware image stored in the CAS.
@@ -350,7 +358,9 @@ func (s *Server) getFirmwareImage(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/binary")
 	w.Header().Set("Content-Length", strconv.Itoa(len(image)))
-	w.Write(image)
+	if _, err := w.Write(image); err != nil {
+		glog.Errorf("w.Write(): %v", err)
+	}
 }
 
 // addAnnotationMalware handles requests to annotate a logged firmware with a malware annotation.

--- a/binary_transparency/firmware/cmd/ft_personality/internal/trillian/client.go
+++ b/binary_transparency/firmware/cmd/ft_personality/internal/trillian/client.go
@@ -80,7 +80,11 @@ func NewClient(ctx context.Context, timeout time.Duration, logAddr string, treeS
 		logID:       tree.TreeId,
 		client:      log,
 		golden:      golden,
-		done:        func() { conn.Close() },
+		done: func() {
+			if err := conn.Close(); err != nil {
+				glog.Errorf("conn.Close(): %v", err)
+			}
+		},
 	}
 
 	return client, nil

--- a/binary_transparency/firmware/cmd/ft_witness/impl/ft_witness.go
+++ b/binary_transparency/firmware/cmd/ft_witness/impl/ft_witness.go
@@ -58,7 +58,11 @@ func Main(ctx context.Context, opts WitnessOpts) error {
 	r := mux.NewRouter()
 	witness.RegisterHandlers(r)
 
-	go witness.Poll(ctx)
+	go func() {
+		if err := witness.Poll(ctx); err != nil {
+			glog.Errorf("witness.Poll(): %v", err)
+		}
+	}()
 
 	hServer := &http.Server{
 		Addr:    opts.ListenAddr,
@@ -71,6 +75,8 @@ func Main(ctx context.Context, opts WitnessOpts) error {
 	}()
 	<-ctx.Done()
 	glog.Info("Server shutting down")
-	hServer.Shutdown(ctx)
+	if err := hServer.Shutdown(ctx); err != nil {
+		glog.Errorf("server.Shutdown(): %v", err)
+	}
 	return <-e
 }

--- a/binary_transparency/firmware/cmd/ft_witness/internal/http/witness.go
+++ b/binary_transparency/firmware/cmd/ft_witness/internal/http/witness.go
@@ -79,7 +79,9 @@ func NewWitness(ws WitnessStore, logURL string, logSigVerifier note.Verifier, po
 func (s *Witness) getCheckpoint(w http.ResponseWriter, r *http.Request) {
 	s.witnessLock.Lock()
 	w.Header().Set("Content-Type", "text/plain")
-	w.Write(s.gcp.Envelope)
+	if _, err := w.Write(s.gcp.Envelope); err != nil {
+		glog.Errorf("w.Write(): %v", err)
+	}
 }
 
 // RegisterHandlers registers HTTP handlers for firmware transparency endpoints.

--- a/binary_transparency/firmware/cmd/ft_witness/internal/ws/store.go
+++ b/binary_transparency/firmware/cmd/ft_witness/internal/ws/store.go
@@ -48,7 +48,6 @@ func (ws *Storage) init() error {
 	if err != nil {
 		return fmt.Errorf("failed to open file: %w", err)
 	}
-	defer f.Close()
 	if err := f.Close(); err != nil {
 		return fmt.Errorf("failed to close file: %w", err)
 	}
@@ -64,12 +63,12 @@ func (ws *Storage) StoreCP(wcp []byte) error {
 	// Check if file exists, open for write and store the checkpoint
 	f, err := os.OpenFile(ws.fp, os.O_RDWR, fileMask)
 	if err != nil {
-		f.Close()
+		_ = f.Close()
 		return fmt.Errorf("failed to open file: %w", err)
 	}
 
 	if _, err := f.Write(wcp); err != nil {
-		f.Close()
+		_ = f.Close()
 		return fmt.Errorf("failed to write data to witness db file: %w", err)
 	}
 	if err := f.Close(); err != nil {

--- a/binary_transparency/firmware/cmd/ftmapserver/impl/ftmapserver.go
+++ b/binary_transparency/firmware/cmd/ftmapserver/impl/ftmapserver.go
@@ -79,7 +79,9 @@ func Main(ctx context.Context, opts MapServerOpts) error {
 	}()
 	<-ctx.Done()
 	glog.Info("Server shutting down")
-	hServer.Shutdown(ctx)
+	if err := hServer.Shutdown(ctx); err != nil {
+		glog.Errorf("server.Shutdown(): %v", err)
+	}
 	return <-e
 }
 
@@ -122,7 +124,9 @@ func (s *Server) getCheckpoint(w http.ResponseWriter, r *http.Request) {
 
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(js)
+	if _, err := w.Write(js); err != nil {
+		glog.Errorf("w.Write(): %v", err)
+	}
 }
 
 // getTile returns the tile at the given revision & path.
@@ -159,7 +163,9 @@ func (s *Server) getTile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(js)
+	if _, err := w.Write(js); err != nil {
+		glog.Errorf("w.Write(): %v", err)
+	}
 }
 
 // getAggregation returns the aggregation for the firware at the given log index.
@@ -186,7 +192,9 @@ func (s *Server) getAggregation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(js)
+	if _, err := w.Write(js); err != nil {
+		glog.Errorf("w.Write(): %v", err)
+	}
 }
 
 // RegisterHandlers registers HTTP handlers for the endpoints.

--- a/binary_transparency/firmware/cmd/publisher/impl/publish.go
+++ b/binary_transparency/firmware/cmd/publisher/impl/publish.go
@@ -114,7 +114,11 @@ func Main(ctx context.Context, opts PublishOpts) error {
 		if err != nil {
 			return fmt.Errorf("failed to create output package file %q: %w", opts.OutputPath, err)
 		}
-		defer f.Close()
+		defer func() {
+			if err := f.Close(); err != nil {
+				glog.Errorf("f.Close(): %v", err)
+			}
+		}()
 
 		if err := json.NewEncoder(f).Encode(bundle); err != nil {
 			return fmt.Errorf("failed to encode output package JSON: %w", err)

--- a/binary_transparency/firmware/devices/dummy/flash.go
+++ b/binary_transparency/firmware/devices/dummy/flash.go
@@ -63,7 +63,9 @@ func New(storage string) (*Device, error) {
 		}
 		return d, fmt.Errorf("failed to read bundle file %q: %w", fPath, err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	err = json.NewDecoder(f).Decode(&d.bundle)
 	return d, err

--- a/binary_transparency/firmware/devices/usbarmory/flash/flash.go
+++ b/binary_transparency/firmware/devices/usbarmory/flash/flash.go
@@ -75,7 +75,9 @@ func New(storage string) (*Device, error) {
 		}
 		return d, fmt.Errorf("failed to read bundle file %q: %w", d.bundlePath, err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	err = json.NewDecoder(f).Decode(&d.bundle)
 	return d, err

--- a/binary_transparency/firmware/internal/client/client.go
+++ b/binary_transparency/firmware/internal/client/client.go
@@ -129,7 +129,11 @@ func (c ReadonlyClient) GetCheckpoint() (*api.LogCheckpoint, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer r.Body.Close()
+	defer func() {
+		if err := r.Body.Close(); err != nil {
+			glog.Errorf("r.Body.Close(): %v", err)
+		}
+	}()
 	if r.StatusCode != 200 {
 		return &api.LogCheckpoint{}, errFromResponse("failed to fetch checkpoint", r)
 	}

--- a/binary_transparency/firmware/internal/client/client_test.go
+++ b/binary_transparency/firmware/internal/client/client_test.go
@@ -439,7 +439,9 @@ func TestGetFirmwareImage(t *testing.T) {
 					http.Error(w, "unknown", http.StatusNotFound)
 					return
 				}
-				w.Write(test.body)
+				if _, err := w.Write(test.body); err != nil {
+					t.Errorf("w.Write(): %v", err)
+				}
 			}))
 			defer ts.Close()
 

--- a/binary_transparency/firmware/internal/client/mapclient.go
+++ b/binary_transparency/firmware/internal/client/mapclient.go
@@ -147,7 +147,11 @@ func (c *MapClient) fetch(path string) ([]byte, error) {
 		return nil, errFromResponse(fmt.Sprintf("failed to fetch %s", path), r)
 	}
 	body := r.Body
-	defer body.Close()
+	defer func() {
+		if err := body.Close(); err != nil {
+			glog.Errorf("body.Close(): %v", err)
+		}
+	}()
 	return io.ReadAll(body)
 }
 

--- a/binary_transparency/firmware/internal/client/wclient.go
+++ b/binary_transparency/firmware/internal/client/wclient.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/golang/glog"
 	"github.com/google/trillian-examples/binary_transparency/firmware/api"
 	"golang.org/x/mod/sumdb/note"
 	"google.golang.org/grpc/status"
@@ -42,7 +43,11 @@ func (c WitnessClient) GetWitnessCheckpoint() (*api.LogCheckpoint, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer r.Body.Close()
+	defer func() {
+		if err := r.Body.Close(); err != nil {
+			glog.Errorf("r.Body.Close(): %v", err)
+		}
+	}()
 	if r.StatusCode != 200 {
 		return nil, errFromRsp("failed to fetch checkpoint", r)
 	}

--- a/binary_transparency/firmware/internal/ftmap/log.go
+++ b/binary_transparency/firmware/internal/ftmap/log.go
@@ -67,7 +67,9 @@ func (fn *moduleLogHashFn) ProcessElement(log *api.DeviceReleaseLog) (*batchmap.
 		bs := make([]byte, 8)
 		binary.LittleEndian.PutUint64(bs, v)
 		h := RecordHash(bs)
-		logRange.Append(h[:], nil)
+		if err := logRange.Append(h[:], nil); err != nil {
+			return nil, err
+		}
 	}
 	logRoot, err := logRange.GetRootHash(nil)
 	if err != nil {

--- a/clone/cmd/serverlessclone/serverlessclone.go
+++ b/clone/cmd/serverlessclone/serverlessclone.go
@@ -181,6 +181,10 @@ func readHTTP(ctx context.Context, u *url.URL) ([]byte, error) {
 	default:
 		return nil, fmt.Errorf("unexpected http status %q", resp.Status)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			glog.Errorf("resp.Body.Close(): %v", err)
+		}
+	}()
 	return io.ReadAll(resp.Body)
 }

--- a/clone/internal/cloner/clone_test.go
+++ b/clone/internal/cloner/clone_test.go
@@ -84,11 +84,11 @@ func TestClone(t *testing.T) {
 	}
 }
 
-func newInMemoryDatabase() (*logdb.Database, func() error, error) {
+func newInMemoryDatabase() (*logdb.Database, func(), error) {
 	sqlitedb, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to open temporary in-memory DB: %v", err)
 	}
 	db, err := logdb.NewDatabaseDirect(sqlitedb)
-	return db, sqlitedb.Close, err
+	return db, func() { _ = sqlitedb.Close }, err
 }

--- a/clone/internal/download/http.go
+++ b/clone/internal/download/http.go
@@ -20,6 +20,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+
+	"github.com/golang/glog"
 )
 
 // NewHTTPFetcher returns an HTTPFetcher that gets paths appended to the given prefix.
@@ -46,7 +48,11 @@ func (f HTTPFetcher) GetData(path string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("http.Get: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			glog.Errorf("resp.Body.Close(): %v", err)
+		}
+	}()
 	if resp.StatusCode != 200 {
 		// Could be worth returning a special error when we've been explicitly told to back off.
 		return nil, fmt.Errorf("GET %v: %v", target, resp.Status)

--- a/clone/internal/verify/verify.go
+++ b/clone/internal/verify/verify.go
@@ -74,7 +74,9 @@ func (v LogVerifier) MerkleRoot(ctx context.Context, size uint64) ([]byte, [][]b
 			return nil, nil, fmt.Errorf("failed to get leaves from DB: %w", err)
 		default:
 		}
-		cr.Append(v.lh(index, leaf), nil)
+		if err := cr.Append(v.lh(index, leaf), nil); err != nil {
+			glog.Errorf("cr.Append(): %v", err)
+		}
 		index++
 	}
 	if index != size {

--- a/clone/internal/verify/verify_test.go
+++ b/clone/internal/verify/verify_test.go
@@ -159,11 +159,11 @@ func TestPartialRoot(t *testing.T) {
 	}
 }
 
-func NewInMemoryDatabase() (*logdb.Database, func() error, error) {
+func NewInMemoryDatabase() (*logdb.Database, func(), error) {
 	sqlitedb, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to open temporary in-memory DB: %v", err)
 	}
 	db, err := logdb.NewDatabaseDirect(sqlitedb)
-	return db, sqlitedb.Close, err
+	return db, func() { _ = sqlitedb.Close }, err
 }

--- a/clone/logdb/database_test.go
+++ b/clone/logdb/database_test.go
@@ -283,13 +283,13 @@ func TestCheckpoints(t *testing.T) {
 	}
 }
 
-func NewInMemoryDatabase() (*Database, func() error, error) {
+func NewInMemoryDatabase() (*Database, func(), error) {
 	sqlitedb, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to open temporary in-memory DB: %v", err)
 	}
 	db, err := NewDatabaseDirect(sqlitedb)
-	return db, sqlitedb.Close, err
+	return db, func() { _ = sqlitedb.Close }, err
 }
 
 func mustHash(s string) []byte {

--- a/distributor/cmd/internal/distributor/distributor.go
+++ b/distributor/cmd/internal/distributor/distributor.go
@@ -91,7 +91,11 @@ func (d *Distributor) GetCheckpointN(ctx context.Context, logID string, n uint32
 	if err != nil {
 		return nil, fmt.Errorf("query failed: %v", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			glog.Errorf("rows.Close(): %v", err)
+		}
+	}()
 	var currentSize uint64
 	var witsAtSize []note.Verifier
 	var cpsAtSize [][]byte

--- a/distributor/cmd/internal/http/server.go
+++ b/distributor/cmd/internal/http/server.go
@@ -91,7 +91,9 @@ func (s *Server) getCheckpointN(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/plain")
-	w.Write(chkpt)
+	if _, err := w.Write(chkpt); err != nil {
+		glog.Errorf("w.Write(): %v", err)
+	}
 }
 
 // getCheckpointWitness returns the latest checkpoint stored for a given log by the given witness.
@@ -108,7 +110,9 @@ func (s *Server) getCheckpointWitness(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/plain")
-	w.Write(chkpt)
+	if _, err := w.Write(chkpt); err != nil {
+		glog.Errorf("w.Write(): %v", err)
+	}
 }
 
 // getLogs returns a list of all logs the witness is aware of.
@@ -124,7 +128,9 @@ func (s *Server) getLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/json")
-	w.Write(logList)
+	if _, err := w.Write(logList); err != nil {
+		glog.Errorf("w.Write(): %v", err)
+	}
 }
 
 // RegisterHandlers registers HTTP handlers for witness endpoints.

--- a/experimental/batchmap/ctmap/internal/pipeline/log.go
+++ b/experimental/batchmap/ctmap/internal/pipeline/log.go
@@ -65,7 +65,9 @@ func (fn *moduleLogHashFn) ProcessElement(log *DomainCertIndexLog) (*batchmap.En
 		bs := make([]byte, 8)
 		binary.LittleEndian.PutUint64(bs, v)
 		h := RecordHash(bs)
-		logRange.Append(h[:], nil)
+		if err := logRange.Append(h[:], nil); err != nil {
+			return nil, fmt.Errorf("logRange.Append(): %v", err)
+		}
 	}
 	logRoot, err := logRange.GetRootHash(nil)
 	if err != nil {

--- a/experimental/batchmap/sumdb/build/pipeline/log.go
+++ b/experimental/batchmap/sumdb/build/pipeline/log.go
@@ -77,7 +77,9 @@ func (fn *moduleLogHashFn) ProcessElement(log *ModuleVersionLog) (*batchmap.Entr
 	logRange := fn.rf.NewEmptyRange(0)
 	for _, v := range log.Versions {
 		h := tlog.RecordHash([]byte(v))
-		logRange.Append(h[:], nil)
+		if err := logRange.Append(h[:], nil); err != nil {
+			return nil, fmt.Errorf("logRange.Append(): %v", err)
+		}
 	}
 	logRoot, err := logRange.GetRootHash(nil)
 	if err != nil {

--- a/experimental/batchmap/sumdb/verify/verify.go
+++ b/experimental/batchmap/sumdb/verify/verify.go
@@ -68,7 +68,11 @@ func main() {
 	if err != nil {
 		glog.Exitf("failed to read file %q: %q", *sumFile, err)
 	}
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			glog.Errorf("file.Close(): %v", err)
+		}
+	}()
 	scanner := bufio.NewScanner(file)
 
 	var root []byte

--- a/experimental/batchmap/sumdb/versions/versions.go
+++ b/experimental/batchmap/sumdb/versions/versions.go
@@ -78,7 +78,9 @@ func main() {
 	logRange := rf.NewEmptyRange(0)
 	for _, v := range versions {
 		h := tlog.RecordHash([]byte(v))
-		logRange.Append(h[:], nil)
+		if err := logRange.Append(h[:], nil); err != nil {
+			glog.Exitf("logRange.Append(): %v", err)
+		}
 	}
 	logRoot, err := logRange.GetRootHash(nil)
 	if err != nil {

--- a/helloworld/helloworld_test.go
+++ b/helloworld/helloworld_test.go
@@ -89,7 +89,9 @@ func TestAppend(t *testing.T) {
 		chkptOld := mustOpenCheckpoint(t, chkptOldRaw)
 		// Add a random entry so we can be sure it's new.
 		entry := make([]byte, 10)
-		rand.Read(entry)
+		if _, err := rand.Read(entry); err != nil {
+			t.Error(err)
+		}
 		chkptNewRaw, err := personality.Append(ctx, entry)
 		if err != nil {
 			t.Fatalf(err.Error())
@@ -123,8 +125,12 @@ func TestUpdate(t *testing.T) {
 		}
 		client.chkpt = mustOpenCheckpoint(t, chkptRaw)
 		entry := make([]byte, 10)
-		rand.Read(entry)
-		personality.Append(ctx, entry)
+		if _, err := rand.Read(entry); err != nil {
+			t.Error(err)
+		}
+		if _, err := personality.Append(ctx, entry); err != nil {
+			t.Error(err)
+		}
 		chkptNewRaw, pf, err := personality.UpdateChkpt(ctx, client.chkpt.Size)
 		if err != nil {
 			t.Fatalf(err.Error())

--- a/serverless/api/state_test.go
+++ b/serverless/api/state_test.go
@@ -83,7 +83,9 @@ func TestMarshalTileRoundtrip(t *testing.T) {
 					tile.Nodes = append(tile.Nodes, emptyHashes(idx-l+1)...)
 				}
 				// Fill in the leaf index
-				rand.Read(tile.Nodes[idx])
+				if _, err := rand.Read(tile.Nodes[idx]); err != nil {
+					t.Error(err)
+				}
 			}
 
 			raw, err := tile.MarshalText()

--- a/serverless/cmd/client/client.go
+++ b/serverless/cmd/client/client.go
@@ -413,7 +413,11 @@ func readHTTP(ctx context.Context, u *url.URL) ([]byte, error) {
 	default:
 		return nil, fmt.Errorf("unexpected http status %q", resp.Status)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			glog.Errorf("resp.Body.Close(): %v", err)
+		}
+	}()
 	return io.ReadAll(resp.Body)
 }
 

--- a/serverless/integration/integration_test.go
+++ b/serverless/integration/integration_test.go
@@ -190,7 +190,7 @@ func TestServerlessViaHTTP(t *testing.T) {
 		}
 	}()
 	go func() {
-		if err := srv.Serve(listener); err != nil {
+		if err := srv.Serve(listener); err != http.ErrServerClosed {
 			t.Error(err)
 		}
 	}()

--- a/serverless/integration/integration_test.go
+++ b/serverless/integration/integration_test.go
@@ -184,9 +184,15 @@ func TestServerlessViaHTTP(t *testing.T) {
 	srv := http.Server{
 		Handler: http.FileServer(http.Dir(root)),
 	}
-	defer srv.Close()
+	defer func() {
+		if err := srv.Close(); err != nil {
+			t.Errorf("srv.Close(): %v", err)
+		}
+	}()
 	go func() {
-		srv.Serve(listener)
+		if err := srv.Serve(listener); err != nil {
+			t.Error(err)
+		}
 	}()
 
 	// Create fetcher
@@ -229,7 +235,11 @@ func httpFetcher(t *testing.T, u string) client.Fetcher {
 		if err != nil {
 			return nil, err
 		}
-		defer resp.Body.Close()
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				t.Errorf("resp.Body.Close(): %v", err)
+			}
+		}()
 		return io.ReadAll(resp.Body)
 	}
 }

--- a/serverless/pkg/log/integrate.go
+++ b/serverless/pkg/log/integrate.go
@@ -95,7 +95,9 @@ func Integrate(ctx context.Context, checkpoint log.Checkpoint, st Storage, h mer
 		func(seq uint64, entry []byte) error {
 			lh := h.HashLeaf(entry)
 			// Update range and set nodes
-			newRange.Append(lh, tc.Visit)
+			if err := newRange.Append(lh, tc.Visit); err != nil {
+				return fmt.Errorf("newRange.Append(): %v", err)
+			}
 			return nil
 		})
 	if err != nil {

--- a/sumdbaudit/audit/service.go
+++ b/sumdbaudit/audit/service.go
@@ -457,7 +457,9 @@ func (s *Service) checkCheckpoint(cp *client.Checkpoint, getStragglers func(stra
 			// Calculate this tile as a standalone subtree
 			tcr := s.rf.NewEmptyRange(0)
 			for _, t := range tHashes {
-				tcr.Append(t, nil)
+				if err := tcr.Append(t, nil); err != nil {
+					return fmt.Errorf("tcr.Append(): %v", err)
+				}
 			}
 			// Now use the range as what it really is; a commitment to a larger number of leaves
 			treeRange, err := s.rf.NewRange(uint64(offset)*tileLeafCount, uint64(offset+1)*tileLeafCount, tcr.Hashes())
@@ -465,7 +467,9 @@ func (s *Service) checkCheckpoint(cp *client.Checkpoint, getStragglers func(stra
 				return fmt.Errorf("failed to create range for tile L=%d, O=%d: %v", level, offset, err)
 			}
 			// Append this into the running log range.
-			logRange.AppendRange(treeRange, nil)
+			if err := logRange.AppendRange(treeRange, nil); err != nil {
+				return fmt.Errorf("logRange.AppendRange(): %v", err)
+			}
 		}
 	}
 
@@ -477,7 +481,9 @@ func (s *Service) checkCheckpoint(cp *client.Checkpoint, getStragglers func(stra
 			return fmt.Errorf("failed to get stragglers: %w", err)
 		}
 		for i := 0; i < stragglersCount; i++ {
-			logRange.Append(stragglers[i], nil)
+			if err := logRange.Append(stragglers[i], nil); err != nil {
+				return fmt.Errorf("logRange.Append(): %v", err)
+			}
 		}
 	}
 
@@ -508,7 +514,9 @@ func (s *Service) hashLeafLevel(tileCount int, roots chan<- *compact.Range) erro
 		}
 		cr := s.rf.NewEmptyRange(uint64(offset) * 1 << s.height)
 		for _, h := range hashes {
-			cr.Append(h, nil)
+			if err := cr.Append(h, nil); err != nil {
+				return fmt.Errorf("cr.Append(): %v", err)
+			}
 		}
 		if got, want := len(cr.Hashes()), 1; got != want {
 			return fmt.Errorf("expected single root hash but got %d", got)
@@ -567,7 +575,9 @@ func (s *Service) hashUpperLevel(level, tileCount int, in <-chan *compact.Range,
 		}
 		cr := s.rf.NewEmptyRange(uint64(offset * tileWidth))
 		for _, h := range inHashes {
-			cr.Append(h, nil)
+			if err := cr.Append(h, nil); err != nil {
+				return fmt.Errorf("cr.Append(): %v", err)
+			}
 		}
 		if got, want := len(cr.Hashes()), 1; got != want {
 			return fmt.Errorf("expected single root hash but got %d", got)

--- a/sumdbaudit/cli/witness/witness.go
+++ b/sumdbaudit/cli/witness/witness.go
@@ -53,7 +53,9 @@ func (s *server) getGolden(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
 	w.Header().Set("Content-Length", strconv.Itoa(len(golden.Raw)))
-	w.Write(golden.Raw)
+	if _, err := w.Write(golden.Raw); err != nil {
+		glog.Errorf("w.Write(): %v", err)
+	}
 }
 
 // checkConsistency validates whether the provided checkpoint is consistent

--- a/sumdbaudit/client/sumdb.go
+++ b/sumdbaudit/client/sumdb.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/golang/glog"
 	"golang.org/x/mod/sumdb/note"
 	"golang.org/x/mod/sumdb/tlog"
 )
@@ -180,7 +181,11 @@ func (f *HTTPFetcher) GetData(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			glog.Errorf("resp.Body.Close(): %v", err)
+		}
+	}()
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("GET %v: %v", target, resp.Status)
 	}


### PR DESCRIPTION
Previously only named linters were ran, but the benefits of doing this are lost in time. Some of the linters that are excluded from this technique provide good value (such as checking that errors are inspected).
