### PR TITLE
Bump tamago version in integration test

### DIFF
--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir protoc && \
 # Tamago bits
 RUN apt-get -y install binutils-arm-none-eabi build-essential make u-boot-tools && \
     apt-get -y install -t buster-backports fuse fuse2fs
-RUN curl -sfL https://github.com/usbarmory/tamago-go/releases/download/tamago-go1.17.8/tamago-go1.17.8.linux-amd64.tar.gz | tar -xzf - -C /
+RUN curl -sfL https://github.com/usbarmory/tamago-go/releases/download/tamago-go1.19.5/tamago-go1.19.5.linux-amd64.tar.gz | tar -xzf - -C /
 ENV TAMAGO=/usr/local/tamago-go/bin/go
 
 ENV GOPATH /go


### PR DESCRIPTION
This is required for newer versions of glog which rely on new Go language features.