### PR TITLE
Use SQL syntax that works in MariaDB

### DIFF
--- a/distributor/cmd/internal/distributor/distributor.go
+++ b/distributor/cmd/internal/distributor/distributor.go
@@ -158,21 +158,18 @@ func (d *Distributor) Distribute(ctx context.Context, logID, witID string, nextR
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %v", err)
 	}
-	saveCheckpointFn := func() error {
-		_, err := tx.ExecContext(ctx, `INSERT OR REPLACE INTO chkpts (logID, witID, treeSize, chkpt) VALUES (?, ?, ?, ?)`, logID, witID, newCP.Size, nextRaw)
-		if err != nil {
-			return fmt.Errorf("Exec(): %v", err)
-		}
-		if err := tx.Commit(); err != nil {
-			return err
-		}
-		return nil
-	}
 	oldBs, err := getLatestCheckpoint(ctx, tx, logID, witID)
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
 			// If this is the first checkpoint for this witness then just save and exit
-			return saveCheckpointFn()
+			_, err := tx.ExecContext(ctx, `INSERT INTO chkpts (logID, witID, treeSize, chkpt) VALUES (?, ?, ?, ?)`, logID, witID, newCP.Size, nextRaw)
+			if err != nil {
+				return fmt.Errorf("Exec(): %v", err)
+			}
+			if err := tx.Commit(); err != nil {
+				return err
+			}
+			return nil
 		}
 		return err
 	}
@@ -196,7 +193,14 @@ func (d *Distributor) Distribute(ctx context.Context, logID, witID string, nextR
 		// Nothing to do; checkpoint is equivalent to the old one so avoid DB writes.
 		return nil
 	}
-	return saveCheckpointFn()
+	_, err = tx.ExecContext(ctx, `REPLACE INTO chkpts (logID, witID, treeSize, chkpt) VALUES (?, ?, ?, ?)`, logID, witID, newCP.Size, nextRaw)
+	if err != nil {
+		return fmt.Errorf("Exec(): %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // init ensures that the database is in good order. This must be called before

--- a/distributor/cmd/internal/distributor/distributor.go
+++ b/distributor/cmd/internal/distributor/distributor.go
@@ -208,8 +208,8 @@ func (d *Distributor) Distribute(ctx context.Context, logID, witID string, nextR
 // the application as it is idempotent.
 func (d *Distributor) init() error {
 	if _, err := d.db.Exec(`CREATE TABLE IF NOT EXISTS chkpts (
-		logID BLOB,
-		witID BLOB,
+		logID VARCHAR(200),
+		witID VARCHAR(200),
 		treeSize INTEGER,
 		chkpt BLOB,
 		PRIMARY KEY (logID, witID)

--- a/distributor/cmd/internal/distributor/distributor_test.go
+++ b/distributor/cmd/internal/distributor/distributor_test.go
@@ -22,11 +22,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian-examples/distributor/cmd/internal/distributor"
-	_ "github.com/mattn/go-sqlite3" // Load drivers for sqlite3
 	"github.com/transparency-dev/formats/log"
 	"golang.org/x/mod/sumdb/note"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	_ "github.com/mattn/go-sqlite3" // Load drivers for sqlite3
 )
 
 var (


### PR DESCRIPTION
`INSERT OR REPLACE INTO` doesn't work in MariaDB. Fortunately, we already knew in the code where this was a first-time insert or an update, so the SQL has been simplified to something that works with both MariaDB and sqlite.