### PR TITLE
Fix for Dockerfile smell DL3006

### DIFF
--- a/feeder/cmd/pixel_bt_feeder/Dockerfile
+++ b/feeder/cmd/pixel_bt_feeder/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN go build -o /build/bin/pixel_bt_feeder ./feeder/cmd/pixel_bt_feeder
 
 # Build release image
-FROM alpine
+FROM alpine:3.17.3
 
 COPY --from=builder /build/bin/pixel_bt_feeder /bin/pixel_bt_feeder
 ENTRYPOINT ["/bin/pixel_bt_feeder"]


### PR DESCRIPTION
Hi!
The Dockerfile placed at "feeder/cmd/pixel_bt_feeder/Dockerfile" contains the best practice violation [DL3006](https://github.com/hadolint/hadolint/wiki/DL3006) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3006 occurs when the image tag for the base image is missing.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for the given base image. In detail, it selects the most recent image tag which corresponds to the same image digest that currently corresponds to the "latest" tag, used by default when pulling the image from DockerHub if a specific image tag is missing.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance