### PR TITLE
Explicit version tags for docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+- package-ecosystem: "docker"
+  directory: "/"
+  schedule:
+    interval: "weekly"

--- a/binary_transparency/firmware/cmd/ft_personality/Dockerfile
+++ b/binary_transparency/firmware/cmd/ft_personality/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:buster AS builder
+FROM golang:1.20.3-buster AS builder
 LABEL stage=builder
 
 ARG GOFLAGS=""
@@ -20,7 +20,7 @@ COPY . .
 RUN go build ./binary_transparency/firmware/cmd/ft_personality
 
 # Build release image
-FROM golang:buster
+FROM golang:1.20.3-buster
 
 COPY --from=builder /build/ft_personality /bin/ft_personality
 ENTRYPOINT ["/bin/ft_personality"]

--- a/binary_transparency/firmware/cmd/ftmapserver/Dockerfile
+++ b/binary_transparency/firmware/cmd/ftmapserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:buster AS builder
+FROM golang:1.20.3-buster AS builder
 LABEL stage=builder
 
 ARG GOFLAGS=""
@@ -20,7 +20,7 @@ COPY . .
 RUN go build ./binary_transparency/firmware/cmd/ftmapserver
 
 # Build release image
-FROM golang:buster
+FROM golang:1.20.3-buster
 
 COPY --from=builder /build/ftmapserver /bin/ftmapserver
 ENTRYPOINT ["/bin/ftmapserver"]

--- a/clone/cmd/ctclone/Dockerfile
+++ b/clone/cmd/ctclone/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN go build ./clone/cmd/ctclone
 
 # Build release image
-FROM alpine
+FROM alpine:3.17.3
 
 COPY --from=builder /build/ctclone /bin/ctclone
 ENTRYPOINT ["/bin/ctclone"]

--- a/clone/cmd/ctclone/Dockerfile
+++ b/clone/cmd/ctclone/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM golang:1.19-alpine3.17 AS builder
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS

--- a/clone/cmd/ctverify/Dockerfile
+++ b/clone/cmd/ctverify/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN go build ./clone/cmd/ctverify
 
 # Build release image
-FROM alpine
+FROM alpine:3.17.3
 
 COPY --from=builder /build/ctverify /bin/ctverify
 ENTRYPOINT ["/bin/ctverify"]

--- a/clone/cmd/ctverify/Dockerfile
+++ b/clone/cmd/ctverify/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM golang:1.19-alpine3.17 AS builder
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS

--- a/clone/cmd/sumdbclone/Dockerfile
+++ b/clone/cmd/sumdbclone/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN go build ./clone/cmd/sumdbclone
 
 # Build release image
-FROM alpine
+FROM alpine:3.17.3
 
 COPY --from=builder /build/sumdbclone /bin/sumdbclone
 ENTRYPOINT ["/bin/sumdbclone"]

--- a/clone/cmd/sumdbclone/Dockerfile
+++ b/clone/cmd/sumdbclone/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM golang:1.19-alpine3.17 AS builder
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS

--- a/feeder/cmd/pixel_bt_feeder/Dockerfile
+++ b/feeder/cmd/pixel_bt_feeder/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN go build -o /build/bin/pixel_bt_feeder ./feeder/cmd/pixel_bt_feeder
 
 # Build release image
-FROM alpine
+FROM alpine:3.17.3
 
 COPY --from=builder /build/bin/pixel_bt_feeder /bin/pixel_bt_feeder
 ENTRYPOINT ["/bin/pixel_bt_feeder"]

--- a/feeder/cmd/pixel_bt_feeder/Dockerfile
+++ b/feeder/cmd/pixel_bt_feeder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM golang:1.19-alpine3.17 AS builder
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS

--- a/feeder/cmd/rekor_feeder/Dockerfile
+++ b/feeder/cmd/rekor_feeder/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN go build -o /build/bin/rekor_feeder ./feeder/cmd/rekor_feeder
 
 # Build release image
-FROM alpine
+FROM alpine:3.17.3
 
 COPY --from=builder /build/bin/rekor_feeder /bin/rekor_feeder
 ENTRYPOINT ["/bin/rekor_feeder"]

--- a/feeder/cmd/rekor_feeder/Dockerfile
+++ b/feeder/cmd/rekor_feeder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM golang:1.19-alpine3.17 AS builder
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS

--- a/feeder/cmd/sumdb_feeder/Dockerfile
+++ b/feeder/cmd/sumdb_feeder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM golang:1.19-alpine3.17 AS builder
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS

--- a/feeder/cmd/sumdb_feeder/Dockerfile
+++ b/feeder/cmd/sumdb_feeder/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN go build -o /build/bin/feeder ./feeder/cmd/sumdb_feeder
 
 # Build release image
-FROM alpine
+FROM alpine:3.17.3
 
 COPY --from=builder /build/bin/feeder /bin/feeder
 ENTRYPOINT ["/bin/feeder"]

--- a/serverless/cmd/distribute/github/Dockerfile
+++ b/serverless/cmd/distribute/github/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM golang:1.19-alpine3.17 AS builder
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS

--- a/serverless/cmd/distribute/github/Dockerfile
+++ b/serverless/cmd/distribute/github/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN go build -o /build/bin/distribute ./serverless/cmd/distribute/github
 
 # Build release image
-FROM alpine
+FROM alpine:3.17.3
 
 COPY --from=builder /build/bin/distribute /bin/distribute
 ENTRYPOINT ["/bin/distribute"]

--- a/serverless/cmd/feeder/Dockerfile
+++ b/serverless/cmd/feeder/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN go build -o /build/bin/feeder ./serverless/cmd/feeder/
 
 # Build release image
-FROM alpine
+FROM alpine:3.17.3
 
 COPY --from=builder /build/bin/feeder /bin/feeder
 

--- a/serverless/cmd/feeder/Dockerfile
+++ b/serverless/cmd/feeder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM golang:1.19-alpine3.17 AS builder
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS

--- a/serverless/deploy/github/distributor/combine_witness_signatures/Dockerfile
+++ b/serverless/deploy/github/distributor/combine_witness_signatures/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /src/
 COPY . ./
 RUN CGO_ENABLED=0 go build -o /bin/combine_witness_signatures .
 
-FROM alpine
+FROM alpine:3.17.3
 
 RUN apk add --no-cache bash git
 

--- a/serverless/deploy/github/distributor/combine_witness_signatures/Dockerfile
+++ b/serverless/deploy/github/distributor/combine_witness_signatures/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS build
+FROM golang:1.19-alpine3.17 AS build
 
 WORKDIR /src/
 COPY . ./

--- a/serverless/deploy/github/distributor/update_logs_index/Dockerfile
+++ b/serverless/deploy/github/distributor/update_logs_index/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /src/
 COPY . ./
 RUN CGO_ENABLED=0 go build -o /bin/update_logs_index .
 
-FROM alpine
+FROM alpine:3.17.3
 
 RUN apk add --no-cache bash git
 

--- a/serverless/deploy/github/distributor/update_logs_index/Dockerfile
+++ b/serverless/deploy/github/distributor/update_logs_index/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS build
+FROM golang:1.19-alpine3.17 AS build
 
 WORKDIR /src/
 COPY . ./

--- a/serverless/deploy/github/log/leaf_validator/Dockerfile
+++ b/serverless/deploy/github/log/leaf_validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.17.3
 
 RUN apk add --no-cache bash curl git jq
 

--- a/serverless/deploy/github/log/sequence_and_integrate/Dockerfile
+++ b/serverless/deploy/github/log/sequence_and_integrate/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /src/
 RUN CGO_ENABLED=0 go install github.com/google/trillian-examples/serverless/cmd/integrate@HEAD
 RUN CGO_ENABLED=0 go install github.com/google/trillian-examples/serverless/cmd/sequence@HEAD
 
-FROM alpine
+FROM alpine:3.17.3
 
 RUN apk add --no-cache bash git
 

--- a/serverless/deploy/github/log/sequence_and_integrate/Dockerfile
+++ b/serverless/deploy/github/log/sequence_and_integrate/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS build
+FROM golang:1.19-alpine3.17 AS build
 
 WORKDIR /src/
 # Note: this could be a bit surprising as folks who pinned their action to some particular version

--- a/sumdbaudit/docker/mirror/Dockerfile
+++ b/sumdbaudit/docker/mirror/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:buster AS builder
+FROM golang:1.20.3-buster AS builder
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
@@ -19,7 +19,7 @@ COPY . .
 RUN go build ./sumdbaudit/cli/mirror
 
 # Build release image
-FROM golang:buster
+FROM golang:1.20.3-buster
 
 COPY --from=builder /build/mirror /bin/mirror
 ENTRYPOINT ["/bin/mirror"]

--- a/sumdbaudit/docker/witness/Dockerfile
+++ b/sumdbaudit/docker/witness/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:buster AS builder
+FROM golang:1.20.3-buster AS builder
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
@@ -19,7 +19,7 @@ COPY . .
 RUN go build -o sumdbwitness ./sumdbaudit/cli/witness
 
 # Build release image
-FROM golang:buster
+FROM golang:1.20.3-buster
 
 COPY --from=builder /build/sumdbwitness /bin/witness
 ENTRYPOINT ["/bin/witness"]

--- a/witness/golang/cmd/omniwitness/Dockerfile
+++ b/witness/golang/cmd/omniwitness/Dockerfile
@@ -20,7 +20,7 @@ COPY . .
 RUN go build -o omniwitness ./witness/golang/cmd/omniwitness
 
 # Build release image
-FROM alpine
+FROM alpine:3.17.3
 
 COPY --from=builder /build/omniwitness /bin/omniwitness
 ENTRYPOINT ["/bin/omniwitness"]

--- a/witness/golang/cmd/omniwitness/Dockerfile
+++ b/witness/golang/cmd/omniwitness/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM golang:1.19-alpine3.17 AS builder
 RUN apk add --no-cache gcc musl-dev
 
 ARG GOFLAGS=""

--- a/witness/golang/cmd/witness/Dockerfile
+++ b/witness/golang/cmd/witness/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN go build -o /build/bin/witness ./witness/golang/cmd/witness
 
 # Build release image
-FROM alpine
+FROM alpine:3.17.3
 
 COPY --from=builder /build/bin/witness /bin/witness
 ENTRYPOINT ["/bin/witness"]

--- a/witness/golang/cmd/witness/Dockerfile
+++ b/witness/golang/cmd/witness/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM golang:1.19-alpine3.17 AS builder
 RUN apk add --no-cache gcc musl-dev
 
 ARG GOFLAGS=""


### PR DESCRIPTION
This is motivated by #788. Using explict tags that are updated by dependabot seems like the pragmatic solution to this problem.

- Explicit alpine image usage
- Update golang:buster images to latest explicit version
- Update golang:1.19-alpine images to latest explicit version
