### PR TITLE
Distributor explicitly handles zero and large numbers

### DIFF
--- a/distributor/cmd/internal/distributor/distributor.go
+++ b/distributor/cmd/internal/distributor/distributor.go
@@ -32,6 +32,9 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// maxSigs is the maximum number of sigs that can be requested.
+const maxSigs = 100
+
 // LogInfo contains the information that the distributor needs to know about
 // a log, other than its ID.
 type LogInfo struct {
@@ -73,6 +76,9 @@ func (d *Distributor) GetLogs(ctx context.Context) ([]string, error) {
 
 // GetCheckpointN gets the largest checkpoint for a given log that has at least `n` signatures.
 func (d *Distributor) GetCheckpointN(ctx context.Context, logID string, n uint32) ([]byte, error) {
+	if n == 0 || n > maxSigs {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid N %d", n)
+	}
 	l, ok := d.ls[logID]
 	if !ok {
 		return nil, status.Errorf(codes.InvalidArgument, "unknown log ID %q", logID)

--- a/distributor/cmd/internal/distributor/distributor_test.go
+++ b/distributor/cmd/internal/distributor/distributor_test.go
@@ -587,6 +587,26 @@ func TestGetCheckpointN(t *testing.T) {
 			wantErr:     true,
 			wantErrCode: codes.NotFound,
 		},
+		{
+			desc:        "zero invalid",
+			distWit:     witWattle,
+			distLog:     logFoo,
+			distSize:    16,
+			reqLog:      "FooLog",
+			reqN:        0,
+			wantErr:     true,
+			wantErrCode: codes.InvalidArgument,
+		},
+		{
+			desc:        "huge number invalid",
+			distWit:     witWattle,
+			distLog:     logFoo,
+			distSize:    16,
+			reqLog:      "FooLog",
+			reqN:        999,
+			wantErr:     true,
+			wantErrCode: codes.InvalidArgument,
+		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {


### PR DESCRIPTION
The exact threshold of the max N should probably be configurable eventually, but having some max is better than nothing to prevent easy queries of death.
