### PR TITLE
docs: fix docker-compose container name mismatch

### DIFF
--- a/helloworld/README.md
+++ b/helloworld/README.md
@@ -36,7 +36,7 @@ export TREE_ID=$(go run github.com/google/trillian/cmd/createtree --admin_server
 ```bash
 docker compose up -d
 # Wait a second for MySQL to start up between these commands
-curl https://raw.githubusercontent.com/google/trillian/master/storage/mysql/schema/storage.sql | docker exec -i helloworld_db_1 mysql -pzaphod -Dtest
+curl https://raw.githubusercontent.com/google/trillian/master/storage/mysql/schema/storage.sql | docker exec -i helloworld-db-1 mysql -pzaphod -Dtest
 ```
 
 # Running the tests


### PR DESCRIPTION
The docker-compose file uses "-" in the container name, adjusting the docs to make it easier for a anyone to run the tool.

Thans guys, 
You are amazing <3