### PR TITLE
Allow witnesses to be configured at runtime

### DIFF
--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"database/sql"
 	"flag"
-	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/distributor/cmd/internal/distributor"
@@ -54,7 +54,7 @@ func main() {
 	flag.Parse()
 	ctx := context.Background()
 
-	configWitnesses, err := ioutil.ReadFile(*witnessConfigFile)
+	configWitnesses, err := os.ReadFile(*witnessConfigFile)
 	if err != nil {
 		glog.Exitf("Failed to read witness_config_file (%q): %v", *witnessConfigFile, err)
 	}

--- a/distributor/cmd/main.go
+++ b/distributor/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"database/sql"
 	"flag"
+	"io/ioutil"
 	"net"
 	"net/http"
 
@@ -42,19 +43,21 @@ var (
 	addr     = flag.String("listen", ":8080", "Address to listen on")
 	mysqlURI = flag.String("mysql_uri", "", "URI for MySQL DB")
 
+	witnessConfigFile = flag.String("witness_config_file", "", "Path to a file containing the public keys of allowed witnesses")
+
 	// configLogs is the config for the logs this distributor will accept.
 	//go:embed logs.yaml
 	configLogs []byte
-
-	// configWitnesses is the config for the witnesses this distributor will accept.
-	//go:embed witnesses.yaml
-	configWitnesses []byte
 )
 
 func main() {
 	flag.Parse()
 	ctx := context.Background()
 
+	configWitnesses, err := ioutil.ReadFile(*witnessConfigFile)
+	if err != nil {
+		glog.Exitf("Failed to read witness_config_file (%q): %v", *witnessConfigFile, err)
+	}
 	// This error group will be used to run all top level processes.
 	// If any process dies, then all of them will be stopped via context cancellation.
 	g, ctx := errgroup.WithContext(ctx)

--- a/distributor/docker-compose.yaml
+++ b/distributor/docker-compose.yaml
@@ -25,11 +25,14 @@ services:
       "--alsologtostderr",
       "--v=2",
       "--mysql_uri=distributor:letmein@tcp(db:3306)/distributor",
-      "--listen=:8080"
+      "--witness_config_file=/var/config/witnesses.yaml",
+      "--listen=:8081"
     ]
     ports:
-     - "8080:8080"
+     - "8081:8081"
     restart: always
     depends_on:
       db:
         condition: service_healthy
+    volumes:
+      - ./cmd/witnesses.yaml:/var/config/witnesses.yaml


### PR DESCRIPTION
The witnesses that a distributor accepts should not be statically compiled into the code as we don't have a strong opinion on this set. The logs could also be made configurable at runtime in the future, but for now keeping these the same as the omniwitness makes configuration simpler and doesn't alienate any users.

Also updated ports to avoid collisions with witness.
