### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/serverless/deploy/github/distributor/README.md
+++ b/serverless/deploy/github/distributor/README.md
@@ -256,7 +256,7 @@ jobs:
         id: pr_metadata
         run: |
           unzip pr_metadata.zip
-          echo "::set-output name=pr::$(cat NR)"
+          echo "pr=$(cat NR)" >> $GITHUB_OUTPUT
 
       - name: automerge
         uses: "pascalgn/automerge-action@v0.15.5"


### PR DESCRIPTION
### Description

Closes #838 

Update `serverless/deploy/github/distributor/README.md` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the example config that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' -o -name '*.md' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=pr::$(cat NR)"
```

**TO-BE**

```yaml
echo "pr=$(cat NR)" >> $GITHUB_OUTPUT
```