### PR TITLE
Improve the StreamLeaves API and implementation

### DIFF
--- a/clone/internal/verify/verify.go
+++ b/clone/internal/verify/verify.go
@@ -65,7 +65,7 @@ func (v LogVerifier) MerkleRoot(ctx context.Context, size uint64) ([]byte, [][]b
 	leaves := make(chan []byte, 1)
 	errc := make(chan error)
 	glog.V(1).Infof("Streaming leaves [%d, %d)", from, size)
-	go v.db.StreamLeaves(from, size, leaves, errc)
+	go v.db.StreamLeaves(ctx, from, size, leaves, errc)
 
 	index := from
 	for leaf := range leaves {

--- a/clone/internal/verify/verify.go
+++ b/clone/internal/verify/verify.go
@@ -62,19 +62,16 @@ func (v LogVerifier) MerkleRoot(ctx context.Context, size uint64) ([]byte, [][]b
 		}
 	}
 
-	leaves := make(chan []byte, 1)
-	errc := make(chan error)
+	results := make(chan logdb.StreamResult, 1)
 	glog.V(1).Infof("Streaming leaves [%d, %d)", from, size)
-	go v.db.StreamLeaves(ctx, from, size, leaves, errc)
+	go v.db.StreamLeaves(ctx, from, size, results)
 
 	index := from
-	for leaf := range leaves {
-		select {
-		case err := <-errc:
-			return nil, nil, fmt.Errorf("failed to get leaves from DB: %w", err)
-		default:
+	for result := range results {
+		if result.Err != nil {
+			return nil, nil, fmt.Errorf("failed to get leaves from DB: %w", result.Err)
 		}
-		if err := cr.Append(v.lh(index, leaf), nil); err != nil {
+		if err := cr.Append(v.lh(index, result.Leaf), nil); err != nil {
 			glog.Errorf("cr.Append(): %v", err)
 		}
 		index++

--- a/clone/logdb/database.go
+++ b/clone/logdb/database.go
@@ -140,9 +140,9 @@ func (d *Database) WriteLeaves(ctx context.Context, start uint64, leaves [][]byt
 
 // StreamLeaves streams leaves in order starting at the given index, putting the leaf preimage
 // values on the `out` channel.
-func (d *Database) StreamLeaves(start, end uint64, out chan []byte, errc chan error) {
+func (d *Database) StreamLeaves(ctx context.Context, start, end uint64, out chan []byte, errc chan error) {
 	defer close(out)
-	rows, err := d.db.Query("SELECT data FROM leaves WHERE id>=? AND id < ? ORDER BY id", start, end)
+	rows, err := d.db.QueryContext(ctx, "SELECT data FROM leaves WHERE id>=? AND id < ? ORDER BY id", start, end)
 	if err != nil {
 		errc <- err
 		return

--- a/clone/logdb/database_test.go
+++ b/clone/logdb/database_test.go
@@ -117,19 +117,16 @@ func TestRoundTrip(t *testing.T) {
 				t.Fatal("failed to write leaves", err)
 			}
 
-			lc := make(chan []byte, 1)
-			errc := make(chan error)
-			go db.StreamLeaves(context.Background(), test.start, test.end, lc, errc)
+			results := make(chan StreamResult, 1)
+			go db.StreamLeaves(context.Background(), test.start, test.end, results)
 
 			got := make([][]byte, 0)
 		Receive:
-			for l := range lc {
-				select {
-				case err = <-errc:
+			for result := range results {
+				if result.Err != nil {
 					break Receive
-				default:
 				}
-				got = append(got, l)
+				got = append(got, result.Leaf)
 			}
 
 			if err != nil {

--- a/clone/logdb/database_test.go
+++ b/clone/logdb/database_test.go
@@ -119,7 +119,7 @@ func TestRoundTrip(t *testing.T) {
 
 			lc := make(chan []byte, 1)
 			errc := make(chan error)
-			go db.StreamLeaves(test.start, test.end, lc, errc)
+			go db.StreamLeaves(context.Background(), test.start, test.end, lc, errc)
 
 			got := make([][]byte, 0)
 		Receive:


### PR DESCRIPTION
This is a long-running operation and now respects context cancellation.

Also changed the two returns channels to combine them into a single channel. This is far easier to understand and implement bug-free code with. Previously the err channel wasn't closed, which wasn't clean. Now everything is closed when StreamLeaves returns.