### PR TITLE
Added tool for creating tile-based logs from cloned log

### DIFF
--- a/clone/logdb/database.go
+++ b/clone/logdb/database.go
@@ -161,6 +161,9 @@ func (d *Database) StreamLeaves(ctx context.Context, start, end uint64, out chan
 		}
 		out <- StreamResult{Leaf: data}
 	}
+	if err := rows.Err(); err != nil {
+		out <- StreamResult{Err: err}
+	}
 }
 
 // Head returns the largest leaf index written.

--- a/serverless/cmd/clone2serverless/README.md
+++ b/serverless/cmd/clone2serverless/README.md
@@ -1,0 +1,67 @@
+# clone2serverless
+
+This tool create a [tile-based log](https://research.swtch.com/tlog#tiling_a_log) on the local filesystem.
+The log data is read from a MySQL database that has been populated using one of the [clone tools](../../../clone/cmd/).
+
+## Setup
+
+It is strongly recommended to create a virtual filesystem for any sizeable log.
+The tile-based log will create `O(N)` files & directories, which can quickly exhaust the inodes for an `ext4` filesystem provisioned for "normal" desktop/server usage.
+
+The instructions below demonstrate one way to create a [btrfs](https://btrfs.readthedocs.io/en/latest/) filesystem in a file.
+Creating the filesystem in a file is a convenient way to experiment with a new filesystem:
+ - set up without formatting or partitioning existing disks
+ - minimize the risk of inode exhaustion on the parent filesystem
+ - tear down by deleting the file
+
+```shell
+export LOGID=sumdb
+# Create a 32 GB file to hold the filesystem
+sudo truncate -s32G /media/${LOGID}.btrfs.img
+# Provision a btrfs filesystem inside the new file
+sudo mkfs.btrfs /media/${LOGID}.btrfs.img
+# Create a mount point to attach the new filesystem
+sudo mkdir /mnt/${LOGID}_tlog
+# Mount the filesystem using a loopback interface
+sudo mount -t auto -o loop /media/${LOGID}.btrfs.img /mnt/${LOGID}_tlog
+# Make the mount point owned by the normal user
+sudo chown $USER /mnt/${LOGID}_tlog
+```
+
+See [Tear Down](#tear-down) for instructions to free up space afterwards.
+
+## Running
+
+The following command will create a tlog from the [sumdb](../../../clone/cmd/sumdbclone/) cloned database into a directory called `fs` within a btrfs filesystem mounted at `/mnt/sumdb_tlog`:
+
+```shell
+go run ./serverless/cmd/clone2serverless \
+  --mysql_uri='sumdb:letmein@tcp(localhost:3366)/sumdb' \
+  --output_root=/mnt/sumdb_tlog/fs \
+  --log_vkey=sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8 \
+  --log_origin="go.sum database tree" \
+  --alsologtostderr --v=1
+```
+
+## Verifying
+
+As a quick check to make sure that the tlog was generated successfully, we can use the serverless client tool to check an inclusion proof:
+
+```shell
+echo sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8 > /tmp/sumdbvkey
+go run ./serverless/cmd/client \
+  --log_public_key=/tmp/sumdbvkey \
+  --origin="go.sum database tree" \
+  --log_url=file:////mnt/sumdb_tlog/fs/ \
+  inclusion /mnt/sumdb_tlog/fs/seq/00/00/c9/5d/12 0xc95d12
+```
+
+## Tear Down
+
+To delete the tlog and free up the resources on disk:
+
+```shell
+export LOGID=sumdb
+sudo umount /mnt/${LOGID}_tlog
+sudo rm /media/${LOGID}.btrfs.img
+```

--- a/serverless/cmd/clone2serverless/README.md
+++ b/serverless/cmd/clone2serverless/README.md
@@ -3,6 +3,13 @@
 This tool create a [tile-based log](https://research.swtch.com/tlog#tiling_a_log) on the local filesystem.
 The log data is read from a MySQL database that has been populated using one of the [clone tools](../../../clone/cmd/).
 
+`clone2serverless` will not output the hash-to-index mapping in the `leaves` directory, which is a notable difference from the tlog generated using the [sequence](../sequence/) and [integrate](../integrate/).
+This choice was made with the following considerations in mind:
+
+* to reduce the impact on the filesystem for large logs (enabling this feature creates 3x the number of files/directories)
+* deduplication needs to be disabled for cloned/mirrored logs (if the input log has duplicates, they need to be present in the mirror)
+* the mapping from hash-to-index is an ancillary feature of logs that is not verifiable (logs can claim that a hash is not present in the log when it is, and this can't be _efficiently_ disproved)
+
 ## Setup
 
 It is strongly recommended to create a virtual filesystem for any sizeable log.
@@ -42,6 +49,9 @@ go run ./serverless/cmd/clone2serverless \
   --log_origin="go.sum database tree" \
   --alsologtostderr --v=1
 ```
+
+This may take a while to complete.
+Once it is complete you can inspect the new filesystem at `/mnt/sumdb_tlog/fs`.
 
 ## Verifying
 

--- a/serverless/cmd/clone2serverless/main.go
+++ b/serverless/cmd/clone2serverless/main.go
@@ -118,9 +118,13 @@ func main() {
 	rCtxCancel()
 
 	glog.V(1).Infof("Integrating leaves [%d, %d)", fromSize, toSize)
-	log.Integrate(ctx, fromSize, logRoot, rfc6962.DefaultHasher)
+	if _, err := log.Integrate(ctx, fromSize, logRoot, rfc6962.DefaultHasher); err != nil {
+		glog.Exitf("Failed to integrate leaves: %v", err)
+	}
 	glog.V(1).Info("Writing checkpoint")
-	logRoot.WriteCheckpoint(ctx, inputCheckpointRaw)
+	if err := logRoot.WriteCheckpoint(ctx, inputCheckpointRaw); err != nil {
+		glog.Exitf("Failed to write checkpoint: %v", err)
+	}
 	glog.V(1).Infof("Successfully created tlog with %d leaves at %q", toSize, *outputRoot)
 }
 

--- a/serverless/cmd/clone2serverless/main.go
+++ b/serverless/cmd/clone2serverless/main.go
@@ -140,6 +140,8 @@ func initStorage(logVerifier note.Verifier, outputRoot string) (*fs.Storage, uin
 			return nil, 0, fmt.Errorf("failed to create log root filesystem: %v", err)
 		}
 		glog.Infof("Created new log root filesystem at %q", outputRoot)
+	} else if err != nil {
+		return nil, 0, fmt.Errorf("failed to stat %q: %v", outputRoot, err)
 	} else if !fstat.IsDir() {
 		return nil, 0, fmt.Errorf("output root is not a directory: %v", outputRoot)
 	} else {

--- a/serverless/cmd/clone2serverless/main.go
+++ b/serverless/cmd/clone2serverless/main.go
@@ -1,0 +1,205 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// clone2serverless is a one-shot tool that creates a tile-based (serverless)
+// log on disk from the contents of a cloned DB.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/clone/logdb"
+	"github.com/google/trillian-examples/serverless/internal/storage/fs"
+	"github.com/google/trillian-examples/serverless/pkg/log"
+	fmtlog "github.com/transparency-dev/formats/log"
+	"github.com/transparency-dev/merkle/rfc6962"
+	"golang.org/x/mod/sumdb/note"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+var (
+	mysqlURI   = flag.String("mysql_uri", "", "URL of a MySQL database to clone the log into. The DB should contain only one log.")
+	outputRoot = flag.String("output_root", "", "File path to the directory that the tile-based log will be created in. If this directory exists then it must contain a valid tile-based log. If it doesn't exist it will be created.")
+	vkey       = flag.String("log_vkey", "", "Verifier key for the log checkpoint signature.")
+	origin     = flag.String("log_origin", "", "Expected Origin for the log checkpoints.")
+)
+
+func main() {
+	flag.Parse()
+
+	if len(*mysqlURI) == 0 {
+		glog.Exit("Missing required parameter 'mysql_uri'")
+	}
+	if len(*origin) == 0 {
+		glog.Exit("Missing required parameter 'log_origin'")
+	}
+	if len(*vkey) == 0 {
+		glog.Exit("Missing required parameter 'log_vkey'")
+	}
+	if len(*outputRoot) == 0 {
+		glog.Exit("Missing required parameter 'output_root'")
+	}
+
+	db, err := logdb.NewDatabase(*mysqlURI)
+	if err != nil {
+		glog.Exitf("Failed to connect to database: %v", err)
+	}
+	logVerifier, err := note.NewVerifier(*vkey)
+	if err != nil {
+		glog.Exitf("Failed to instantiate Verifier: %q", err)
+	}
+
+	ctx := context.Background()
+	toSize, inputCheckpointRaw, _, err := db.GetLatestCheckpoint(ctx)
+	if err != nil {
+		glog.Exitf("Failed to get latest checkpoint from clone DB: %v", err)
+	}
+	logRoot, fromSize, err := initStorage(logVerifier, *outputRoot)
+	if err != nil {
+		glog.Exitf("Could not initialize tile-based storage: %v", err)
+	}
+
+	// Set up a background thread to report progress (as it can take a long time).
+	rCtx, rCtxCancel := context.WithCancel(ctx)
+	defer rCtxCancel()
+	r := reporter{
+		lastReported: fromSize,
+		lastReport:   time.Now(),
+		treeSize:     toSize,
+	}
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				r.report()
+			case <-rCtx.Done():
+				return
+			}
+		}
+	}()
+
+	results := make(chan logdb.StreamResult, 16)
+	glog.V(1).Infof("Sequencing leaves [%d, %d)", fromSize, toSize)
+	go db.StreamLeaves(ctx, fromSize, toSize, results)
+
+	index := fromSize
+	for result := range results {
+		if result.Err != nil {
+			glog.Exitf("Failed fetching leaves from DB: %v", result.Err)
+		}
+		workDone := r.trackWork(index)
+		err := logRoot.Assign(ctx, index, result.Leaf)
+		if err != nil {
+			glog.Exitf("Failed to sequence leaves: %v", err)
+		}
+		workDone()
+		index++
+	}
+	rCtxCancel()
+
+	glog.V(1).Infof("Integrating leaves [%d, %d)", fromSize, toSize)
+	log.Integrate(ctx, fromSize, logRoot, rfc6962.DefaultHasher)
+	glog.V(1).Info("Writing checkpoint")
+	logRoot.WriteCheckpoint(ctx, inputCheckpointRaw)
+	glog.V(1).Infof("Successfully created tlog with %d leaves at %q", toSize, *outputRoot)
+}
+
+// initStorage loads or creates the tile-based log storage in the given output directory
+// and returns the storage, along with the tree size currently persisted.
+func initStorage(logVerifier note.Verifier, outputRoot string) (*fs.Storage, uint64, error) {
+	var logRoot *fs.Storage
+	var fromSize uint64
+	if fstat, err := os.Stat(outputRoot); os.IsNotExist(err) {
+		glog.Infof("No directory exists at %q; creating new tile-based log filesystem", outputRoot)
+		logRoot, err = fs.Create(outputRoot)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to create log root filesystem: %v", err)
+		}
+		glog.Infof("Created new log root filesystem at %q", outputRoot)
+	} else if !fstat.IsDir() {
+		return nil, 0, fmt.Errorf("output root is not a directory: %v", outputRoot)
+	} else {
+		glog.Infof("Reading existing tile-based log from %q", outputRoot)
+		fsCheckpointRaw, err := fs.ReadCheckpoint(outputRoot)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to read checkpoint from log root filesystem: %v", err)
+		}
+		fsCheckpoint, _, _, err := fmtlog.ParseCheckpoint(fsCheckpointRaw, *origin, logVerifier)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to open Checkpoint: %q", err)
+		}
+		logRoot, err = fs.Load(outputRoot, fromSize)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to load log root filesystem: %v", err)
+		}
+		fromSize = fsCheckpoint.Size
+	}
+	return logRoot, fromSize, nil
+}
+
+// reporter is copied from clone/internal/cloner/clone.go.
+type reporter struct {
+	// treeSize is fixed for the lifetime of the reporter.
+	treeSize uint64
+
+	// Fields read/written only in report()
+	lastReport   time.Time
+	lastReported uint64
+
+	// Fields shared across multiple threads, protected by workedMutex
+	lastWorked  uint64
+	epochWorked time.Duration
+	workedMutex sync.Mutex
+}
+
+func (r *reporter) report() {
+	lastWorked, epochWorked := func() (uint64, time.Duration) {
+		r.workedMutex.Lock()
+		defer r.workedMutex.Unlock()
+		lw, ew := r.lastWorked, r.epochWorked
+		r.epochWorked = 0
+		return lw, ew
+	}()
+
+	elapsed := time.Since(r.lastReport)
+	workRatio := epochWorked.Seconds() / elapsed.Seconds()
+	remaining := r.treeSize - r.lastReported - 1
+	rate := float64(lastWorked-r.lastReported) / elapsed.Seconds()
+	eta := time.Duration(float64(remaining)/rate) * time.Second
+	glog.Infof("%.1f leaves/s, last leaf=%d (remaining: %d, ETA: %s), time working=%.1f%%", rate, r.lastReported, remaining, eta, 100*workRatio)
+
+	r.lastReport = time.Now()
+	r.lastReported = r.lastWorked
+}
+
+func (r *reporter) trackWork(index uint64) func() {
+	start := time.Now()
+
+	return func() {
+		end := time.Now()
+		r.workedMutex.Lock()
+		defer r.workedMutex.Unlock()
+		r.lastWorked = index
+		r.epochWorked += end.Sub(start)
+	}
+}

--- a/serverless/cmd/integrate/main.go
+++ b/serverless/cmd/integrate/main.go
@@ -117,7 +117,7 @@ func main() {
 	}
 
 	// Integrate new entries
-	newCp, err := log.Integrate(ctx, *cp, st, h)
+	newCp, err := log.Integrate(ctx, cp.Size, st, h)
 	if err != nil {
 		glog.Exitf("Failed to integrate: %q", err)
 	}

--- a/serverless/experimental/wasm/main.go
+++ b/serverless/experimental/wasm/main.go
@@ -126,7 +126,7 @@ func integrate() js.Func {
 		}
 
 		ctx := context.Background()
-		newCp, err := log.Integrate(ctx, *&cp.Size, logStorage, rfc6962.DefaultHasher)
+		newCp, err := log.Integrate(ctx, cp.Size, logStorage, rfc6962.DefaultHasher)
 		if err != nil {
 			logMsg(fmt.Sprintf("Failed to integrate: %q", err))
 			panic(err)

--- a/serverless/experimental/wasm/main.go
+++ b/serverless/experimental/wasm/main.go
@@ -126,7 +126,7 @@ func integrate() js.Func {
 		}
 
 		ctx := context.Background()
-		newCp, err := log.Integrate(ctx, *cp, logStorage, rfc6962.DefaultHasher)
+		newCp, err := log.Integrate(ctx, *&cp.Size, logStorage, rfc6962.DefaultHasher)
 		if err != nil {
 			logMsg(fmt.Sprintf("Failed to integrate: %q", err))
 			panic(err)

--- a/serverless/integration/integration_test.go
+++ b/serverless/integration/integration_test.go
@@ -74,7 +74,7 @@ func RunIntegration(t *testing.T, s log.Storage, f client.Fetcher, lh *rfc6962.H
 		var latestCpNote *note.Note
 		// Integrate those leaves
 		{
-			update, err := log.Integrate(ctx, checkpoint, s, lh)
+			update, err := log.Integrate(ctx, checkpoint.Size, s, lh)
 			if err != nil {
 				t.Fatalf("Integrate = %v", err)
 			}


### PR DESCRIPTION
This tool allows a file-based mirror of any cloneable log to be created. This required a change to Integrate to remove the requirement for a prior checkpoint. This has been replaced with the fromSize. In the case of mirrors, we can't create and sign a valid checkpooint of size 0, which is what the integrate command had assumed was possible from its previous usage.

TODO: write up instructions for setting up a filesystem that can handle this without running out of space / inodes.
