### PR TITLE
Added size checks on unsafe operations

### DIFF
--- a/binary_transparency/firmware/cmd/ftmapserver/impl/ftmapserver.go
+++ b/binary_transparency/firmware/cmd/ftmapserver/impl/ftmapserver.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 
@@ -136,6 +137,11 @@ func (s *Server) getTile(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	if rev > math.MaxInt {
+		// TODO(mhutchinson): Revision probably ought to be uint64 as negative revisions are weird.
+		http.Error(w, "revision is too large", http.StatusBadRequest)
+		return
+	}
 	path, err := parseBase64Param(r, "path")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -173,6 +179,11 @@ func (s *Server) getAggregation(w http.ResponseWriter, r *http.Request) {
 	rev, err := parseUintParam(r, "revision")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if rev > math.MaxInt {
+		// TODO(mhutchinson): Revision probably ought to be uint64 as negative revisions are weird.
+		http.Error(w, "revision is too large", http.StatusBadRequest)
 		return
 	}
 	fwIndex, err := parseUintParam(r, "fwIndex")

--- a/binary_transparency/firmware/internal/crypto/signature.go
+++ b/binary_transparency/firmware/internal/crypto/signature.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha512"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -102,6 +103,9 @@ func (c *Claimant) getPublicKey() (*rsa.PublicKey, error) {
 
 // SignMessage is used to sign the Statement
 func (c *Claimant) SignMessage(stype api.StatementType, msg []byte) ([]byte, error) {
+	if len(msg) > 64*1024*1024 {
+		return nil, errors.New("msg too large")
+	}
 	bs := make([]byte, len(msg)+1)
 	bs[0] = byte(stype)
 	copy(bs[1:], msg)


### PR DESCRIPTION
Fixes https://github.com/google/trillian-examples/security/code-scanning/5, https://github.com/google/trillian-examples/security/code-scanning/7, https://github.com/google/trillian-examples/security/code-scanning/8.