### PR TITLE
Clean up dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,14 @@
 version: 2
 updates:
 - package-ecosystem: gomod
-  directory: "/"
+  directory: /
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: "github-actions"
-  directory: "/"
+
+- package-ecosystem: github-actions
+  directory: /
   schedule:
-    interval: "weekly"
-- package-ecosystem: "docker"
-  directory: "/"
-  schedule:
-    interval: "weekly"
+    interval: daily
 
 - package-ecosystem: docker
   directory: /binary_transparency/firmware/cmd/ft_personality


### PR DESCRIPTION
Made it internally consistent by removing quotes, and making everything daily. Removed the limit for open PRs as we haven't used that, and the other ecosystem stanzas don't have it. Removed the docker stanza for the root as there is no Dockerfile there.
