### PR TITLE
Bump Go from 1.19 to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/trillian-examples
 
-go 1.19
+go 1.20
 
 require (
 	github.com/apache/beam/sdks/v2 v2.49.0

--- a/serverless/deploy/github/distributor/combine_witness_signatures/go.mod
+++ b/serverless/deploy/github/distributor/combine_witness_signatures/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/trillian-examples/serverless/deploy/github/distributor/combine_witness_signatures
 
-go 1.19
+go 1.20
 
 require (
 	github.com/golang/glog v1.1.2

--- a/serverless/deploy/github/distributor/update_logs_index/go.mod
+++ b/serverless/deploy/github/distributor/update_logs_index/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/trillian-examples/serverless/deploy/github/distributor/update_logs_index
 
-go 1.19
+go 1.20
 
 require (
 	github.com/golang/glog v1.1.2

--- a/serverless/experimental/gcp-log/gcs_uploader/go.mod
+++ b/serverless/experimental/gcp-log/gcs_uploader/go.mod
@@ -1,6 +1,6 @@
 module github.com/gcp_serverless_example_module
 
-go 1.19
+go 1.20
 
 require cloud.google.com/go/storage v1.32.0
 


### PR DESCRIPTION
We support the last two minor versions (1.20 and 1.21).