### PR TITLE
Remove GO111MODULE env var from all Dockerfiles

### DIFF
--- a/binary_transparency/firmware/cmd/ft_personality/Dockerfile
+++ b/binary_transparency/firmware/cmd/ft_personality/Dockerfile
@@ -3,7 +3,6 @@ LABEL stage=builder
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
-ENV GO111MODULE=on
 
 # Move to working directory /build
 WORKDIR /build

--- a/binary_transparency/firmware/cmd/ftmapserver/Dockerfile
+++ b/binary_transparency/firmware/cmd/ftmapserver/Dockerfile
@@ -3,7 +3,6 @@ LABEL stage=builder
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
-ENV GO111MODULE=on
 
 # Move to working directory /build
 WORKDIR /build

--- a/clone/cmd/ctclone/Dockerfile
+++ b/clone/cmd/ctclone/Dockerfile
@@ -2,7 +2,6 @@ FROM golang:1.21-alpine3.17@sha256:6467daf26aec6b82c750be4ca9b6aaf3a6a07ed22e1d4
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
-ENV GO111MODULE=on
 
 # Move to working directory /build
 WORKDIR /build

--- a/clone/cmd/ctverify/Dockerfile
+++ b/clone/cmd/ctverify/Dockerfile
@@ -2,7 +2,6 @@ FROM golang:1.21-alpine3.17@sha256:6467daf26aec6b82c750be4ca9b6aaf3a6a07ed22e1d4
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
-ENV GO111MODULE=on
 
 # Move to working directory /build
 WORKDIR /build

--- a/clone/cmd/sumdbclone/Dockerfile
+++ b/clone/cmd/sumdbclone/Dockerfile
@@ -2,7 +2,6 @@ FROM golang:1.21-alpine3.17@sha256:6467daf26aec6b82c750be4ca9b6aaf3a6a07ed22e1d4
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
-ENV GO111MODULE=on
 
 # Move to working directory /build
 WORKDIR /build

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /testbase
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
-ENV GO111MODULE=on
 
 RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-free" >> /etc/apt/sources.list
 RUN apt-get update && apt-get -y install curl docker-compose lsof netcat unzip wget xxd

--- a/sumdbaudit/docker/mirror/Dockerfile
+++ b/sumdbaudit/docker/mirror/Dockerfile
@@ -2,7 +2,6 @@ FROM golang:1.20.5-buster@sha256:eb3f9ac805435c1b2c965d63ce460988e1000058e1f6788
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
-ENV GO111MODULE=on
 
 # Move to working directory /build
 WORKDIR /build


### PR DESCRIPTION
The `GO111MODULE` is on by default since Go 1.16.