### PR TITLE
Tighter clone semantics for DB writing

### DIFF
--- a/clone/README.md
+++ b/clone/README.md
@@ -25,25 +25,24 @@ A single download session looks like this:
 
 1. Get a checkpoint from the log and store this _in memory_
    1. We will refer to the size of this checkpoint (i.e. the number of leaves it commits to) as `N`
-2. Read the last checkpoint persisted in the local database in order to determine `M`
+2. Read the last checkpoint persisted in the local database in order to determine the local size, `M`
    1. If no previous checkpoint is stored then `M` is 0
-3. Download all leaves in the range `[M, N)`  from the log
-   1. Leaves are fetched in batches, in parallel, and stored in memory temporarily
-   2. Leaves are written to the `leaves` table of the database from this memory pool, strictly _in order_ of their index
+3. Download all leaves in the range `[M, N)` from the log
+   1. Leaves are fetched in batches, in parallel, and pooled in memory temporarily
+   2. Leaves from this memory pool are written to the `leaves` table of the database from this memory pool, strictly _in order_ of their index
 4. Once `N` leaves have been written to the database, calculate the Merkle root of all of these leaves
 5. If, and only if, the Merkle root matches the checkpoint downloaded in (1), write this checkpoint to the `checkpoints` table of the database
-   1. A compact expression of the Merkle tree is also stored along with this checkpoint in the form of a [compact range](https://github.com/transparency-dev/merkle/tree/main/compact)
+   1. A compact respresentation of the Merkle tree is also stored along with this checkpoint in the form of a [compact range](https://github.com/transparency-dev/merkle/tree/main/compact)
 
 Note that this means that until a download session completes successfully, the database may contain unverified leaves with an index greater than that stored in the latest checkpoint.
+Leaves must not be trusted if their index is greater or equal to the size of the latest checkpoint.
 
 ## Custom Processing
 
-The design of this library is that it forms the first part of a local data pipeline, i.e. downstream tooling can be written that reads from this local mirror of the log.
-Such tooling MUST only trust leaves that are committed to by a checkpoint.
-Reading leaves with an index greater than the current checkpoint size is possible, but such data is unverified and using this defeats the purpose of using verifiable data structures.
+This library was designed to form the first part of a local data pipeline, i.e. downstream tooling can be written that reads from this local mirror of the log.
+Such tooling MUST only trust leaves that are committed to by a checkpoint; reading leaves with an index greater than the current checkpoint size is possible, but such data is unverified and using this defeats the purpose of using verifiable data structures.
 
-The `leaves` table records the leaf data as blobs.
-This accurately reflects what the log has committed to, but does not enable efficient SQL queries into the data.
+The `leaves` table records the leaf data as blobs; this accurately reflects what the log has committed to, but does not enable efficient SQL queries into the data.
 A common usage pattern for a specific log ecosystem would be to have the first stage of the local pipeline parse the leaf data and break out the contents into a table with an appropriate schema for the parsed data.
 
 ## Database Setup

--- a/clone/cmd/serverlessclone/serverlessclone.go
+++ b/clone/cmd/serverlessclone/serverlessclone.go
@@ -101,6 +101,8 @@ func clone(ctx context.Context, db *logdb.Database, f client.Fetcher, targetCp c
 	if err != nil {
 		return fmt.Errorf("couldn't determine first leaf to fetch: %v", err)
 	}
+	// TODO(mhutchinson): other implementations don't have this check. Is this redundant,
+	// OR can it be moved deeper into the call stack?
 	if next >= uint64(targetCp.Size) {
 		glog.Infof("No work to do. Local tree size = %d, latest log tree size = %d", next, targetCp.Size)
 		return nil

--- a/clone/cmd/serverlessclone/serverlessclone.go
+++ b/clone/cmd/serverlessclone/serverlessclone.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"flag"
 	"fmt"
@@ -29,10 +28,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/clone/internal/cloner"
-	"github.com/google/trillian-examples/clone/internal/verify"
 	"github.com/google/trillian-examples/clone/logdb"
-	"github.com/transparency-dev/formats/log"
-	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/serverless-log/client"
 	"golang.org/x/mod/sumdb/note"
 
@@ -88,31 +84,17 @@ func main() {
 	}
 	glog.Infof("Target checkpoint is for tree size %d", targetCp.Size)
 
-	if err := clone(ctx, db, f, targetCp); err != nil {
+	cp := cloner.UnwrappedCheckpoint{
+		Size: targetCp.Size,
+		Hash: targetCp.Hash,
+		Raw:  rawCp,
+	}
+	if err := clone(ctx, db, f, cp); err != nil {
 		glog.Exitf("Failed to clone: %v", err)
-	}
-
-	// Verify the downloaded leaves with the target checkpoint, and if it verifies, persist the checkpoint.
-	h := rfc6962.DefaultHasher
-	lh := func(_ uint64, preimage []byte) []byte {
-		return h.HashLeaf(preimage)
-	}
-
-	lv := verify.NewLogVerifier(db, lh, h.HashChildren)
-	root, crs, err := lv.MerkleRoot(ctx, uint64(targetCp.Size))
-	if err != nil {
-		glog.Exitf("Failed to compute root: %q", err)
-	}
-	if !bytes.Equal(targetCp.Hash[:], root) {
-		glog.Exitf("Computed root %x != provided checkpoint %x for tree size %d", root, targetCp.Hash, targetCp.Size)
-	}
-	glog.Infof("Got matching roots for tree size %d: %x", targetCp.Size, root)
-	if err := db.WriteCheckpoint(ctx, uint64(targetCp.Size), rawCp, crs); err != nil {
-		glog.Exitf("Failed to update database with new checkpoint: %v", err)
 	}
 }
 
-func clone(ctx context.Context, db *logdb.Database, f client.Fetcher, targetCp *log.Checkpoint) error {
+func clone(ctx context.Context, db *logdb.Database, f client.Fetcher, targetCp cloner.UnwrappedCheckpoint) error {
 	cl := cloner.New(*workers, 1, *writeBatchSize, db)
 
 	next, err := cl.Next()
@@ -133,8 +115,8 @@ func clone(ctx context.Context, db *logdb.Database, f client.Fetcher, targetCp *
 		return err
 	}
 
-	if err := cl.Clone(ctx, uint64(targetCp.Size), batchFetch); err != nil {
-		return fmt.Errorf("failed to clone log: %v", err)
+	if err := cl.CloneAndVerify(ctx, batchFetch, targetCp); err != nil {
+		return fmt.Errorf("failed to clone and verify log: %v", err)
 	}
 	return nil
 }

--- a/clone/internal/cloner/clone_test.go
+++ b/clone/internal/cloner/clone_test.go
@@ -71,7 +71,7 @@ func TestClone(t *testing.T) {
 				}
 				return nil
 			}
-			if err := cloner.Clone(context.Background(), test.treeSize, fetcher); err != nil {
+			if err := cloner.clone(context.Background(), test.treeSize, fetcher); err != nil {
 				t.Fatalf("Clone(): %v", err)
 			}
 


### PR DESCRIPTION
Previously each clone tool implementation was responsible for calling Clone() and then Verify() and then persisting the checkpoint to the database. A bad implementation could have written the checkpoint with incomplete verification, which would have broken the expected contract for these tools.

This change makes this contract about when leaves can be trusted far clearer. The API makes this hard to get wrong, and the docs have been updated to clearly communicate what can be expected of the data. The docs also make it clearer that this is expected to be the first stage of a pipeline, and that the leaf data being raw isn't a blocker because later pipeline stages can parse this.
