### PR TITLE
Adapt ctclone for 'coerced get-entries' in Let's Encrypt and other CT Logs

### DIFF
--- a/clone/cmd/ctclone/ctclone_test.go
+++ b/clone/cmd/ctclone/ctclone_test.go
@@ -58,6 +58,13 @@ func TestCertLeafFetcher(t *testing.T) {
 			urls:    map[string]string{"ct/v1/get-entries?start=42&end=43": `{"entries":[{"leaf_input": "b25l"}]}`},
 			wantErr: true,
 		},
+		{
+			name:  "returned coerced page",
+			start: 43,
+			count: 2,
+			urls:  map[string]string{"ct/v1/get-entries?start=43&end=44": `{"entries":[{"leaf_input": "b25lIG9oIG9uZQ=="}]}`},
+			want:  []string{"one oh one", ""},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			clf := ctFetcher{&fakeFetcher{test.urls}}


### PR DESCRIPTION
This commit updates ctclone to handle the 'coerced get-entries' feature introduced in Let's Encrypt's Certificate Transparency logs. Previously, ctclone did not account for the log's behavior of truncating responses to align with cacheable boundaries.

Fixes #1044 