### PR TITLE
Adapt ctclone for 'coerced get-entries' in Let's Encrypt and other CT Logs

### DIFF
--- a/clone/cmd/ctclone/ctclone_test.go
+++ b/clone/cmd/ctclone/ctclone_test.go
@@ -62,7 +62,7 @@ func TestCertLeafFetcher(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			clf := ctFetcher{&fakeFetcher{test.urls}}
 			leaves := make([][]byte, test.count)
-			err := clf.Batch(test.start, leaves)
+			_, err := clf.Batch(test.start, leaves)
 			switch {
 			case err != nil && !test.wantErr:
 				t.Fatalf("Got unexpected error %q", err)

--- a/clone/cmd/serverlessclone/serverlessclone.go
+++ b/clone/cmd/serverlessclone/serverlessclone.go
@@ -108,13 +108,13 @@ func clone(ctx context.Context, db *logdb.Database, f client.Fetcher, targetCp c
 		return nil
 	}
 
-	batchFetch := func(start uint64, leaves [][]byte) error {
+	batchFetch := func(start uint64, leaves [][]byte) (uint64, error) {
 		if len(leaves) != 1 {
-			return fmt.Errorf("true batch fetching not supported")
+			return 0, fmt.Errorf("true batch fetching not supported")
 		}
 		leaf, err := client.GetLeaf(ctx, f, start)
 		leaves[0] = leaf
-		return err
+		return 1, err
 	}
 
 	if err := cl.CloneAndVerify(ctx, batchFetch, targetCp); err != nil {

--- a/clone/internal/cloner/clone_test.go
+++ b/clone/internal/cloner/clone_test.go
@@ -65,11 +65,11 @@ func TestClone(t *testing.T) {
 			defer close()
 
 			cloner := New(test.workers, test.fetchBatchSize, test.writeBatchSize, db)
-			fetcher := func(start uint64, leaves [][]byte) error {
+			fetcher := func(start uint64, leaves [][]byte) (uint64, error) {
 				for i := range leaves {
 					leaves[i] = []byte(fmt.Sprintf("leaf %d", start+1))
 				}
-				return nil
+				return uint64(len(leaves)), nil
 			}
 			if err := cloner.clone(context.Background(), test.treeSize, fetcher); err != nil {
 				t.Fatalf("Clone(): %v", err)

--- a/clone/internal/download/batch.go
+++ b/clone/internal/download/batch.go
@@ -36,9 +36,8 @@ type BulkResult struct {
 
 // Bulk keeps downloading leaves starting from `first`, using the given leaf fetcher.
 // The number of workers and the batch size to use for each of the fetch requests are also specified.
-// The resulting leaves are returned in order over `leafChan`, and any terminal errors are returned via `errc`.
+// The resulting leaves or terminal errors are returned in order over `rc`. Bulk takes ownership of `rc` and will close it when no more values will be written.
 // Internally this uses exponential backoff on the workers to download as fast as possible, but no faster.
-// Bulk takes ownership of `rc` and will close it when no more values will be written.
 func Bulk(ctx context.Context, first, treeSize uint64, batchFetch BatchFetch, workers, batchSize uint, rc chan<- BulkResult) {
 	defer close(rc)
 	ctx, cancel := context.WithCancel(ctx)

--- a/clone/internal/download/batch.go
+++ b/clone/internal/download/batch.go
@@ -25,8 +25,8 @@ import (
 )
 
 // BatchFetch should be implemented to provide a mechanism to fetch a range of leaves.
-// Enough leaves should be fetched to fully fill `leaves`, or an error should be returned.
-type BatchFetch func(start uint64, leaves [][]byte) error
+// It should return the number of leaves fetched, or an error if the fetch failed.
+type BatchFetch func(start uint64, leaves [][]byte) (uint64, error)
 
 // BulkResult combines a downloaded leaf, or the error found when trying to obtain the leaf.
 type BulkResult struct {
@@ -128,7 +128,7 @@ func (w fetchWorker) run(ctx context.Context) {
 		leaves := make([][]byte, count)
 		var c workerResult
 		operation := func() error {
-			err := w.batchFetch(w.start, leaves)
+			_, err := w.batchFetch(w.start, leaves)
 			if err != nil {
 				return fmt.Errorf("LeafFetcher.Batch(%d, %d): %w", w.start, w.count, err)
 			}

--- a/clone/internal/download/batch_test.go
+++ b/clone/internal/download/batch_test.go
@@ -211,7 +211,7 @@ func TestBulkIncomplete(t *testing.T) {
 			treeSize:  100,
 			batchSize: 10,
 			workers:   4,
-			wantErr:   true,
+			wantErr:   false,
 			fakeFetch: func(start uint64, leaves [][]byte) (uint64, error) {
 				fetched := uint64(len(leaves))
 				for i := range leaves {


### PR DESCRIPTION
Adapt ctclone to handle the 'coerced get-entries' feature by: trying to retrieve just one request, checking the number of returned results, either continuing with the rest workers, or stopping fetching, storing the incomplete tile, exiting delegating orchestration system to start the process again.

Fixes https://github.com/google/trillian-examples/issues/1044