### PR TITLE
Safeguard against redirects on POST request

### DIFF
--- a/binary_transparency/firmware/internal/client/client.go
+++ b/binary_transparency/firmware/internal/client/client.go
@@ -96,9 +96,9 @@ func (c SubmitClient) PublishFirmware(manifest, image []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to publish to log endpoint (%s): %w", u, err)
 	}
-	if resp.Request.Method != "POST" {
+	if r.Request.Method != "POST" {
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections#permanent_redirections
-		return fmt.Errorf("POST request to %q was converted to %s request to %q", u.String(), resp.Request.Method, resp.Request.URL)
+		return fmt.Errorf("POST request to %q was converted to %s request to %q", u.String(), r.Request.Method, r.Request.URL)
 	}
 	if r.StatusCode != http.StatusOK {
 		return errFromResponse("failed to submit to log", r)

--- a/binary_transparency/firmware/internal/client/client.go
+++ b/binary_transparency/firmware/internal/client/client.go
@@ -96,6 +96,10 @@ func (c SubmitClient) PublishFirmware(manifest, image []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to publish to log endpoint (%s): %w", u, err)
 	}
+	if resp.Request.Method != "POST" {
+		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections#permanent_redirections
+		return fmt.Errorf("POST request to %q was converted to %s request to %q", u.String(), resp.Request.Method, resp.Request.URL)
+	}
 	if r.StatusCode != http.StatusOK {
 		return errFromResponse("failed to submit to log", r)
 	}


### PR DESCRIPTION
A redirect on a POST request will make the http client perform a GET request to the signposted URL. This will (probably) return a 200, which the code will then interpret as a successful POST. This check ensures that the method the response relates to is the same as the one we invoked.
