### PR TITLE
Update Debian apt source from `buster-backports` to `bullseye-backports`

### DIFF
--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /testbase
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
 
-RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-free" >> /etc/apt/sources.list
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main contrib non-free" >> /etc/apt/sources.list
 RUN apt-get update && apt-get -y install curl docker-compose lsof netcat unzip wget xxd
 
 RUN cd /usr/bin && curl -L -O https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && mv jq-linux64 /usr/bin/jq && chmod +x /usr/bin/jq


### PR DESCRIPTION
This PR fixes the broken cloud build pipeline to unblock Dependabot PRs.