### PR TITLE
Move dependabot to monthly cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directories:
     - /
   schedule:
-    interval: weekly
+    interval: monthly
   groups:
     all-deps:
       applies-to: version-updates
@@ -14,7 +14,7 @@ updates:
 - package-ecosystem: github-actions
   directory: /
   schedule:
-    interval: weekly
+    interval: monthly
   groups:
     all-deps:
       applies-to: version-updates
@@ -30,7 +30,7 @@ updates:
     - /clone/cmd/sumdbclone
     - /integration
   schedule:
-    interval: weekly
+    interval: monthly
   groups:
     all-deps:
       applies-to: version-updates


### PR DESCRIPTION
Weekly is requiring a lot of human time to review and support non-standard upgrades (e.g. protobuf changes that require regen files). Moving to monthly to give us some more breathing space.
