### PR TITLE
End-to-end index built via a command line tool

### DIFF
--- a/experimental/vindex/cmd/main.go
+++ b/experimental/vindex/cmd/main.go
@@ -1,0 +1,146 @@
+// Copyright 2025 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// vindex builds a verifiable map in memory from a clone of a log.
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/google/trillian-examples/clone/logdb"
+	"github.com/google/trillian-examples/experimental/vindex"
+	"github.com/gorilla/mux"
+	"golang.org/x/mod/semver"
+	"k8s.io/klog/v2"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+var (
+	logDSN  = flag.String("logDSN", "", "Connection string for a clone DB log.")
+	walPath = flag.String("walPath", "", "Path to use for the Write Ahead Log. If empty, a temporary file will be used.")
+	addr    = flag.String("addr", ":8088", "Address to set up HTTP server listening on")
+
+	// Example leaf:
+	// golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+	// golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+	//
+	line0RE = regexp.MustCompile(`(.*) (.*) h1:(.*)`)
+	line1RE = regexp.MustCompile(`(.*) (.*)/go.mod h1:(.*)`)
+)
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+
+	ctx := context.Background()
+
+	log, err := logdb.NewDatabase(*logDSN)
+	if err != nil {
+		klog.Exitf("Failed to connect to DB: %s", err)
+	}
+	b, err := vindex.NewVerifiableIndex(ctx, log, mapFnFromFlags(), walPathFromFlags())
+	if err != nil {
+		klog.Exitf("NewIndexBuilder(): %v", err)
+	}
+
+	s := NewServer(func(s string) string {
+		idxes := b.Lookup(s)
+		return fmt.Sprintf("Indices in log: %v", idxes)
+
+	})
+	r := mux.NewRouter()
+	s.registerHandlers(r)
+	hServer := &http.Server{
+		Addr:    *addr,
+		Handler: r,
+	}
+
+	go func() {
+		// TODO(mhutchinson): This should update periodically.
+		// There is locking to consider here, as Lookup during Update isn't safe, yet.
+		if err := b.Update(ctx); err != nil {
+			klog.Exitf("Failed to update Verifiable Index: %s", err)
+		}
+		// On successful update, this should post the vindex root into an output log.
+		// Log is likely to be POSIX Tessera.
+		klog.Info("Verifiable Index built")
+	}()
+
+	e := make(chan error, 1)
+	go func() {
+		e <- hServer.ListenAndServe()
+		close(e)
+	}()
+	klog.Infof("HTTP server listening on %s", *addr)
+	<-ctx.Done()
+	klog.Info("Server shutting down")
+	if err := hServer.Shutdown(ctx); err != nil {
+		klog.Errorf("server.Shutdown(): %v", err)
+	}
+	if err := <-e; err != nil {
+		klog.Exit(err)
+	}
+}
+
+func mapFnFromFlags() vindex.MapFn {
+	// TODO(mhutchinson): Implement a flag-selectable switch for which MapFn to use.
+	// Realistically, this would be multiple binaries in a real world application, but
+	// for the sake of a demo, showing that it's exactly the same binary apart from the
+	// MapFn is a selling point.
+	mapFn := func(data []byte) [][32]byte {
+		lines := strings.Split(string(data), "\n")
+
+		line0Parts := line0RE.FindStringSubmatch(lines[0])
+		line0Module, line0Version := line0Parts[1], line0Parts[2]
+
+		line1Parts := line1RE.FindStringSubmatch(lines[1])
+		line1Module, line1Version := line1Parts[1], line1Parts[2]
+
+		if line0Module != line1Module {
+			klog.Errorf("mismatched module names: (%s, %s)", line0Module, line1Module)
+		}
+		if line0Version != line1Version {
+			klog.Errorf("mismatched version names: (%s, %s)", line0Version, line0Version)
+		}
+		if semver.Prerelease(line0Version) != "" || semver.Build(line0Version) != "" {
+			// Drop any emphemeral builds
+			return nil
+		}
+
+		klog.V(2).Infof("MapFn found: Module: %s:\t%s", line0Module, line0Version)
+
+		return [][32]byte{sha256.Sum256([]byte(line0Module))}
+	}
+	return mapFn
+}
+
+func walPathFromFlags() string {
+	if len(*walPath) > 0 {
+		return *walPath
+	}
+	f, err := os.CreateTemp("", "walPath")
+	if err != nil {
+		klog.Exitf("Failed to create temporary path for WAL: %s", err)
+	}
+	klog.Infof("Created temporary WAL at %s", f.Name())
+	return f.Name()
+}

--- a/experimental/vindex/cmd/main.go
+++ b/experimental/vindex/cmd/main.go
@@ -28,7 +28,7 @@ import (
 	"github.com/google/trillian-examples/clone/logdb"
 	"github.com/google/trillian-examples/experimental/vindex"
 	"github.com/gorilla/mux"
-	"golang.org/x/mod/semver"
+	"golang.org/x/mod/module"
 	"k8s.io/klog/v2"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -121,7 +121,7 @@ func mapFnFromFlags() vindex.MapFn {
 		if line0Version != line1Version {
 			klog.Errorf("mismatched version names: (%s, %s)", line0Version, line0Version)
 		}
-		if semver.Prerelease(line0Version) != "" || semver.Build(line0Version) != "" {
+		if module.IsPseudoVersion(line0Version) {
 			// Drop any emphemeral builds
 			return nil
 		}

--- a/experimental/vindex/cmd/templates/form.html
+++ b/experimental/vindex/cmd/templates/form.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Verifiable Index Lookup</title>
+    <style>
+        body { font-family: sans-serif; margin: 20px; background-color: #f4f4f4; }
+        .container { background-color: #fff; padding: 30px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); max-width: 500px; margin: 50px auto; }
+        label { display: block; margin-bottom: 8px; font-weight: bold; }
+        input[type="text"] { width: calc(100% - 22px); padding: 10px; margin-bottom: 20px; border: 1px solid #ddd; border-radius: 4px; font-size: 16px; }
+        input[type="submit"] { background-color: #007bff; color: white; padding: 12px 20px; border: none; border-radius: 4px; cursor: pointer; font-size: 16px; }
+        input[type="submit"]:hover { background-color: #0056b3; }
+        p { color: #555; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Verifiable Index Lookup</h1>
+        <p>{{.Message}}</p>
+        <form action="/submit" method="POST">
+            <label for="inputString">Map Key:</label>
+            <input type="text" id="inputString" name="inputString" placeholder="Enter map key here..." required>
+            <br>
+            <input type="submit" value="Submit Map Key">
+        </form>
+    </div>
+</body>
+</html>

--- a/experimental/vindex/cmd/web.go
+++ b/experimental/vindex/cmd/web.go
@@ -1,0 +1,99 @@
+// Copyright 2025 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"k8s.io/klog/v2"
+)
+
+// Define a struct to hold any data we might pass to the template
+type FormData struct {
+	Message string
+}
+
+var tmpl *template.Template // Global template variable
+
+func init() {
+	// Parse the template file once when the program starts
+	// Must be in the 'templates' directory
+	var err error
+	tmpl, err = template.ParseFiles("experimental/vindex/cmd/templates/form.html")
+	if err != nil {
+		klog.Fatalf("Error parsing template: %v", err)
+	}
+}
+
+func NewServer(lookup func(string) string) Server {
+	return Server{
+		lookup: lookup,
+	}
+}
+
+type Server struct {
+	lookup func(string) string
+}
+
+// serveForm handles GET requests to the root path ("/")
+// It renders the HTML form.
+func (s Server) serveForm(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Render the form template with no initial data
+	err := tmpl.Execute(w, FormData{Message: "Enter your string below:"})
+	if err != nil {
+		klog.Warningf("Error executing template: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+	}
+}
+
+// handleSubmit handles POST requests to "/submit"
+// It parses the form data and responds.
+func (s Server) handleSubmit(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	err := r.ParseForm()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Error parsing form: %v", err), http.StatusBadRequest)
+		return
+	}
+	inputString := r.FormValue("inputString")
+
+	klog.V(2).Infof("Received string from form: '%s'", inputString)
+
+	responseMessage := s.lookup(inputString)
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, responseMessage)
+}
+
+func (s Server) registerHandlers(r *mux.Router) {
+	r.HandleFunc("/", s.serveForm).Methods("GET")
+	r.HandleFunc("/submit", s.handleSubmit).Methods("POST")
+}

--- a/experimental/vindex/cmd/web.go
+++ b/experimental/vindex/cmd/web.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	_ "embed"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -28,17 +29,11 @@ type FormData struct {
 	Message string
 }
 
-var tmpl *template.Template // Global template variable
-
-func init() {
-	// Parse the template file once when the program starts
-	// Must be in the 'templates' directory
-	var err error
-	tmpl, err = template.ParseFiles("experimental/vindex/cmd/templates/form.html")
-	if err != nil {
-		klog.Fatalf("Error parsing template: %v", err)
-	}
-}
+var (
+	//go:embed templates/form.html
+	templateStr string
+	tmpl        = template.Must(template.New("form").Parse(templateStr))
+)
 
 func NewServer(lookup func(string) string) Server {
 	return Server{

--- a/experimental/vindex/map.go
+++ b/experimental/vindex/map.go
@@ -19,6 +19,7 @@ package vindex
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -26,87 +27,175 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
+	"filippo.io/torchwood/mpt"
 	"github.com/google/trillian-examples/clone/logdb"
+	"golang.org/x/sync/errgroup"
 	"k8s.io/klog/v2"
 )
 
 // MapFn takes the raw leaf data from a log entry and outputs the SHA256 hashes
 // of the keys at which this leaf should be indexed under.
 // A leaf can be recorded at any number of entries, including no entries (in which case an empty slice must be returned).
-type MapFn func([]byte) [][]byte
+type MapFn func([]byte) [][32]byte
 
-// NewIndexBuilder returns an IndexBuilder that pulls entries from the given clonedb database, determines
+// NewVerifiableIndex returns an IndexBuilder that pulls entries from the given clonedb database, determines
 // indices for each one using the mapFn, and then writes the entries out to a Write Ahead Log at the given
 // path.
 // Note that only one IndexBuilder should exist for any given walPath at any time. The behaviour is unspecified,
 // but likely broken, if multiple processes are writing to the same file at any given time.
-func NewIndexBuilder(ctx context.Context, log *logdb.Database, mapFn MapFn, walPath string) (IndexBuilder, error) {
-	b := IndexBuilder{
-		log:   log,
-		mapFn: mapFn,
-		wal: &writeAheadLog{
-			walPath: walPath,
-		},
+func NewVerifiableIndex(ctx context.Context, log *logdb.Database, mapFn MapFn, walPath string) (*VerifiableIndex, error) {
+	wal := &writeAheadLog{
+		walPath: walPath,
 	}
-	return b, b.init(ctx)
+	ws, err := wal.init()
+	if err != nil {
+		return nil, err
+	}
+	reader, err := newLogReader(walPath)
+	vtreeStorage := mpt.NewMemoryStorage()
+	mpt.InitStorage(sha256.Sum256, vtreeStorage)
+	b := &VerifiableIndex{
+		log:       log,
+		mapFn:     mapFn,
+		wal:       wal,
+		reader:    reader,
+		vindex:    *mpt.NewTree(sha256.Sum256, vtreeStorage),
+		data:      map[[32]byte][]uint64{},
+		nextIndex: ws,
+	}
+	return b, nil
 }
 
-// IndexBuilder pulls data from a clone log DB, applies a MapFn, and outputs
+// VerifiableIndex pulls data from a clone log DB, applies a MapFn, and outputs
 // the resulting operations needed on the map to a write-ahead log.
-type IndexBuilder struct {
-	log   *logdb.Database
-	mapFn MapFn
-	wal   *writeAheadLog
+type VerifiableIndex struct {
+	log    *logdb.Database
+	mapFn  MapFn
+	wal    *writeAheadLog
+	reader *logReader
+	vindex mpt.Tree
+	data   map[[32]byte][]uint64
+
+	nextIndex uint64 // nextIndex is the next index in the log to consume
+	rawCp     []byte // rawCp is the last checkpoint we started syncing to
+	cpSize    uint64 // cpSize is the tree size of rawCp
+	mapSize   uint64 // mapSize is the last index from the log that was put into the map
 }
 
-func (b IndexBuilder) Close() error {
+func (b VerifiableIndex) Close() error {
 	return b.wal.close()
 }
 
-func (b IndexBuilder) init(ctx context.Context) error {
-	// Ready the write-ahead log, to determine the index we can guarantee we processed
-	idx, err := b.wal.init()
+func (b VerifiableIndex) Lookup(key string) (indices []uint64) {
+	// TODO(mhutchinson): This needs to return verifiable stuff
+	kh := sha256.Sum256([]byte(key))
+	return b.data[kh]
+}
+
+// Update checks the input log for a new Checkpoint, and ensures that the Verifiable Index
+// is updated to the corresponding size.
+func (b VerifiableIndex) Update(ctx context.Context) error {
+	var eg errgroup.Group
+
+	var err error
+	b.cpSize, b.rawCp, _, err = b.log.GetLatestCheckpoint(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get latest checkpoint from DB: %v", err)
 	}
+	klog.Infof("Building map to log size of %d", b.cpSize)
+	eg.Go(func() error { return b.syncFromDatabase(ctx) })
+	eg.Go(func() error { return b.buildMap(ctx) })
 
-	// Kick off a thread to read from the DB wherever the WAL was last written.
-	// This thread will only write to the WAL.
-	go b.pullFromDatabase(ctx, idx)
+	return eg.Wait()
+}
 
-	// Kick off a thread to:
-	//  - read snapshot of the WAL and populate map
-	//  - consume entries from the channel to update the map
+// syncFromDatabase reads the latest checkpoint from the DB mirror of the log.
+// It stores this checkpoint in the builder, and ensures the WAL is updated with
+// all VIndex updates required to represent the log.
+func (b VerifiableIndex) syncFromDatabase(ctx context.Context) error {
+	if b.cpSize > b.nextIndex {
+		leaves := make(chan logdb.StreamResult, 1)
+		go b.log.StreamLeaves(ctx, b.nextIndex, b.cpSize, leaves)
 
+		var l logdb.StreamResult
+		for ; b.nextIndex < b.cpSize; b.nextIndex++ {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case l = <-leaves:
+			}
+			if l.Err != nil {
+				return fmt.Errorf("failed to read leaf at index %d: %v", b.nextIndex, l.Err)
+			}
+			hashes := b.mapFn(l.Leaf)
+			if len(hashes) == 0 && b.nextIndex < b.cpSize-1 {
+				// We can skip writing out values with no hashes, as long as we're
+				// not at the end of the log.
+				// If we are at the end of the log, we need to write out a value as a sentinel
+				// even if there are no hashes.
+				continue
+			}
+			if err := b.wal.append(b.nextIndex, hashes); err != nil {
+				return fmt.Errorf("failed to add index to entry for leaf %d: %v", b.nextIndex, err)
+			}
+		}
+	}
 	return nil
 }
 
-func (b IndexBuilder) pullFromDatabase(ctx context.Context, start uint64) {
-	size, rawCp, _, err := b.log.GetLatestCheckpoint(ctx)
-	if err != nil {
-		klog.Exitf("Panic: failed to get latest checkpoint from DB: %v", err)
-	}
-
-	if size > start {
-		leaves := make(chan logdb.StreamResult, 1)
-		b.log.StreamLeaves(ctx, start, size, leaves)
-
-		for i := start; i < size; i++ {
-			l := <-leaves
-			if l.Err != nil {
-				klog.Exitf("Panic: failed to read leaf at index %d: %v", i, err)
+// buildMap reads from the WAL until the file has been consumed and the map has been
+// built up the WAL size.
+func (b VerifiableIndex) buildMap(ctx context.Context) error {
+	for b.mapSize < b.cpSize-1 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		idx, hashes, err := b.reader.next()
+		if err != nil {
+			if err != io.EOF {
+				return err
 			}
-			hashes := b.mapFn(l.Leaf)
-			if err := b.wal.append(i, hashes); err != nil {
-				klog.Exitf("failed to add index to entry for leaf %d: %v", i, err)
+			// Wait a small amount of time for more data to become available
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		b.mapSize = idx
+		for _, h := range hashes {
+			klog.V(2).Infof("Read from WAL: index %d: %x", idx, h)
+			// Add the data to the key/value map
+			idxes := b.data[h]
+			idxes = append(idxes, idx)
+			b.data[h] = idxes
+
+			// Here we hash by simply appending all indices in the list and hashing that
+			// TODO(mhutchinson): maybe use a log construction?
+			sum := sha256.New()
+			for _, idx := range idxes {
+				b := []byte{
+					byte(idx),
+					byte(idx >> 8),
+					byte(idx >> 16),
+					byte(idx >> 24),
+					byte(idx >> 32),
+					byte(idx >> 40),
+					byte(idx >> 48),
+					byte(idx >> 56)}
+				if _, err := sum.Write(b); err != nil {
+					klog.Warning(err)
+					return err
+				}
 			}
-			// TODO(mhutchinson): announce updates to map construction code
+
+			// Finally, we update the vindex
+			b.vindex.Insert(h, [32]byte(sum.Sum(nil)))
+			klog.V(1).Infof("Updated map: %x: %v", h, idxes)
 		}
 	}
-
-	// TODO(mhutchinson): the raw log checkpoint needs to be propagated into the map checkpoint
-	_ = rawCp
+	return nil
 }
 
 type writeAheadLog struct {
@@ -215,7 +304,7 @@ func (l *writeAheadLog) validate() (uint64, error) {
 	return idx, err
 }
 
-func (l *writeAheadLog) append(idx uint64, hashes [][]byte) error {
+func (l *writeAheadLog) append(idx uint64, hashes [][32]byte) error {
 	e, err := marshalWalEntry(idx, hashes)
 	if err != nil {
 		return fmt.Errorf("failed to marshal entry: %v", err)
@@ -245,7 +334,7 @@ type logReader struct {
 // TODO(mhutchinson): change this as it's inconvenient with EOF handling,
 // which should be common when reader hits the end of the file but more is
 // to be written.
-func (r *logReader) next() (uint64, [][]byte, error) {
+func (r *logReader) next() (uint64, [][32]byte, error) {
 	line, err := r.r.ReadString('\n')
 	if err != nil {
 		if err == io.EOF {
@@ -266,20 +355,23 @@ func (r *logReader) close() error {
 
 // unmarshalWalEntry parses a line from the WAL.
 // This is the reverse of marshalWalEntry.
-func unmarshalWalEntry(e string) (uint64, [][]byte, error) {
+func unmarshalWalEntry(e string) (uint64, [][32]byte, error) {
 	tokens := strings.Split(e, " ")
 	idx, err := strconv.ParseUint(tokens[0], 10, 64)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to parse idx from %q", e)
 	}
 
-	hashes := make([][]byte, 0, len(tokens)-1)
+	hashes := make([][32]byte, 0, len(tokens)-1)
 	for i, h := range tokens[1:] {
 		parsed, err := hex.DecodeString(h)
 		if err != nil {
 			return 0, nil, fmt.Errorf("failed to parse hex token %d from %q", i, e)
 		}
-		hashes = append(hashes, parsed)
+		if got, want := len(parsed), 32; got != want {
+			return 0, nil, fmt.Errorf("expected 32 byte hash but got %d bytes at idx %d", got, i)
+		}
+		hashes = append(hashes, [32]byte(parsed))
 	}
 
 	return idx, hashes, nil
@@ -287,13 +379,13 @@ func unmarshalWalEntry(e string) (uint64, [][]byte, error) {
 
 // unmarshalWalEntry converts an index and the hashes it affects into a line for the WAL.
 // This is the reverse of unmarshalWalEntry.
-func marshalWalEntry(idx uint64, hashes [][]byte) (string, error) {
+func marshalWalEntry(idx uint64, hashes [][32]byte) (string, error) {
 	sb := strings.Builder{}
 	if _, err := sb.WriteString(strconv.FormatUint(idx, 10)); err != nil {
 		return "", err
 	}
 	for _, h := range hashes {
-		if _, err := sb.WriteString(" " + hex.EncodeToString(h)); err != nil {
+		if _, err := sb.WriteString(" " + hex.EncodeToString(h[:])); err != nil {
 			return "", err
 		}
 	}

--- a/experimental/vindex/map.go
+++ b/experimental/vindex/map.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -175,16 +176,7 @@ func (b VerifiableIndex) buildMap(ctx context.Context) error {
 			// TODO(mhutchinson): maybe use a log construction?
 			sum := sha256.New()
 			for _, idx := range idxes {
-				b := []byte{
-					byte(idx),
-					byte(idx >> 8),
-					byte(idx >> 16),
-					byte(idx >> 24),
-					byte(idx >> 32),
-					byte(idx >> 40),
-					byte(idx >> 48),
-					byte(idx >> 56)}
-				if _, err := sum.Write(b); err != nil {
+				if err := binary.Write(sum, binary.LittleEndian, idx); err != nil {
 					klog.Warning(err)
 					return err
 				}

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	cloud.google.com/go/profiler v0.4.2 // indirect
 	cloud.google.com/go/storage v1.52.0 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
+	filippo.io/torchwood v0.5.1-0.20250605130057-fa65d721a6ce // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.51.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,10 @@ cloud.google.com/go/trace v1.11.5 h1:CALS1loyxJMnRiCwZSpdf8ac7iCsjreMxFD2WGxzzHU
 cloud.google.com/go/trace v1.11.5/go.mod h1:TwblCcqNInriu5/qzaeYEIH7wzUcchSdeY2l5wL3Eec=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+filippo.io/torchwood v0.5.1-0.20250604161531-515b1068a52f h1:3DqMJOdhc6CZNRCQPktbMTVlcGmhJ2NwLT8eoA7MeTE=
+filippo.io/torchwood v0.5.1-0.20250604161531-515b1068a52f/go.mod h1:n82QaQC2EzvctEMkM1KAahZaAcQ2uZoCdn051sUXOQY=
+filippo.io/torchwood v0.5.1-0.20250605130057-fa65d721a6ce h1:8bVOhkZ6uQn3qCmrz/F7Rz0epygH9KO3dgbS9g/zclk=
+filippo.io/torchwood v0.5.1-0.20250605130057-fa65d721a6ce/go.mod h1:n82QaQC2EzvctEMkM1KAahZaAcQ2uZoCdn051sUXOQY=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 h1:ErKg/3iS1AKcTkf3yixlZ54f9U1rljCkQyEXWUnIUxc=


### PR DESCRIPTION
This version is the MVP to demonstrate creating an index out of a clone
of the SumDB. Each release with a plain semver (e.g. vX.Y.Z, no suffix)
is logged into the map. The map key is the hash of the module name. The
map value is the list of all uint64 indices at which a release for this
module can be found in the origin log.

An HTTP server is launched, which has a simple form that takes a map key
and looks up the corresponding indices.

Under the hood this is constructing a Merkle tree, though it isn't used
for Lookup yet.
