### PR TITLE
Bump Dockerfile base images from bullseye to bookworm releases

### DIFF
--- a/binary_transparency/firmware/cmd/ft_personality/Dockerfile
+++ b/binary_transparency/firmware/cmd/ft_personality/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4-bullseye@sha256:dfd72198d14bc22f270c9e000c304a2ffd19f5a5f693fad82643311afdc6b568 AS builder
+FROM golang:1.24.5-bookworm@sha256:ef8c5c733079ac219c77edab604c425d748c740d8699530ea6aced9de79aea40 AS builder
 LABEL stage=builder
 
 ARG GOFLAGS=""
@@ -19,7 +19,7 @@ COPY . .
 RUN go build ./binary_transparency/firmware/cmd/ft_personality
 
 # Build release image
-FROM golang:1.24.4-bullseye@sha256:dfd72198d14bc22f270c9e000c304a2ffd19f5a5f693fad82643311afdc6b568
+FROM golang:1.24.5-bookworm@sha256:ef8c5c733079ac219c77edab604c425d748c740d8699530ea6aced9de79aea40
 
 COPY --from=builder /build/ft_personality /bin/ft_personality
 ENTRYPOINT ["/bin/ft_personality"]

--- a/binary_transparency/firmware/cmd/ftmapserver/Dockerfile
+++ b/binary_transparency/firmware/cmd/ftmapserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4-bullseye@sha256:dfd72198d14bc22f270c9e000c304a2ffd19f5a5f693fad82643311afdc6b568 AS builder
+FROM golang:1.24.5-bookworm@sha256:ef8c5c733079ac219c77edab604c425d748c740d8699530ea6aced9de79aea40 AS builder
 LABEL stage=builder
 
 ARG GOFLAGS=""
@@ -19,7 +19,7 @@ COPY . .
 RUN go build ./binary_transparency/firmware/cmd/ftmapserver
 
 # Build release image
-FROM golang:1.24.4-bullseye@sha256:dfd72198d14bc22f270c9e000c304a2ffd19f5a5f693fad82643311afdc6b568
+FROM golang:1.24.5-bookworm@sha256:ef8c5c733079ac219c77edab604c425d748c740d8699530ea6aced9de79aea40
 
 COPY --from=builder /build/ftmapserver /bin/ftmapserver
 ENTRYPOINT ["/bin/ftmapserver"]

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,12 +1,12 @@
 # This Dockerfile builds a base image for the CloudBuild integration testing.
-FROM golang:1.24.4-bullseye@sha256:dfd72198d14bc22f270c9e000c304a2ffd19f5a5f693fad82643311afdc6b568 AS testbase
+FROM golang:1.24.5-bookworm@sha256:ef8c5c733079ac219c77edab604c425d748c740d8699530ea6aced9de79aea40 AS testbase
 
 WORKDIR /testbase
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
 
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main contrib non-free" >> /etc/apt/sources.list
+RUN echo "deb http://deb.debian.org/debian bookworm-backports main contrib non-free" >> /etc/apt/sources.list
 RUN apt-get update && apt-get -y install curl docker-compose lsof netcat unzip wget xxd
 
 RUN cd /usr/bin && curl -L -O https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && mv jq-linux64 /usr/bin/jq && chmod +x /usr/bin/jq


### PR DESCRIPTION
This should unblock other pull requests.

Debian Backports provides new packages with new features on supported Debian stable releases:

- bookworm-backports provides new packages for Debian 12 (bookworm), backported from Debian testing (trixie), which will be updated until 1 year after the trixie release
- bullseye-backports has reached end-of-life and is no longer supported or updated
- [bullseye-backports-sloppy](https://backports.debian.org/Instructions/#the-old-stable-sloppy-suite) has reached end-of-life and is no longer supported or updated
- All older branches have reached end-of-life and are no longer supported or updated

https://backports.debian.org/Instructions/