### PR TITLE
Migrate golangci-lint to GitHub Actions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,23 @@
+name: golangci-lint
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: go.mod
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        with:
+          version: v2.5.0
+          args: --timeout=8m

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -10,7 +10,6 @@ RUN echo "deb http://deb.debian.org/debian bookworm-backports main contrib non-f
 RUN apt-get update && apt-get -y install curl docker-compose lsof netcat-traditional unzip wget xxd
 
 RUN cd /usr/bin && curl -L -O https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && mv jq-linux64 /usr/bin/jq && chmod +x /usr/bin/jq
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.6
 RUN mkdir protoc && \
     (cd protoc && \
     wget "https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip" && \

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -127,11 +127,6 @@ main() {
   fi
 
   if [[ "${run_lint}" -eq 1 ]]; then
-    check_cmd golangci-lint \
-      'have you installed github.com/golangci/golangci-lint?' || exit 1
-
-    echo 'running golangci-lint'
-    golangci-lint run --timeout=10m
     echo 'checking license headers'
     ./scripts/check_license.sh ${go_srcs}
   fi


### PR DESCRIPTION
This pull request also bumps the version to 2.5.0. This should unblock https://github.com/google/trillian-examples/pull/1350.